### PR TITLE
refactor/integration: integrate with latest routing master

### DIFF
--- a/src/core/client/mod.rs
+++ b/src/core/client/mod.rs
@@ -51,8 +51,6 @@ use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex, mpsc};
 use std::sync::mpsc::Sender;
 
-const MIN_SECTION_SIZE: usize = 8;
-
 /// The main self-authentication client instance that will interface all the request from high
 /// level API's to the actual routing layer and manage all interactions with it. This is
 /// essentially a non-blocking Client with upper layers having an option to either block and wait
@@ -85,7 +83,7 @@ impl Client {
 
         let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                              vec![network_event_sender]);
-        let routing = try!(Routing::new(routing_sender, None, MIN_SECTION_SIZE));
+        let routing = try!(Routing::new(routing_sender, None));
 
         trace!("Waiting to get connected to the Network...");
         match try!(network_event_receiver.recv()) {
@@ -131,7 +129,7 @@ impl Client {
 
         let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                              vec![network_event_sender]);
-        let routing = try!(Routing::new(routing_sender, Some(id_packet), MIN_SECTION_SIZE));
+        let routing = try!(Routing::new(routing_sender, Some(id_packet)));
 
         trace!("Waiting to get connected to the Network...");
         match try!(network_event_receiver.recv()) {
@@ -225,7 +223,7 @@ impl Client {
 
             let (message_queue, raii_joiner) = MessageQueue::new(routing_receiver,
                                                                  vec![network_event_sender]);
-            let routing = try!(Routing::new(routing_sender, Some(id_packet), MIN_SECTION_SIZE));
+            let routing = try!(Routing::new(routing_sender, Some(id_packet)));
 
             trace!("Waiting to get connected to the Network...");
             match try!(network_event_receiver.recv()) {

--- a/src/core/client/non_networking_test_framework/mod.rs
+++ b/src/core/client/non_networking_test_framework/mod.rs
@@ -668,7 +668,7 @@ mod test {
 
         let (message_queue, _raii_joiner) = MessageQueue::new(routing_receiver,
                                                               vec![network_event_sender]);
-        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet), 8));
+        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet)));
 
         match unwrap!(network_event_receiver.recv()) {
             NetworkEvent::Connected => (),
@@ -778,7 +778,7 @@ mod test {
 
         let (message_queue, _raii_joiner) = MessageQueue::new(routing_receiver,
                                                               vec![network_event_sender]);
-        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet), 8));
+        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet)));
 
         match unwrap!(network_event_receiver.recv()) {
             NetworkEvent::Connected => (),
@@ -1113,7 +1113,7 @@ mod test {
 
         let (message_queue, _raii_joiner) = MessageQueue::new(routing_receiver,
                                                               vec![network_event_sender]);
-        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet), 8));
+        let mut mock_routing = unwrap!(RoutingMock::new(routing_sender, Some(id_packet)));
 
         match unwrap!(network_event_receiver.recv()) {
             NetworkEvent::Connected => (),

--- a/src/core/client/non_networking_test_framework/mod.rs
+++ b/src/core/client/non_networking_test_framework/mod.rs
@@ -15,7 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-#![cfg_attr(feature="clippy", allow(map_entry))]  // TODO: Look to enable this lint check.
+// TODO: Look to enable this lint check.
+#![cfg_attr(feature="clippy", allow(map_entry))]
 
 mod storage;
 
@@ -59,10 +60,7 @@ pub struct RoutingMock {
 }
 
 impl RoutingMock {
-    pub fn new(sender: Sender<Event>,
-               _id: Option<FullId>,
-               _min_section_size: usize)
-               -> Result<RoutingMock, RoutingError> {
+    pub fn new(sender: Sender<Event>, _id: Option<FullId>) -> Result<RoutingMock, RoutingError> {
         ::rust_sodium::init();
 
         let cloned_sender = sender.clone();

--- a/src/core/client/non_networking_test_framework/storage.rs
+++ b/src/core/client/non_networking_test_framework/storage.rs
@@ -56,9 +56,7 @@ impl Storage {
     // Save the data to the storage.
     pub fn put_data(&mut self, name: XorName, data: Data) -> Result<(), StorageError> {
         serialise(&data)
-            .map(|data| {
-                let _ = self.data_store.insert(name, data);
-            })
+            .map(|data| { let _ = self.data_store.insert(name, data); })
             .map_err(StorageError::SerialisationError)
     }
 


### PR DESCRIPTION
Routing has remove requirement of min section size in client interface - so removing that in mock and in production code here too.
Rustfmt changes.