### PR TITLE
fix/unreg-client: allow unreg client to fetch immut-data

### DIFF
--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -125,8 +125,7 @@ pub unsafe extern "C" fn idata_close_self_encryptor(app: *const App,
                     let ser_data_map = serialise(&data_map)?;
                     let enc_data_map = {
                         let cipher_opt = context2.object_cache().get_cipher_opt(cipher_opt_h)?;
-                        let sym_key = context2.sym_enc_key()?;
-                        cipher_opt.encrypt(&ser_data_map, sym_key)?
+                        cipher_opt.encrypt(&ser_data_map, &context2)?
                     };
 
                     Ok(enc_data_map)
@@ -175,10 +174,7 @@ pub unsafe extern "C" fn idata_fetch_self_encryptor(app: *const App,
             immutable_data::get_value(client, &name, None)
                 .map_err(AppError::from)
                 .and_then(move |enc_data_map| {
-                    let sym_key = context2.sym_enc_key()?;
-                    let (asym_pk, asym_sk) = client2.encryption_keypair()?;
-                    let ser_data_map =
-                        CipherOpt::decrypt(&enc_data_map, sym_key, &asym_pk, &asym_sk)?;
+                    let ser_data_map = CipherOpt::decrypt(&enc_data_map, &context2, &client2)?;
                     let data_map = deserialise(&ser_data_map)?;
 
                     Ok(data_map)


### PR DESCRIPTION
The code was wrongly trying to extract encryption keys even if the data (cipher-opt variant) was plaintext. That should only happen if the type is not plain text else all fetches by unregistered apps will fail even if the data was plaintext because unreg-clients don't have enc-keys.