### PR TITLE
refactor/ffi: improve safe_app API consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - osx
 language: rust
 rust:
-  - stable
+  - 1.17.0
   - nightly-2017-04-28
 sudo: false
 branches:
@@ -19,18 +19,15 @@ cache:
   cargo: true
 
 before_script:
-  - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
-  - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
-  - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
-      (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
+  - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
+  - bash cargo_install.sh cargo-prune;
+  - if [ "${TRAVIS_RUST_VERSION}" = 1.17.0 ]; then
+      bash cargo_install.sh rustfmt 0.8.3;
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      clippy_vers=0.0.128;
-      if ! cargo clippy --version | grep -q $clippy_vers; then
-        cargo install clippy --vers=$clippy_vers --force;
-      fi
+      bash cargo_install.sh clippy 0.0.128;
     fi
 script:
-  - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
+  - if [ "${TRAVIS_RUST_VERSION}" = 1.17.0 ]; then
         (
             set -x;
             echo "--- Check format ---" &&

--- a/ffi_utils/src/repr_c.rs
+++ b/ffi_utils/src/repr_c.rs
@@ -82,3 +82,13 @@ impl ReprC for [u8; 32] {
         Ok(*c_repr)
     }
 }
+
+/// Nonce
+impl ReprC for [u8; 24] {
+    type C = *const [u8; 24];
+    type Error = ();
+
+    unsafe fn clone_from_repr_c(c_repr: *const [u8; 24]) -> Result<[u8; 24], ()> {
+        Ok(*c_repr)
+    }
+}

--- a/ffi_utils/src/string.rs
+++ b/ffi_utils/src/string.rs
@@ -29,7 +29,7 @@ impl ReprC for String {
 
     unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<String, StringError> {
         Ok(if c_repr.is_null() {
-               "".to_owned()
+               String::default()
            } else {
                from_c_str(c_repr)?
            })

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -74,15 +74,13 @@ pub unsafe extern "C" fn access_container_get_names(app: *const App,
                               Ok(c_str_vec)
                           })
                 .map(move |c_str_vec| {
-                    let ptr_vec: Vec<*const c_char> = c_str_vec
-                        .iter()
-                        .map(|c_string| c_string.as_ptr())
-                        .collect();
-                    o_cb(user_data.0,
-                         FFI_RESULT_OK,
-                         ptr_vec.as_safe_ptr(),
-                         c_str_vec.len() as u32);
-                })
+                         let ptr_vec: Vec<*const c_char> =
+                             c_str_vec.iter().map(|c_string| c_string.as_ptr()).collect();
+                         o_cb(user_data.0,
+                              FFI_RESULT_OK,
+                              ptr_vec.as_safe_ptr(),
+                              c_str_vec.len() as u32);
+                     })
                 .map_err(move |e| {
                     let (error_code, description) = ffi_error!(e);
                     o_cb(user_data.0,

--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -145,9 +145,7 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(app: *const App,
 
     catch_unwind_cb(user_data, o_cb, || {
         (*app).send(move |_, context| {
-            let pk = match context
-                      .object_cache()
-                      .get_encrypt_key(peer_encrypt_key_h) {
+            let pk = match context.object_cache().get_encrypt_key(peer_encrypt_key_h) {
                 Ok(pk) => *pk,
                 Err(e) => {
                     let (error_code, description) = ffi_error!(e);

--- a/safe_app/src/ffi/mutable_data/entry_actions.rs
+++ b/safe_app/src/ffi/mutable_data/entry_actions.rs
@@ -34,9 +34,7 @@ pub unsafe extern "C" fn mdata_entry_actions_new(app: *const App,
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, |_, context| {
             let actions = Default::default();
-            Ok(context
-                   .object_cache()
-                   .insert_mdata_entry_actions(actions))
+            Ok(context.object_cache().insert_mdata_entry_actions(actions))
         })
     })
 }
@@ -128,9 +126,7 @@ unsafe fn add_action<F>(app: *const App,
         let action = f();
 
         send_sync(app, user_data, o_cb, move |_, context| {
-            let mut actions = context
-                .object_cache()
-                .get_mdata_entry_actions(actions_h)?;
+            let mut actions = context.object_cache().get_mdata_entry_actions(actions_h)?;
             let _ = actions.insert(key, action);
             Ok(())
         })

--- a/safe_app/src/ffi/mutable_data/permissions.rs
+++ b/safe_app/src/ffi/mutable_data/permissions.rs
@@ -126,9 +126,7 @@ pub unsafe extern "C" fn mdata_permissions_set_free(app: *const App,
                                                     o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let _ = context
-                .object_cache()
-                .remove_mdata_permission_set(set_h)?;
+            let _ = context.object_cache().remove_mdata_permission_set(set_h)?;
             Ok(())
         })
     })
@@ -158,9 +156,7 @@ pub unsafe extern "C" fn mdata_permissions_len(app: *const App,
                                                o_cb: extern "C" fn(*mut c_void, FfiResult, usize)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let permissions = context
-                .object_cache()
-                .get_mdata_permissions(permissions_h)?;
+            let permissions = context.object_cache().get_mdata_permissions(permissions_h)?;
             Ok(permissions.len())
         })
     })
@@ -178,9 +174,7 @@ pub unsafe extern "C" fn mdata_permissions_get(app: *const App,
                                                                    MDataPermissionSetHandle)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let permissions = context
-                .object_cache()
-                .get_mdata_permissions(permissions_h)?;
+            let permissions = context.object_cache().get_mdata_permissions(permissions_h)?;
             let handle = *permissions
                               .get(&helper::get_user(context.object_cache(), user_h)?)
                               .ok_or(AppError::InvalidSignKeyHandle)?;
@@ -206,9 +200,7 @@ done_cb: extern "C" fn(*mut c_void, FfiResult )){
         let user_data = OpaqueCtx(user_data);
 
         send_sync(app, user_data.0, done_cb, move |_, context| {
-            let permissions = context
-                .object_cache()
-                .get_mdata_permissions(permissions_h)?;
+            let permissions = context.object_cache().get_mdata_permissions(permissions_h)?;
             for (user_key, permission_set_h) in &*permissions {
                 let user_h = match *user_key {
                     User::Key(key) => context.object_cache().insert_sign_key(key),
@@ -234,9 +226,7 @@ pub unsafe extern "C" fn mdata_permissions_insert(app: *const App,
                                                   o_cb: extern "C" fn(*mut c_void, FfiResult)) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let mut permissions = context
-                .object_cache()
-                .get_mdata_permissions(permissions_h)?;
+            let mut permissions = context.object_cache().get_mdata_permissions(permissions_h)?;
             let _ = permissions.insert(helper::get_user(context.object_cache(), user_h)?,
                                        permission_set_h);
 

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -431,8 +431,8 @@ mod tests {
     fn get_container_names() {
         let mut container_permissions = HashMap::new();
         let _ = container_permissions.insert("_videos".to_string(), btree_set![Permission::Read]);
-        let _ = container_permissions.insert("_downloads".to_string(),
-                                             btree_set![Permission::Read]);
+        let _ = container_permissions
+            .insert("_downloads".to_string(), btree_set![Permission::Read]);
 
         let app = create_app_with_access(container_permissions);
 

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -77,11 +77,8 @@ pub unsafe extern "C" fn authenticator_rm_revoked_app(auth: *const Authenticator
 
             get_config(client)
                 .and_then(move |(cfg_version, auth_cfg)| {
-                              app_state(&c2, &auth_cfg, app_id).map(move |app_state| {
-                                                                        (app_state,
-                                                                         auth_cfg,
-                                                                         cfg_version)
-                                                                    })
+                              app_state(&c2, &auth_cfg, app_id)
+                                  .map(move |app_state| (app_state, auth_cfg, cfg_version))
                           })
                 .and_then(move |(app_state, auth_cfg, cfg_version)| match app_state {
                               AppState::Revoked => Ok((auth_cfg, cfg_version)),
@@ -91,12 +88,15 @@ pub unsafe extern "C" fn authenticator_rm_revoked_app(auth: *const Authenticator
                               }
                           })
                 .and_then(move |(mut auth_cfg, cfg_version)| {
-                              let _app = fry!(auth_cfg.remove(&app_id_hash)
-                        .ok_or_else(|| AuthError::from("Logical error: app isn't found in \
-                                                        authenticator config")));
+                    let _app = fry!(auth_cfg
+                                        .remove(&app_id_hash)
+                                        .ok_or_else(|| {
+                        AuthError::from("Logical error: app isn't found in \
+                                                        authenticator config")
+                    }));
 
-                              update_config(&c3, Some(cfg_version + 1), &auth_cfg)
-                          })
+                    update_config(&c3, Some(cfg_version + 1), &auth_cfg)
+                })
                 .and_then(move |_| remove_app_container(c4, &app_id2))
                 .then(move |res| {
                     let (error_code, description) = ffi_result!(res);
@@ -130,9 +130,8 @@ usize)){
 
                 get_config(client)
                     .and_then(move |(_, auth_cfg)| {
-                                  access_container(&c2).map(move |access_container| {
-                                                                (access_container, auth_cfg)
-                                                            })
+                                  access_container(&c2)
+                                      .map(move |access_container| (access_container, auth_cfg))
                               })
                     .and_then(move |(access_container, auth_cfg)| {
                                   c3.list_mdata_entries(access_container.name,
@@ -200,9 +199,8 @@ pub unsafe extern "C" fn authenticator_registered_apps(auth: *const Authenticato
 
                 get_config(client)
                     .and_then(move |(_, auth_cfg)| {
-                                  access_container(&c2).map(move |access_container| {
-                                                                (access_container, auth_cfg)
-                                                            })
+                                  access_container(&c2)
+                                      .map(move |access_container| (access_container, auth_cfg))
                               })
                     .and_then(move |(access_container, auth_cfg)| {
                                   c3.list_mdata_entries(access_container.name,

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -247,9 +247,8 @@ pub unsafe extern "C" fn authenticator_revoke_app(auth: *const Authenticator,
                 app_info(client, &app_id)
                     .and_then(move |app| Ok(app.ok_or(AuthError::IpcError(IpcError::UnknownApp))?))
                     .and_then(move |app| {
-                                  access_container(&c2).map(move |access_container| {
-                                                                (access_container, app)
-                                                            })
+                                  access_container(&c2)
+                                      .map(move |access_container| (access_container, app))
                               })
                     .and_then(move |(access_container, app)| {
                         // Get an access container entry for the app being revoked
@@ -258,11 +257,12 @@ pub unsafe extern "C" fn authenticator_revoke_app(auth: *const Authenticator,
                                                &app.info.id,
                                                app.keys.clone())
                                 .and_then(move |(version, permissions)| {
-                                              Ok((version, app,
-                                        permissions.ok_or(AuthError::IpcError(
-                                            IpcError::UnknownApp))?,
+                                    Ok((version,
+                                        app,
+                                        permissions
+                                            .ok_or(AuthError::IpcError(IpcError::UnknownApp))?,
                                         access_container))
-                                          })
+                                })
                     })
                     .and_then(move |(version, app, permissions, access_container)| {
                         // Remove the revoked app from the access container
@@ -355,9 +355,9 @@ pub unsafe extern "C" fn encode_auth_resp(auth: *const Authenticator,
 
         if !is_granted {
             let resp = encode_response(&IpcMsg::Resp {
-                                            req_id: req_id,
-                                            resp: IpcResp::Auth(Err(IpcError::AuthDenied)),
-                                        },
+                                           req_id: req_id,
+                                           resp: IpcResp::Auth(Err(IpcError::AuthDenied)),
+                                       },
                                        &auth_req.app.id)?;
 
             let (error_code, description) = ffi_error!(AuthError::from(IpcError::AuthDenied));
@@ -444,24 +444,26 @@ pub unsafe extern "C" fn encode_auth_resp(auth: *const Authenticator,
                                 .and_then(move |auth_granted| {
                                     let resp =
                                         encode_response(&IpcMsg::Resp {
-                                                             req_id: req_id,
-                                                             resp: IpcResp::Auth(Ok(auth_granted)),
-                                                         },
+                                                            req_id: req_id,
+                                                            resp: IpcResp::Auth(Ok(auth_granted)),
+                                                        },
                                                         &app_id2)?;
                                     Ok(o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr()))
                                 })
                                 .or_else(move |e| -> Result<(), AuthError> {
                                     let (error_code, description) = ffi_error!(e);
                                     let resp = encode_response(&IpcMsg::Resp {
-                                        req_id: req_id,
-                                        resp:
-                                        IpcResp::Auth(Err(e.into())),
-                                    },
+                                                                   req_id: req_id,
+                                                                   resp:
+                                                                       IpcResp::Auth(Err(e.into())),
+                                                               },
                                                                &app_id3)?;
-                                    Ok(o_cb(user_data.0, FfiResult {
-                                        error_code,
-                                        description: description.as_ptr()
-                                    }, resp.as_ptr()))
+                                    Ok(o_cb(user_data.0,
+                                            FfiResult {
+                                                error_code,
+                                                description: description.as_ptr(),
+                                            },
+                                            resp.as_ptr()))
                                 })
                                 .into_box()
                         })
@@ -500,9 +502,9 @@ pub unsafe extern "C" fn encode_containers_resp(auth: *const Authenticator,
 
         if !is_granted {
             let resp = encode_response(&IpcMsg::Resp {
-                                            req_id: req_id,
-                                            resp: IpcResp::Containers(Err(IpcError::AuthDenied)),
-                                        },
+                                           req_id: req_id,
+                                           resp: IpcResp::Containers(Err(IpcError::AuthDenied)),
+                                       },
                                        &cont_req.app.id)?;
             let (error_code, description) = ffi_error!(AuthError::from(IpcError::AuthDenied));
             o_cb(user_data.0,
@@ -526,11 +528,11 @@ pub unsafe extern "C" fn encode_containers_resp(auth: *const Authenticator,
                     app_info(client, &app_id)
                         .and_then(move |app| match app {
                                       Some(app) => {
-                            let sign_pk = app.keys.sign_pk;
-                            update_container_perms(&c2, permissions, sign_pk)
-                                .map(move |perms| (app, perms))
-                                .into_box()
-                        }
+                                          let sign_pk = app.keys.sign_pk;
+                                          update_container_perms(&c2, permissions, sign_pk)
+                                              .map(move |perms| (app, perms))
+                                              .into_box()
+                                      }
                                       None => err!(IpcError::UnknownApp),
                                   })
                         .and_then(move |(app, perms)| {
@@ -575,9 +577,9 @@ pub unsafe extern "C" fn encode_containers_resp(auth: *const Authenticator,
                                   })
                         .and_then(move |_| {
                             let resp = encode_response(&IpcMsg::Resp {
-                                                            req_id: req_id,
-                                                            resp: IpcResp::Containers(Ok(())),
-                                                        },
+                                                           req_id: req_id,
+                                                           resp: IpcResp::Containers(Ok(())),
+                                                       },
                                                        &cont_req.app.id)?;
                             o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr());
                             Ok(())
@@ -585,10 +587,9 @@ pub unsafe extern "C" fn encode_containers_resp(auth: *const Authenticator,
                         .or_else(move |e| -> Result<(), AuthError> {
                             let (error_code, description) = ffi_error!(e);
                             let resp = encode_response(&IpcMsg::Resp {
-                                                            req_id: req_id,
-                                                            resp:
-                                                                IpcResp::Containers(Err(e.into())),
-                                                        },
+                                                           req_id: req_id,
+                                                           resp: IpcResp::Containers(Err(e.into())),
+                                                       },
                                                        &app_id2)?;
                             Ok(o_cb(user_data.0,
                                     FfiResult {

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -411,11 +411,7 @@ fn revoke_app() {
 
     let _ = run(&authenticator, move |client| {
         file_helper::create(client.clone(), videos_md2, "video.mp4", Vec::new())
-            .and_then(move |writer| {
-                          writer
-                              .write(&[1u8; 10])
-                              .and_then(move |_| writer.close())
-                      })
+            .and_then(move |writer| writer.write(&[1u8; 10]).and_then(move |_| writer.close()))
             .map_err(From::from)
     });
 
@@ -487,11 +483,7 @@ fn revoke_app_reencryption() {
 
     let _ = run(&authenticator, move |client| {
         file_helper::create(client.clone(), videos_md2, "video.mp4", vec![1, 2, 3])
-            .and_then(move |writer| {
-                          writer
-                              .write(&[1u8; 10])
-                              .and_then(move |_| writer.close())
-                      })
+            .and_then(move |writer| writer.write(&[1u8; 10]).and_then(move |_| writer.close()))
             .map_err(From::from)
     });
 

--- a/safe_core/src/client/mdata_info.rs
+++ b/safe_core/src/client/mdata_info.rs
@@ -49,18 +49,6 @@ impl MDataInfo {
         }
     }
 
-    /// Construct `MDataInfo` for private (encrypted) data with a
-    /// randomly generated private key.
-    pub fn gen_private(name: XorName, type_tag: u64) -> Self {
-        let enc_info = Some((secretbox::gen_key(), Some(secretbox::gen_nonce())));
-
-        MDataInfo {
-            name,
-            type_tag,
-            enc_info,
-        }
-    }
-
     /// Construct `MDataInfo` for public data.
     pub fn new_public(name: XorName, type_tag: u64) -> Self {
         MDataInfo {
@@ -73,8 +61,10 @@ impl MDataInfo {
     /// Generate random `MDataInfo` for private (encrypted) mutable data.
     pub fn random_private(type_tag: u64) -> Result<Self, CoreError> {
         let mut rng = os_rng()?;
-        Ok(Self::gen_private(rng.gen(), type_tag))
+        let enc_info = (secretbox::gen_key(), Some(secretbox::gen_nonce()));
+        Ok(Self::new_private(rng.gen(), type_tag, enc_info))
     }
+
     /// Generate random `MDataInfo` for public mutable data.
     pub fn random_public(type_tag: u64) -> Result<Self, CoreError> {
         let mut rng = os_rng()?;

--- a/safe_core/src/client/mdata_info.rs
+++ b/safe_core/src/client/mdata_info.rs
@@ -36,22 +36,36 @@ pub struct MDataInfo {
 }
 
 impl MDataInfo {
-    /// Construct `MDataInfo` for private (encrypted) data.
-    pub fn new_private(name: XorName, type_tag: u64) -> Self {
+    /// Construct `MDataInfo` for private (encrypted) data with a
+    /// provided private key.
+    pub fn new_private(name: XorName,
+                       type_tag: u64,
+                       enc_info: (secretbox::Key, Option<secretbox::Nonce>))
+                       -> Self {
+        MDataInfo {
+            name,
+            type_tag,
+            enc_info: Some(enc_info),
+        }
+    }
+
+    /// Construct `MDataInfo` for private (encrypted) data with a
+    /// randomly generated private key.
+    pub fn gen_private(name: XorName, type_tag: u64) -> Self {
         let enc_info = Some((secretbox::gen_key(), Some(secretbox::gen_nonce())));
 
         MDataInfo {
-            name: name,
-            type_tag: type_tag,
-            enc_info: enc_info,
+            name,
+            type_tag,
+            enc_info,
         }
     }
 
     /// Construct `MDataInfo` for public data.
     pub fn new_public(name: XorName, type_tag: u64) -> Self {
         MDataInfo {
-            name: name,
-            type_tag: type_tag,
+            name,
+            type_tag,
             enc_info: None,
         }
     }
@@ -59,7 +73,7 @@ impl MDataInfo {
     /// Generate random `MDataInfo` for private (encrypted) mutable data.
     pub fn random_private(type_tag: u64) -> Result<Self, CoreError> {
         let mut rng = os_rng()?;
-        Ok(Self::new_private(rng.gen(), type_tag))
+        Ok(Self::gen_private(rng.gen(), type_tag))
     }
     /// Generate random `MDataInfo` for public mutable data.
     pub fn random_public(type_tag: u64) -> Result<Self, CoreError> {

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -592,9 +592,7 @@ fn mutable_data_permissions() {
     // App can no longer mutate the entries.
     let key2 = b"key2";
     let value2_v0 = unwrap!(utils::generate_random_vector(10));
-    let actions = EntryActions::new()
-        .ins(key2.to_vec(), value2_v0, 0)
-        .into();
+    let actions = EntryActions::new().ins(key2.to_vec(), value2_v0, 0).into();
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
@@ -668,12 +666,8 @@ fn mutable_data_permissions() {
         .ins(key3.to_vec(), value3_v0.clone(), 0)
         .into();
     let msg_id = MessageId::new();
-    unwrap!(app2_routing.mutate_mdata_entries(client_mgr,
-                                              name,
-                                              tag,
-                                              actions,
-                                              msg_id,
-                                              app2_sign_key));
+    unwrap!(app2_routing
+                .mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app2_sign_key));
     expect_failure!(app2_routing_rx,
                     msg_id,
                     Response::MutateMDataEntries,
@@ -693,16 +687,10 @@ fn mutable_data_permissions() {
     expect_success!(routing_rx, msg_id, Response::SetMDataUserPermissions);
 
     // The new app can now mutate entries
-    let actions = EntryActions::new()
-        .ins(key3.to_vec(), value3_v0, 0)
-        .into();
+    let actions = EntryActions::new().ins(key3.to_vec(), value3_v0, 0).into();
     let msg_id = MessageId::new();
-    unwrap!(app2_routing.mutate_mdata_entries(client_mgr,
-                                              name,
-                                              tag,
-                                              actions,
-                                              msg_id,
-                                              app2_sign_key));
+    unwrap!(app2_routing
+                .mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app2_sign_key));
     expect_success!(app2_routing_rx, msg_id, Response::MutateMDataEntries);
 
     // Revoke the insert permission for anyone.
@@ -723,12 +711,8 @@ fn mutable_data_permissions() {
         .ins(key4.to_vec(), value4_v0.clone(), 0)
         .into();
     let msg_id = MessageId::new();
-    unwrap!(app2_routing.mutate_mdata_entries(client_mgr,
-                                              name,
-                                              tag,
-                                              actions,
-                                              msg_id,
-                                              app2_sign_key));
+    unwrap!(app2_routing
+                .mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app2_sign_key));
     expect_failure!(app2_routing_rx,
                     msg_id,
                     Response::MutateMDataEntries,

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -522,10 +522,7 @@ impl Client {
 
             let inner = self.inner.clone();
             rx.map(move |data| {
-                         let _ = inner
-                             .borrow_mut()
-                             .cache
-                             .insert(*data.name(), data.clone());
+                         let _ = inner.borrow_mut().cache.insert(*data.name(), data.clone());
                          data
                      })
                 .into_box()
@@ -1256,13 +1253,14 @@ mod tests {
             let client2 = client.clone();
             let client3 = client.clone();
 
-            client.get_idata(*orig_data.name())
+            client
+                .get_idata(*orig_data.name())
                 .then(move |res| {
-                    let data = unwrap!(res);
-                    assert_eq!(data, orig_data);
-                    let dir = unwrap!(MDataInfo::random_private(DIR_TAG));
-                    client2.set_user_root_dir(dir)
-                })
+                          let data = unwrap!(res);
+                          assert_eq!(data, orig_data);
+                          let dir = unwrap!(MDataInfo::random_private(DIR_TAG));
+                          client2.set_user_root_dir(dir)
+                      })
                 .then(move |res| {
                     let e = match res {
                         Ok(_) => {

--- a/safe_core/src/ipc/req/mod.rs
+++ b/safe_core/src/ipc/req/mod.rs
@@ -110,8 +110,7 @@ impl AuthReq {
             containers,
         } = self;
 
-        let containers = containers_into_vec(containers)
-            .map_err(StringError::from)?;
+        let containers = containers_into_vec(containers).map_err(StringError::from)?;
         let (containers_ptr, len, cap) = vec_into_raw_parts(containers);
 
         Ok(ffi::AuthReq {
@@ -158,8 +157,7 @@ impl ContainersReq {
     pub fn into_repr_c(self) -> Result<ffi::ContainersReq, IpcError> {
         let ContainersReq { app, containers } = self;
 
-        let containers = containers_into_vec(containers)
-            .map_err(StringError::from)?;
+        let containers = containers_into_vec(containers).map_err(StringError::from)?;
         let (containers_ptr, len, cap) = vec_into_raw_parts(containers);
 
         Ok(ffi::ContainersReq {
@@ -215,18 +213,12 @@ impl AppExchangeInfo {
         Ok(ffi::AppExchangeInfo {
                id: CString::new(id).map_err(StringError::from)?.into_raw(),
                scope: if let Some(scope) = scope {
-                   CString::new(scope)
-                       .map_err(StringError::from)?
-                       .into_raw()
+                   CString::new(scope).map_err(StringError::from)?.into_raw()
                } else {
                    ptr::null()
                },
-               name: CString::new(name)
-                   .map_err(StringError::from)?
-                   .into_raw(),
-               vendor: CString::new(vendor)
-                   .map_err(StringError::from)?
-                   .into_raw(),
+               name: CString::new(name).map_err(StringError::from)?.into_raw(),
+               vendor: CString::new(vendor).map_err(StringError::from)?.into_raw(),
            })
     }
 }

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -121,9 +121,7 @@ pub fn update<S: AsRef<str>>(client: Client,
                   })
         .into_future()
         .and_then(move |(key, content)| if version != 0 {
-                      Ok((key, content, version, parent))
-                          .into_future()
-                          .into_box()
+                      Ok((key, content, version, parent)).into_future().into_box()
                   } else {
                       client
                           .get_mdata_value(parent.name, parent.type_tag, key.clone())

--- a/safe_core/src/self_encryption_storage.rs
+++ b/safe_core/src/self_encryption_storage.rs
@@ -63,10 +63,7 @@ impl Storage for SelfEncryptionStorage {
     fn put(&mut self, _: Vec<u8>, data: Vec<u8>) -> Box<Future<Item = (), Error = Self::Error>> {
         trace!("Self encrypt invoked PutIData.");
         let data = ImmutableData::new(data);
-        self.client
-            .put_idata(data)
-            .map_err(From::from)
-            .into_box()
+        self.client.put_idata(data).map_err(From::from).into_box()
     }
 }
 

--- a/safe_core/src/utils/mod.rs
+++ b/safe_core/src/utils/mod.rs
@@ -100,9 +100,7 @@ pub fn generate_random_vector<T>(length: usize) -> Result<Vec<T>, CoreError>
 pub fn derive_secrets(acc_locator: &[u8], acc_password: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     let Digest(locator_hash) = sha512::hash(acc_locator);
 
-    let pin = sha512::hash(&locator_hash[DIGESTBYTES / 2..])
-        .0
-        .to_owned();
+    let pin = sha512::hash(&locator_hash[DIGESTBYTES / 2..]).0.to_owned();
     let keyword = locator_hash.to_owned();
     let password = sha512::hash(acc_password).0.to_owned();
 


### PR DESCRIPTION
Previously `mdata_info_new_private` automatically generated a new private key each time it was called. Now, to be consistent with `mdata_info_new_public`, this function is called `mdata_info_gen_private` and a new `mdata_info_new_private` function takes a secret key and a nonce as arguments.

Also, not all functions adhered the new callback convention: error argument is fixed for `network_observer_cb` in `app_registered` and `app_unregistered` functions.