### PR TITLE
Multiple fixes for an incorrect FFI behaviour

### DIFF
--- a/ffi_utils/src/lib.rs
+++ b/ffi_utils/src/lib.rs
@@ -64,7 +64,7 @@ pub use self::base64::{base64_decode, base64_encode};
 pub use self::catch_unwind::{catch_unwind_cb, catch_unwind_error_code};
 pub use self::repr_c::ReprC;
 pub use self::string::{StringError, from_c_str};
-pub use self::vec::{vec_clone_from_raw_parts, vec_into_raw_parts};
+pub use self::vec::{SafePtr, vec_clone_from_raw_parts, vec_into_raw_parts};
 use std::os::raw::c_void;
 
 /// Type that holds opaque user data handed into FFI functions

--- a/ffi_utils/src/vec.rs
+++ b/ffi_utils/src/vec.rs
@@ -16,7 +16,33 @@
 // relating to use of the SAFE Network Software.
 
 use std::mem;
+use std::ptr;
 use std::slice;
+
+/// Provides FFI-safe pointers, as opposed to raw `as_ptr()` in
+/// `Vec` and `String` which can return values such as `0x01` that
+/// can cause segmentation faults with the automatic pointer
+/// dereferencing on the front-end side (e.g. in Node.js).
+pub trait SafePtr {
+    /// Resulting pointer type
+    type Ptr;
+
+    /// Returns a pointer that guarantees safe dereferencing
+    /// on the front-end side.
+    fn as_safe_ptr(&self) -> *const Self::Ptr;
+}
+
+impl<T> SafePtr for Vec<T> {
+    type Ptr = T;
+
+    fn as_safe_ptr(&self) -> *const T {
+        if self.is_empty() {
+            ptr::null()
+        } else {
+            self.as_ptr()
+        }
+    }
+}
 
 /// Converts a pointer and lengts to Vec<T> by cloning the contents.
 pub unsafe fn vec_clone_from_raw_parts<T: Clone>(ptr: *const T, len: usize) -> Vec<T> {

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use App;
-use ffi_utils::{OpaqueCtx, catch_unwind_cb, from_c_str};
+use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb, from_c_str};
 use futures::Future;
 use object_cache::MDataInfoHandle;
 use safe_core::FutureExt;
@@ -69,12 +69,15 @@ pub unsafe extern "C" fn access_container_get_names(app: *const App,
                               Ok(c_str_vec)
                           })
                 .map(move |c_str_vec| {
-                         let ptr_vec: Vec<*const c_char> = c_str_vec
-                             .iter()
-                             .map(|c_string| c_string.as_ptr())
-                             .collect();
-                         o_cb(user_data.0, 0, ptr_vec.as_ptr(), c_str_vec.len() as u32);
-                     })
+                    let ptr_vec: Vec<*const c_char> = c_str_vec
+                        .iter()
+                        .map(|c_string| c_string.as_ptr())
+                        .collect();
+                    o_cb(user_data.0,
+                         0,
+                         ptr_vec.as_safe_ptr(),
+                         c_str_vec.len() as u32);
+                })
                 .map_err(move |e| { o_cb(user_data.0, ffi_error_code!(e), ptr::null(), 0); })
                 .into_box()
                 .into()

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -18,7 +18,7 @@
 use App;
 use errors::AppError;
 use ffi::helper::send_sync;
-use ffi_utils::{OpaqueCtx, catch_unwind_cb};
+use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::MDataInfoHandle;
 use routing::{XOR_NAME_LEN, XorName};
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_key(app: *const App,
                               user_data,
                               o_cb);
 
-            o_cb(user_data.0, 0, vec.as_ptr(), vec.len());
+            o_cb(user_data.0, 0, vec.as_safe_ptr(), vec.len());
 
             None
         })
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_value(app: *const App,
                               user_data,
                               o_cb);
 
-            o_cb(user_data.0, 0, vec.as_ptr(), vec.len());
+            o_cb(user_data.0, 0, vec.as_safe_ptr(), vec.len());
 
             None
         })
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn mdata_info_serialise(app: *const App,
                                o_cb);
             let encoded = try_cb!(serialise(&*info).map_err(AppError::from), user_data, o_cb);
 
-            o_cb(user_data.0, 0, encoded.as_ptr(), encoded.len());
+            o_cb(user_data.0, 0, encoded.as_safe_ptr(), encoded.len());
             None
         })
     })

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -20,7 +20,7 @@
 use App;
 use errors::AppError;
 use ffi::helper::send_sync;
-use ffi_utils::{OpaqueCtx, catch_unwind_cb, vec_clone_from_raw_parts};
+use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb, vec_clone_from_raw_parts};
 use ffi_utils::callback::Callback;
 use object_cache::{MDataEntriesHandle, MDataKeysHandle, MDataValuesHandle};
 use routing::{ClientError, Value};
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn mdata_entries_get(app: *const App,
 
             o_cb(user_data.0,
                  0,
-                 value.content.as_ptr(),
+                 value.content.as_safe_ptr(),
                  value.content.len(),
                  value.entry_version);
 
@@ -145,9 +145,9 @@ pub unsafe extern "C" fn mdata_entries_for_each(app: *const App,
         with_entries(app, entries_h, user_data.0, o_cb, move |entries| {
             for (key, value) in entries {
                 entry_cb(user_data.0,
-                         key.as_ptr(),
+                         key.as_safe_ptr(),
                          key.len(),
-                         value.content.as_ptr(),
+                         value.content.as_safe_ptr(),
                          value.content.len(),
                          value.entry_version);
             }
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn mdata_keys_for_each(app: *const App,
 
         with_keys(app, keys_h, user_data.0, o_cb, move |keys| {
             for key in keys {
-                key_cb(user_data.0, key.as_ptr(), key.len());
+                key_cb(user_data.0, key.as_safe_ptr(), key.len());
             }
 
             Ok(())
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn mdata_values_for_each(app: *const App,
         with_values(app, values_h, user_data.0, o_cb, move |values| {
             for value in values {
                 value_cb(user_data.0,
-                         value.content.as_ptr(),
+                         value.content.as_safe_ptr(),
                          value.content.len(),
                          value.entry_version);
             }

--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 use App;
 use errors::AppError;
 use ffi::helper::send_with_mdata_info;
-use ffi_utils::{OpaqueCtx, catch_unwind_cb, vec_clone_from_raw_parts};
+use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb, vec_clone_from_raw_parts};
 use futures::Future;
 use object_cache::{MDataEntriesHandle, MDataEntryActionsHandle, MDataInfoHandle, MDataKeysHandle,
                    MDataPermissionSetHandle, MDataPermissionsHandle, MDataValuesHandle,
@@ -149,7 +149,11 @@ pub unsafe extern "C" fn mdata_get_value(app: *const App,
                               Ok((content, value.entry_version))
                           })
                 .map(move |(content, version)| {
-                         o_cb(user_data.0, 0, content.as_ptr(), content.len(), version);
+                         o_cb(user_data.0,
+                              0,
+                              content.as_safe_ptr(),
+                              content.len(),
+                              version);
                      })
                 .map_err(AppError::from)
                 .map_err(move |err| o_cb(user_data.0, ffi_error_code!(err), ptr::null(), 0, 0))

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -19,7 +19,7 @@ use AccessContainerEntry;
 use AuthError;
 use Authenticator;
 use access_container::{access_container, access_container_nonce};
-use ffi_utils::{OpaqueCtx, catch_unwind_cb, from_c_str, vec_into_raw_parts};
+use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb, from_c_str, vec_into_raw_parts};
 use futures::Future;
 use ipc::{AppState, app_state, get_config, remove_app_container, update_config};
 use maidsafe_utilities::serialisation::deserialise;
@@ -154,7 +154,7 @@ usize)){
                             }
                         }
 
-                        o_cb(user_data.0, 0, apps.as_ptr(), apps.len());
+                        o_cb(user_data.0, 0, apps.as_safe_ptr(), apps.len());
 
                         Ok(())
                     })
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn authenticator_registered_apps(auth: *const Authenticato
                             }
                         }
 
-                        o_cb(user_data.0, 0, apps.as_ptr(), apps.len());
+                        o_cb(user_data.0, 0, apps.as_safe_ptr(), apps.len());
 
                         Ok(())
                     })

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -141,7 +141,7 @@ pub fn access_container<S: Into<String>>(authenticator: &Authenticator,
     let app_id = app_id.into();
     run(authenticator, move |client| {
         access_container_entry(client, &ac_md_info, &app_id, app_keys)
-            .map(move |(_, ac_entry)| ac_entry)
+            .map(move |(_, ac_entry)| unwrap!(ac_entry, "Access container entry is empty"))
     })
 }
 

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -432,7 +432,7 @@ fn revoke_app() {
     run(&authenticator, move |client| {
         access_container_entry(client, &ac_md_info, &app_id, app_keys)
             .then(move |res| match res {
-                Err(AuthError::CoreError(CoreError::EncodeDecodeError(..))) => Ok(()),
+                Ok((_version, None)) => Ok(()),
                 x => panic!("Unexpected {:?}", x),
             })
     });
@@ -607,6 +607,18 @@ fn lists_of_registered_and_revoked_apps() {
 
     assert_eq!(registered.len(), 1);
     assert_eq!(revoked.len(), 1);
+
+    // Re-register the first app - now there must be 2 registered apps again
+    let _ = unwrap!(register_app(&authenticator, &auth_req1));
+
+    let registered: Vec<RegisteredAppId> = unsafe {
+        unwrap!(call_vec(|ud, cb| authenticator_registered_apps(&authenticator, ud, cb)))
+    };
+    let revoked: Vec<RevokedAppId> =
+        unsafe { unwrap!(call_vec(|ud, cb| authenticator_revoked_apps(&authenticator, ud, cb))) };
+
+    assert_eq!(registered.len(), 2);
+    assert_eq!(revoked.len(), 0);
 }
 
 fn revoke(authenticator: &Authenticator, app_id: &str) {

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -17,7 +17,7 @@
 
 use Authenticator;
 use access_container::access_container_entry;
-use errors::{AuthError, ERR_ALREADY_AUTHORISED, ERR_UNKNOWN_APP};
+use errors::{AuthError, ERR_UNKNOWN_APP};
 use ffi::apps::*;
 use ffi_utils::{ReprC, StringError, base64_encode, from_c_str};
 use ffi_utils::test_utils::{call_1, call_vec, send_via_user_data, sender_as_user_data};
@@ -283,7 +283,7 @@ fn authenticated_app_cannot_be_authenticated_again() {
         }))
     };
 
-    // Second authentication fails.
+    // Second authentication should also return the correct result.
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id: req_id,
@@ -292,10 +292,7 @@ fn authenticated_app_cannot_be_authenticated_again() {
     let encoded_msg = unwrap!(ipc::encode_msg(&msg, "safe-auth"));
 
     match decode_ipc_msg(&authenticator, &encoded_msg) {
-        Err((code,
-             Some(IpcMsg::Resp {
-                      resp: IpcResp::Auth(Err(IpcError::AlreadyAuthorised)), ..
-                  }))) if code == ERR_ALREADY_AUTHORISED => (),
+        Ok(IpcMsg::Req { req: IpcReq::Auth(_), .. }) => (),
         x => panic!("Unexpected {:?}", x),
     };
 }


### PR DESCRIPTION
Get rid of `AlreadyAuthorised` error, fix app reauthentication after revoke, fix unsafe pointers returned by FFI functions