### PR TITLE
refactor/ffi: remove automatic encryption of MData actions

### DIFF
--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-chrono = { version = "~0.3.0", features = ["serde"] }
+chrono = { version = "=0.3.0", features = ["serde"] }
 ffi_utils = { path = "../ffi_utils", version = "~0.1.0" }
 futures = "~0.1.11"
 log = "~0.3.7"

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -1097,7 +1097,20 @@ fn entries_crud_ffi() {
         };
 
         let result = unwrap!(rx.recv());
-        assert_eq!(&unwrap!(result), &value_enc, "got back invalid value");
+        let got_value_enc = unwrap!(result);
+        assert_eq!(&got_value_enc, &value_enc, "got back invalid value");
+
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| {
+                                    mdata_info_decrypt(&app,
+                                                       md_info_priv_h,
+                                                       got_value_enc.as_ptr(),
+                                                       got_value_enc.len(),
+                                                       ud,
+                                                       cb)
+                                }))
+        };
+        assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
     }
 
     extern "C" fn get_value_cb(user_data: *mut c_void,

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.22.0"
 
 [dependencies]
 base64 = "~0.4.1"
-chrono = { version = "~0.3.0", features = ["serde"] }
+chrono = { version = "=0.3.0", features = ["serde"] }
 ffi_utils = { path = "../ffi_utils", version = "~0.1.0" }
 futures = "~0.1.11"
 lazy_static = "~0.2.4"


### PR DESCRIPTION
To make the API more consistent, we don't encrypt values and keys in MutableData actions automatically now - a user has to do this manually. The same applies to mdata_get_value function, which doens't decrypt values from private MData anymore. This commit also adds tests for MutableData FFI APIs which were missing.