### PR TITLE
MAID-1995: Disable padding

### DIFF
--- a/ffi_utils/src/base64.rs
+++ b/ffi_utils/src/base64.rs
@@ -36,7 +36,7 @@ fn config() -> Config {
     Config {
         char_set: CharacterSet::UrlSafe,
         newline: Newline::LF,
-        pad: true,
+        pad: false,
         line_length: None,
     }
 }


### PR DESCRIPTION
`=`-padding is not URL-safe; our primary use case for `ffi_utils::base64_encode` ....