### PR TITLE
fix/authenticator: fix reauthorisation of revoked apps

### DIFF
--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -58,6 +58,7 @@ impl Drop for RegisteredApp {
 }
 
 /// Removes a revoked app from the authenticator config
+#[no_mangle]
 pub unsafe extern "C" fn authenticator_rm_revoked_app(auth: *const Authenticator,
                                                       app_id: *const c_char,
                                                       user_data: *mut c_void,

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -24,7 +24,6 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, SafePtr, catch_unwind_cb, f
 use futures::Future;
 use ipc::{AppState, app_state, get_config, remove_app_container, update_config};
 use maidsafe_utilities::serialisation::deserialise;
-use rust_sodium::crypto::hash::sha256;
 use safe_core::FutureExt;
 use safe_core::ipc::{IpcError, access_container_enc_key};
 use safe_core::ipc::req::ffi::{self, ContainerPermissions};
@@ -32,6 +31,7 @@ use safe_core::utils::symmetric_decrypt;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
+use tiny_keccak::sha3_256;
 
 /// Application registered in the authenticator
 #[repr(C)]
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn authenticator_rm_revoked_app(auth: *const Authenticator
     catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
         let app_id = from_c_str(app_id)?;
         let app_id2 = app_id.clone();
-        let app_id_hash = sha256::hash(app_id.clone().as_bytes());
+        let app_id_hash = sha3_256(app_id.clone().as_bytes());
 
         (*auth).send(move |client| {
             let c2 = client.clone();

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -54,6 +54,7 @@ extern crate serde_derive;
 extern crate rust_sodium;
 #[macro_use]
 extern crate safe_core;
+extern crate tiny_keccak;
 extern crate tokio_core;
 #[macro_use]
 extern crate unwrap;

--- a/safe_authenticator/src/public_id.rs
+++ b/safe_authenticator/src/public_id.rs
@@ -20,8 +20,8 @@ use errors::AuthError;
 use futures::{Future, IntoFuture};
 use maidsafe_utilities::serialisation::serialise;
 use routing::{ClientError, EntryActions, MutableData, XorName};
-use rust_sodium::crypto::hash::sha256;
 use safe_core::{Client, CoreError, FutureExt, MDataInfo, PUBLIC_ID_TAG};
+use tiny_keccak::sha3_256;
 
 // TODO: could we use the same value for both of these?
 const PUBLIC_ID_USER_ROOT_ENTRY_KEY: &'static [u8] = b"_publicId";
@@ -44,7 +44,7 @@ pub fn create<T: Into<String>>(client: &Client, public_id: T) -> Box<AuthFuture<
     let client6 = client.clone();
 
     let public_id = public_id.into();
-    let name = XorName(sha256::hash(public_id.as_bytes()).0);
+    let name = XorName(sha3_256(public_id.as_bytes()));
 
     client.user_root_dir()
         .and_then(|user_root_dir| {

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -26,7 +26,6 @@ use ipc::{authenticator_revoke_app, encode_auth_resp, encode_containers_resp,
           encode_unregistered_resp, get_config};
 use maidsafe_utilities::serialisation::deserialise;
 use routing::User;
-use rust_sodium::crypto::hash::sha256;
 use safe_core::{CoreError, MDataInfo, mdata_info};
 use safe_core::ipc::{self, AuthReq, BootstrapConfig, ContainersReq, IpcError, IpcMsg, IpcReq,
                      IpcResp, Permission};
@@ -41,6 +40,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use test_utils::{access_container, compare_access_container_entries, create_account_and_login,
                  rand_app, register_app, run};
+use tiny_keccak::sha3_256;
 
 // Test creation and content of std dirs after account creation.
 #[test]
@@ -215,7 +215,7 @@ fn app_authentication() {
     let config = run(&authenticator,
                      |client| get_config(client).map(|(_, config)| config));
 
-    let app_config_key = sha256::hash(app_id.as_bytes());
+    let app_config_key = sha3_256(app_id.as_bytes());
     let app_info = unwrap!(config.get(&app_config_key));
 
     assert_eq!(app_info.info, app_exchange_info);

--- a/safe_core/src/ipc/resp/mod.rs
+++ b/safe_core/src/ipc/resp/mod.rs
@@ -25,8 +25,9 @@ use ffi_utils::{ReprC, vec_into_raw_parts};
 use ipc::IpcError;
 use maidsafe_utilities::serialisation::{SerialisationError, deserialise, serialise};
 use routing::{BootstrapConfig, XorName};
-use rust_sodium::crypto::{box_, hash, secretbox, sign};
+use rust_sodium::crypto::{box_, secretbox, sign};
 use std::slice;
+use tiny_keccak::sha3_256;
 
 /// IPC response
 // TODO: `TransOwnership` variant
@@ -241,9 +242,8 @@ pub fn access_container_enc_key(app_id: &str,
     let mut key_pt = key.to_vec();
     key_pt.extend_from_slice(&access_container_nonce[..]);
 
-    let key_nonce = secretbox::Nonce::from_slice(&hash::sha256::hash(&key_pt)
-                                                      [..secretbox::NONCEBYTES])
-            .ok_or(IpcError::EncodeDecodeError)?;
+    let key_nonce = secretbox::Nonce::from_slice(&sha3_256(&key_pt)[..secretbox::NONCEBYTES])
+        .ok_or(IpcError::EncodeDecodeError)?;
 
     Ok(secretbox::seal(key, &key_nonce, app_enc_key))
 }


### PR DESCRIPTION
1. The test for this case was missing.
2. The fact that MData entries aren't removed for now but blanked out wasn't taken into account.
3. There was a missing decryption step before trying to deserialise an app-specific container.