### PR TITLE
fix/safe_core: support providing bootstrap configs for unregistered clients

### DIFF
--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -82,7 +82,7 @@ use maidsafe_utilities::thread::{self, Joiner};
 use rust_sodium::crypto::secretbox;
 use safe_core::{Client, ClientKeys, CoreMsg, CoreMsgTx, FutureExt, MDataInfo, NetworkEvent,
                 NetworkTx, event_loop, utils};
-use safe_core::ipc::{AccessContInfo, AppKeys, AuthGranted, Permission};
+use safe_core::ipc::{AccessContInfo, AppKeys, AuthGranted, BootstrapConfig, Permission};
 use safe_core::ipc::resp::access_container_enc_key;
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
@@ -112,13 +112,13 @@ pub struct App {
 
 impl App {
     /// Create unregistered app.
-    /// TODO: add a `BootstrapConfig` argument to this function and
-    /// figure out what to pass to it.
-    pub fn unregistered<N>(network_observer: N) -> Result<Self, AppError>
+    pub fn unregistered<N>(network_observer: N,
+                           config: Option<BootstrapConfig>)
+                           -> Result<Self, AppError>
         where N: FnMut(Result<NetworkEvent, AppError>) + Send + 'static
     {
         Self::new(network_observer, |el_h, core_tx, net_tx| {
-            let client = Client::unregistered(el_h, core_tx, net_tx)?;
+            let client = Client::unregistered(el_h, core_tx, net_tx, config)?;
             let context = AppContext::unregistered();
             Ok((client, context))
         })

--- a/safe_core/examples/gen_invites.rs
+++ b/safe_core/examples/gen_invites.rs
@@ -127,7 +127,7 @@ fn main() {
 
     // Check a single invite
     if let Some(invite) = args.flag_check_invite {
-        let cl = unwrap!(Client::unregistered(el_h, core_tx.clone(), net_tx.clone()));
+        let cl = unwrap!(Client::unregistered(el_h, core_tx.clone(), net_tx.clone(), None));
 
         unwrap!(core_tx.send(CoreMsg::new(move |client, &()| {
             let id = XorName(sha3_256(invite.as_bytes()));

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -133,16 +133,16 @@ impl Client {
     /// This is a getter-only Gateway function to the Maidsafe network. It will
     /// create an unregistered random client, which can do very limited set of
     /// operations - eg., a Network-Get
-    /// TODO: add `BootstrapConfig` argument.
     pub fn unregistered<T>(el_handle: Handle,
                            core_tx: CoreMsgTx<T>,
-                           net_tx: NetworkTx)
+                           net_tx: NetworkTx,
+                           config: Option<BootstrapConfig>)
                            -> Result<Self, CoreError>
         where T: 'static
     {
         trace!("Creating unregistered client.");
 
-        let (routing, routing_rx) = setup_routing(None, None)?;
+        let (routing, routing_rx) = setup_routing(None, config)?;
         let net_tx_clone = net_tx.clone();
         let core_tx_clone = core_tx.clone();
         let joiner = spawn_routing_thread(routing_rx, core_tx_clone, net_tx_clone);
@@ -1264,7 +1264,8 @@ mod tests {
         }
 
         // Unregistered Client should be able to retrieve the data
-        setup_client(Client::unregistered, move |client| {
+        setup_client(|el_h, core_tx, net_tx| Client::unregistered(el_h, core_tx, net_tx, None),
+                     move |client| {
             let client2 = client.clone();
             let client3 = client.clone();
 


### PR DESCRIPTION
This fixes TODO items in both safe_core and safe_app.
Bootstrap config should be provided in the same format as it is provided in the AuthGranted struct.