### PR TITLE
refactor/all: follow callback result conventions

### DIFF
--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn encode_unregistered_req(user_data: *mut c_void,
     })
 }
 
-unsafe fn encode_ipc(req_id: u32, req: IpcReq) -> Result<CString, AppError> {
+fn encode_ipc(req_id: u32, req: IpcReq) -> Result<CString, AppError> {
     let encoded = ipc::encode_msg(&IpcMsg::Req { req_id, req }, "safe-auth")?;
     Ok(CString::new(encoded)?)
 }


### PR DESCRIPTION
Previously account creation & login functions in both safe_app and safe_authenticator didn't follow the standard convention of returning FfiResult in a callback.