### PR TITLE
refactor/ffi: use new convention for errors in callbacks

### DIFF
--- a/ffi_utils/src/callback.rs
+++ b/ffi_utils/src/callback.rs
@@ -17,6 +17,7 @@
 
 //! Helpers to work with extern "C" callbacks.
 
+use super::FfiResult;
 use std::os::raw::c_void;
 use std::ptr;
 
@@ -28,35 +29,35 @@ pub trait Callback {
 
     /// Call the callback, passing the user data pointer, error code and any
     /// additional arguments.
-    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args);
+    fn call(&self, user_data: *mut c_void, error: FfiResult, args: Self::Args);
 }
 
-impl Callback for extern "C" fn(*mut c_void, i32) {
+impl Callback for extern "C" fn(*mut c_void, FfiResult) {
     type Args = ();
-    fn call(&self, user_data: *mut c_void, error: i32, _args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: FfiResult, _args: Self::Args) {
         self(user_data, error)
     }
 }
 
-impl<T: CallbackArgs> Callback for extern "C" fn(*mut c_void, i32, a: T) {
+impl<T: CallbackArgs> Callback for extern "C" fn(*mut c_void, FfiResult, a: T) {
     type Args = T;
-    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: FfiResult, args: Self::Args) {
         self(user_data, error, args)
     }
 }
 
 impl<T0: CallbackArgs, T1: CallbackArgs> Callback
-    for extern "C" fn(*mut c_void, i32, a0: T0, a1: T1) {
+    for extern "C" fn(*mut c_void, FfiResult, a0: T0, a1: T1) {
     type Args = (T0, T1);
-    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: FfiResult, args: Self::Args) {
         self(user_data, error, args.0, args.1)
     }
 }
 
 impl<T0: CallbackArgs, T1: CallbackArgs, T2: CallbackArgs> Callback
-    for extern "C" fn(*mut c_void, i32, a0: T0, a1: T1, a2: T2) {
+    for extern "C" fn(*mut c_void, FfiResult, a0: T0, a1: T1, a2: T2) {
     type Args = (T0, T1, T2);
-    fn call(&self, user_data: *mut c_void, error: i32, args: Self::Args) {
+    fn call(&self, user_data: *mut c_void, error: FfiResult, args: Self::Args) {
         self(user_data, error, args.0, args.1, args.2)
     }
 }

--- a/ffi_utils/src/lib.rs
+++ b/ffi_utils/src/lib.rs
@@ -65,7 +65,7 @@ pub use self::catch_unwind::{catch_unwind_cb, catch_unwind_error_code};
 pub use self::repr_c::ReprC;
 pub use self::string::{StringError, from_c_str};
 pub use self::vec::{SafePtr, vec_clone_from_raw_parts, vec_into_raw_parts};
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 
 /// Type that holds opaque user data handed into FFI functions
 #[derive(Clone, Copy)]
@@ -83,3 +83,18 @@ pub trait ErrorCode {
     /// Return the error code corresponding to this instance.
     fn error_code(&self) -> i32;
 }
+
+/// FFI result wrapper
+#[repr(C)]
+pub struct FfiResult {
+    /// Unique error code
+    pub error_code: i32,
+    /// Error description
+    pub description: *const c_char,
+}
+
+/// Constant value to be used for OK result
+pub const FFI_RESULT_OK: FfiResult = FfiResult {
+    error_code: 0,
+    description: 0 as *const c_char,
+};

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -26,6 +26,7 @@ use safe_core::nfs::NfsError;
 use self_encryption::SelfEncryptionError;
 use std::error::Error;
 use std::ffi::NulError;
+use std::fmt::{self, Display, Formatter};
 use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::sync::mpsc::{RecvError, RecvTimeoutError};
@@ -147,13 +148,62 @@ pub enum AppError {
 
     /// Error while self-encrypting data
     SelfEncryption(SelfEncryptionError<SelfEncryptionStorageError>),
-    /// Invalid offsets (from-position and lenght combination) provided for
+    /// Invalid offsets (from-position and length combination) provided for
     /// reading form SelfEncryptor. Would have probably caused an overflow.
     InvalidSelfEncryptorReadOffsets,
     /// Input/output Error
     IoError(IoError),
     /// Unexpected error
     Unexpected(String),
+}
+
+impl Display for AppError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            AppError::CoreError(ref error) => write!(formatter, "Core error: {}", error),
+            AppError::IpcError(ref error) => write!(formatter, "IPC error: {:?}", error),
+            AppError::NfsError(ref error) => write!(formatter, "NFS error: {:?}", error),
+            AppError::EncodeDecodeError => write!(formatter, "Serialisation error"),
+            AppError::OperationForbidden => write!(formatter, "Forbidden operation"),
+            AppError::NoSuchContainer => write!(formatter, "Container not found"),
+            AppError::InvalidCipherOptHandle => write!(formatter, "Invalid CipherOpt handle"),
+            AppError::InvalidEncryptPubKeyHandle => {
+                write!(formatter, "Invalid encrypt (box_) key handle")
+            }
+            AppError::InvalidMDataInfoHandle => write!(formatter, "Invalid `MDataInfo` handle"),
+            AppError::InvalidMDataEntriesHandle => {
+                write!(formatter, "Invalid MutableData enties handle")
+            }
+            AppError::InvalidMDataEntryActionsHandle => {
+                write!(formatter, "Invalid MutableData entry actions handle")
+            }
+            AppError::InvalidMDataPermissionsHandle => {
+                write!(formatter, "Invalid MutableData permissions handle")
+            }
+            AppError::InvalidMDataPermissionSetHandle => {
+                write!(formatter, "Invalid MutableData permission set handle")
+            }
+            AppError::InvalidSelfEncryptorHandle => {
+                write!(formatter, "Invalid Self Encryptor handle")
+            }
+            AppError::InvalidSignKeyHandle => write!(formatter, "Invalid sign key handle"),
+            AppError::InvalidEncryptSecKeyHandle => write!(formatter, "Invalid secret key handle"),
+            AppError::SelfEncryption(ref error) => {
+                write!(formatter, "Self-encryption error: {}", error)
+            }
+            AppError::InvalidSelfEncryptorReadOffsets => {
+                write!(formatter,
+                       "Invalid offsets (from-position \
+                        and length combination) provided for \
+                        reading form SelfEncryptor. Would have \
+                        probably caused an overflow.")
+            }
+            AppError::IoError(ref error) => write!(formatter, "I/O error: {}", error),
+            AppError::Unexpected(ref error) => {
+                write!(formatter, "Unexpected (probably a logic error): {}", error)
+            }
+        }
+    }
 }
 
 impl From<CoreError> for AppError {

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -18,7 +18,8 @@
 use App;
 use errors::AppError;
 use ffi::helper::send_sync;
-use ffi_utils::{OpaqueCtx, SafePtr, catch_unwind_cb, vec_clone_from_raw_parts};
+use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, SafePtr, catch_unwind_cb,
+                vec_clone_from_raw_parts};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::MDataInfoHandle;
 use routing::{XOR_NAME_LEN, XorName};
@@ -33,7 +34,7 @@ pub unsafe extern "C" fn mdata_info_new_public(app: *const App,
                                                type_tag: u64,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
-                                                                   i32,
+                                                                   FfiResult,
                                                                    MDataInfoHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         let name = XorName(*name);
@@ -52,7 +53,7 @@ pub unsafe extern "C" fn mdata_info_new_private(app: *const App,
                                                 type_tag: u64,
                                                 user_data: *mut c_void,
                                                 o_cb: extern "C" fn(*mut c_void,
-                                                                    i32,
+                                                                    FfiResult,
                                                                     MDataInfoHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         let name = XorName(*name);
@@ -70,7 +71,7 @@ pub unsafe extern "C" fn mdata_info_random_public(app: *const App,
                                                   type_tag: u64,
                                                   user_data: *mut c_void,
                                                   o_cb: extern "C" fn(*mut c_void,
-                                                                      i32,
+                                                                      FfiResult,
                                                                       MDataInfoHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -86,7 +87,7 @@ pub unsafe extern "C" fn mdata_info_random_private(app: *const App,
                                                    type_tag: u64,
                                                    user_data: *mut c_void,
                                                    o_cb: extern "C" fn(*mut c_void,
-                                                                       i32,
+                                                                       FfiResult,
                                                                        MDataInfoHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -104,7 +105,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_key(app: *const App,
                                                       input_len: usize,
                                                       user_data: *mut c_void,
                                                       o_cb: extern "C" fn(*mut c_void,
-                                                                          i32,
+                                                                          FfiResult,
                                                                           *const u8,
                                                                           usize)) {
     catch_unwind_cb(user_data, o_cb, || {
@@ -119,7 +120,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_key(app: *const App,
                               user_data,
                               o_cb);
 
-            o_cb(user_data.0, 0, vec.as_safe_ptr(), vec.len());
+            o_cb(user_data.0, FFI_RESULT_OK, vec.as_safe_ptr(), vec.len());
 
             None
         })
@@ -134,7 +135,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_value(app: *const App,
                                                         input_len: usize,
                                                         user_data: *mut c_void,
                                                         o_cb: extern "C" fn(*mut c_void,
-                                                                            i32,
+                                                                            FfiResult,
                                                                             *const u8,
                                                                             usize)) {
     catch_unwind_cb(user_data, o_cb, || {
@@ -149,7 +150,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_value(app: *const App,
                               user_data,
                               o_cb);
 
-            o_cb(user_data.0, 0, vec.as_safe_ptr(), vec.len());
+            o_cb(user_data.0, FFI_RESULT_OK, vec.as_safe_ptr(), vec.len());
 
             None
         })
@@ -164,7 +165,7 @@ pub unsafe extern "C" fn mdata_info_decrypt(app: *const App,
                                             input_len: usize,
                                             user_data: *mut c_void,
                                             o_cb: extern "C" fn(*mut c_void,
-                                                                i32,
+                                                                FfiResult,
                                                                 *const u8,
                                                                 usize)) {
     catch_unwind_cb(user_data, o_cb, || {
@@ -179,7 +180,10 @@ pub unsafe extern "C" fn mdata_info_decrypt(app: *const App,
                                     user_data,
                                     o_cb);
 
-            o_cb(user_data.0, 0, decrypted.as_safe_ptr(), decrypted.len());
+            o_cb(user_data.0,
+                 FFI_RESULT_OK,
+                 decrypted.as_safe_ptr(),
+                 decrypted.len());
 
             None
         })
@@ -192,7 +196,7 @@ pub unsafe extern "C" fn mdata_info_extract_name_and_type_tag(app: *const App,
                                                               info_h: MDataInfoHandle,
                                                               user_data: *mut c_void,
                                                               o_cb: extern "C" fn(*mut c_void,
-                                                                                  i32,
+                                                                                  FfiResult,
                                                                                   *const [u8;
                                                                                    XOR_NAME_LEN],
 u64)){
@@ -210,7 +214,7 @@ pub unsafe extern "C" fn mdata_info_serialise(app: *const App,
                                               info_h: MDataInfoHandle,
                                               user_data: *mut c_void,
                                               o_cb: extern "C" fn(*mut c_void,
-                                                                  i32,
+                                                                  FfiResult,
                                                                   *const u8,
                                                                   usize)) {
     catch_unwind_cb(user_data, o_cb, || {
@@ -222,7 +226,10 @@ pub unsafe extern "C" fn mdata_info_serialise(app: *const App,
                                o_cb);
             let encoded = try_cb!(serialise(&*info).map_err(AppError::from), user_data, o_cb);
 
-            o_cb(user_data.0, 0, encoded.as_safe_ptr(), encoded.len());
+            o_cb(user_data.0,
+                 FFI_RESULT_OK,
+                 encoded.as_safe_ptr(),
+                 encoded.len());
             None
         })
     })
@@ -235,7 +242,7 @@ pub unsafe extern "C" fn mdata_info_deserialise(app: *const App,
                                                 len: usize,
                                                 user_data: *mut c_void,
                                                 o_cb: extern "C" fn(*mut c_void,
-                                                                    i32,
+                                                                    FfiResult,
                                                                     MDataInfoHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         let encoded = vec_clone_from_raw_parts(ptr, len);

--- a/safe_app/src/ffi/mutable_data/entry_actions.rs
+++ b/safe_app/src/ffi/mutable_data/entry_actions.rs
@@ -19,7 +19,7 @@
 
 use App;
 use ffi::helper::send_sync;
-use ffi_utils::{catch_unwind_cb, vec_clone_from_raw_parts};
+use ffi_utils::{FfiResult, catch_unwind_cb, vec_clone_from_raw_parts};
 use object_cache::MDataEntryActionsHandle;
 use routing::{EntryAction, Value};
 use std::os::raw::c_void;
@@ -29,7 +29,7 @@ use std::os::raw::c_void;
 pub unsafe extern "C" fn mdata_entry_actions_new(app: *const App,
                                                  user_data: *mut c_void,
                                                  o_cb: extern "C" fn(*mut c_void,
-                                                                     i32,
+                                                                     FfiResult,
                                                                      MDataEntryActionsHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, |_, context| {
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn mdata_entry_actions_insert(app: *const App,
                                                     value_ptr: *const u8,
                                                     value_len: usize,
                                                     user_data: *mut c_void,
-                                                    o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                    o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     add_action(app, actions_h, key_ptr, key_len, user_data, o_cb, || {
         EntryAction::Ins(Value {
                              content: vec_clone_from_raw_parts(value_ptr, value_len),
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn mdata_entry_actions_update(app: *const App,
                                                     value_len: usize,
                                                     entry_version: u64,
                                                     user_data: *mut c_void,
-                                                    o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                    o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     add_action(app, actions_h, key_ptr, key_len, user_data, o_cb, || {
         EntryAction::Update(Value {
                                 content: vec_clone_from_raw_parts(value_ptr, value_len),
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn mdata_entry_actions_delete(app: *const App,
                                                     key_len: usize,
                                                     entry_version: u64,
                                                     user_data: *mut c_void,
-                                                    o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                    o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     add_action(app,
                actions_h,
                key_ptr,
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn mdata_entry_actions_delete(app: *const App,
 pub unsafe extern "C" fn mdata_entry_actions_free(app: *const App,
                                                   actions_h: MDataEntryActionsHandle,
                                                   user_data: *mut c_void,
-                                                  o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                  o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let _ = context
@@ -119,7 +119,7 @@ unsafe fn add_action<F>(app: *const App,
                         key_ptr: *const u8,
                         key_len: usize,
                         user_data: *mut c_void,
-                        o_cb: extern "C" fn(*mut c_void, i32),
+                        o_cb: extern "C" fn(*mut c_void, FfiResult),
                         f: F)
     where F: FnOnce() -> EntryAction
 {

--- a/safe_app/src/ffi/mutable_data/permissions.rs
+++ b/safe_app/src/ffi/mutable_data/permissions.rs
@@ -21,7 +21,7 @@ use App;
 use errors::AppError;
 use ffi::helper::send_sync;
 use ffi::mutable_data::helper;
-use ffi_utils::{OpaqueCtx, catch_unwind_cb};
+use ffi_utils::{FfiResult, OpaqueCtx, catch_unwind_cb};
 use object_cache::{MDataPermissionSetHandle, MDataPermissionsHandle, SignKeyHandle};
 use routing::{Action, PermissionSet, User};
 use std::os::raw::c_void;
@@ -59,7 +59,7 @@ impl Into<Action> for MDataAction {
 pub unsafe extern "C" fn mdata_permission_set_new(app: *const App,
                                                   user_data: *mut c_void,
                                                   o_cb: extern "C" fn(*mut c_void,
-                                                                      i32,
+                                                                      FfiResult,
                                                                       MDataPermissionSetHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, |_, context| {
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn mdata_permissions_set_allow(app: *const App,
                                                      set_h: MDataPermissionSetHandle,
                                                      action: MDataAction,
                                                      user_data: *mut c_void,
-                                                     o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                     o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let mut set = context.object_cache().get_mdata_permission_set(set_h)?;
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn mdata_permissions_set_deny(app: *const App,
                                                     set_h: MDataPermissionSetHandle,
                                                     action: MDataAction,
                                                     user_data: *mut c_void,
-                                                    o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                    o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let mut set = context.object_cache().get_mdata_permission_set(set_h)?;
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn mdata_permissions_set_clear(app: *const App,
                                                      set_h: MDataPermissionSetHandle,
                                                      action: MDataAction,
                                                      user_data: *mut c_void,
-                                                     o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                     o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let mut set = context.object_cache().get_mdata_permission_set(set_h)?;
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn mdata_permissions_set_clear(app: *const App,
 pub unsafe extern "C" fn mdata_permissions_set_free(app: *const App,
                                                     set_h: MDataPermissionSetHandle,
                                                     user_data: *mut c_void,
-                                                    o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                    o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let _ = context
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn mdata_permissions_set_free(app: *const App,
 pub unsafe extern "C" fn mdata_permissions_new(app: *const App,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
-                                                                   i32,
+                                                                   FfiResult,
                                                                    MDataPermissionsHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, |_, context| {
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn mdata_permissions_new(app: *const App,
 pub unsafe extern "C" fn mdata_permissions_len(app: *const App,
                                                permissions_h: MDataPermissionsHandle,
                                                user_data: *mut c_void,
-                                               o_cb: extern "C" fn(*mut c_void, i32, usize)) {
+                                               o_cb: extern "C" fn(*mut c_void, FfiResult, usize)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let permissions = context
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn mdata_permissions_get(app: *const App,
                                                user_h: SignKeyHandle,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
-                                                                   i32,
+                                                                   FfiResult,
                                                                    MDataPermissionSetHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -201,7 +201,7 @@ fn mdata_permissions_for_each(app: *const App,
                                                             SignKeyHandle,
                                                             MDataPermissionSetHandle),
                               user_data: *mut c_void,
-done_cb: extern "C" fn(*mut c_void, i32)){
+done_cb: extern "C" fn(*mut c_void, FfiResult )){
     catch_unwind_cb(user_data, done_cb, || {
         let user_data = OpaqueCtx(user_data);
 
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn mdata_permissions_insert(app: *const App,
                                                   user_h: SignKeyHandle,
                                                   permission_set_h: MDataPermissionSetHandle,
                                                   user_data: *mut c_void,
-                                                  o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                  o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let mut permissions = context
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn mdata_permissions_insert(app: *const App,
 pub unsafe extern "C" fn mdata_permissions_free(app: *const App,
                                                 permissions_h: MDataPermissionsHandle,
                                                 user_data: *mut c_void,
-                                                o_cb: extern "C" fn(*mut c_void, i32)) {
+                                                o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let _ = context

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -27,6 +27,7 @@ use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use std::error::Error;
 use std::ffi::NulError;
+use std::fmt::{self, Display, Formatter};
 use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
@@ -118,6 +119,23 @@ pub enum AuthError {
     NoSuchPublicId,
     /// Public ID already exists
     PublicIdExists,
+}
+
+impl Display for AuthError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            AuthError::Unexpected(ref error) => {
+                write!(formatter, "Unexpected (probably a logic error): {}", error)
+            }
+            AuthError::CoreError(ref error) => write!(formatter, "Core error: {}", error),
+            AuthError::IoError(ref error) => write!(formatter, "I/O error: {}", error),
+            AuthError::NfsError(ref error) => write!(formatter, "NFS error: {:?}", error),
+            AuthError::EncodeDecodeError => write!(formatter, "Serialisation error"),
+            AuthError::IpcError(ref error) => write!(formatter, "IPC error: {:?}", error),
+            AuthError::NoSuchPublicId => write!(formatter, "Public ID not found"),
+            AuthError::PublicIdExists => write!(formatter, "Public ID already exists"),
+        }
+    }
 }
 
 impl Into<IpcError> for AuthError {


### PR DESCRIPTION
Now, instead of passing just an error code (which isn't useful in case of an error types that carry extra info,
like e.g. `AppError::Unexpected` and others), we pass an error description along with it. All callbacks should take the `FfiResult` argument in place of `i32` error code.