### PR TITLE
Fix incorrect network events handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ rust:
   - 1.17.0
   - nightly-2017-04-28
 sudo: false
-branches:
-  only:
-    - master
-    - dev
 cache:
   cargo: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@ environment:
   matrix:
     - RUST_VERSION: stable
 
-branches:
-  only:
-    - master
-    - dev
-
 cache:
   - '%USERPROFILE%\.cargo'
   - '%APPVEYOR_BUILD_FOLDER%\target'

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -210,7 +210,8 @@ pub unsafe extern "C" fn mdata_info_extract_name_and_type_tag(app: *const App,
                                                                                   FfiResult,
                                                                                   *const [u8;
                                                                                    XOR_NAME_LEN],
-u64)){
+                                                                                  u64))
+{
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
             let info = context.object_cache().get_mdata_info(info_h)?;

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -26,7 +26,7 @@ unwrap = "~1.1.0"
 
 [features]
 use-mock-routing = ["safe_core/use-mock-routing"]
-testing = []
+testing = ["safe_core/testing"]
 
 [lib]
 crate_type = ["staticlib", "rlib", "cdylib"]

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -27,18 +27,21 @@ use std::os::raw::{c_char, c_void};
 
 /// Create a registered client. This or any one of the other companion
 /// functions to get an authenticator instance must be called before initiating any
-/// operation allowed by this module. `auth_handle` is a pointer to a pointer and must
-/// point to a valid pointer not junk, else the consequences are undefined.
+/// operation allowed by this module. The `user_data` parameter corresponds to the
+/// first parameter of the `o_cb` callback, while `network_cb_user_data` corresponds
+/// to the first parameter of the network events observer callback (`o_network_obs_cb`).
 #[no_mangle]
 pub unsafe extern "C" fn create_acc(account_locator: *const c_char,
                                     account_password: *const c_char,
                                     invitation: *const c_char,
+                                    network_cb_user_data: *mut c_void,
                                     user_data: *mut c_void,
                                     o_network_obs_cb: unsafe extern "C" fn(*mut c_void, i32, i32),
                                     o_cb: extern "C" fn(*mut c_void,
                                                         FfiResult,
                                                         *mut Authenticator)) {
     let user_data = OpaqueCtx(user_data);
+    let network_cb_user_data = OpaqueCtx(network_cb_user_data);
 
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
         trace!("Authenticator - create a client account.");
@@ -49,11 +52,10 @@ pub unsafe extern "C" fn create_acc(account_locator: *const c_char,
 
         let authenticator =
             Authenticator::create_acc(acc_locator, acc_password, invitation, move |net_event| {
-                let user_data: *mut c_void = user_data.into();
-
+                let ud = network_cb_user_data.0;
                 match net_event {
-                    Ok(event) => o_network_obs_cb(user_data, 0, event.into()),
-                    Err(()) => o_network_obs_cb(user_data, -1, 0),
+                    Ok(event) => o_network_obs_cb(ud, 0, event.into()),
+                    Err(()) => o_network_obs_cb(ud, -1, 0),
                 }
             })?;
 
@@ -67,15 +69,18 @@ pub unsafe extern "C" fn create_acc(account_locator: *const c_char,
 
 /// Log into a registered account. This or any one of the other companion
 /// functions to get an authenticator instance must be called before initiating
-/// any operation allowed for authenticator. `auth_handle` is a pointer to a pointer
-/// and must point to a valid pointer not junk, else the consequences are undefined.
+/// any operation allowed for authenticator. The `user_data` parameter corresponds to the
+/// first parameter of the `o_cb` callback, while `network_cb_user_data` corresponds
+/// to the first parameter of the network events observer callback (`o_network_obs_cb`).
 #[no_mangle]
 pub unsafe extern "C" fn login(account_locator: *const c_char,
                                account_password: *const c_char,
                                user_data: *mut c_void,
+                               network_cb_user_data: *mut c_void,
                                o_network_obs_cb: unsafe extern "C" fn(*mut c_void, i32, i32),
                                o_cb: extern "C" fn(*mut c_void, FfiResult, *mut Authenticator)) {
     let user_data = OpaqueCtx(user_data);
+    let network_cb_user_data = OpaqueCtx(network_cb_user_data);
 
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
         trace!("Authenticator - log in a registererd client.");
@@ -83,14 +88,15 @@ pub unsafe extern "C" fn login(account_locator: *const c_char,
         let acc_locator = from_c_str(account_locator)?;
         let acc_password = from_c_str(account_password)?;
 
-        let authenticator = Authenticator::login(acc_locator, acc_password, move |net_event| {
-            let user_data: *mut c_void = user_data.into();
-
-            match net_event {
-                Ok(event) => o_network_obs_cb(user_data, 0, event.into()),
-                Err(()) => o_network_obs_cb(user_data, -1, 0),
-            }
-        })?;
+        let authenticator =
+            Authenticator::login(acc_locator,
+                                 acc_password,
+                                 move |net_event| match net_event {
+                                     Ok(event) => {
+                                         o_network_obs_cb(network_cb_user_data.0, 0, event.into())
+                                     }
+                                     Err(()) => o_network_obs_cb(network_cb_user_data.0, -1, 0),
+                                 })?;
 
         o_cb(user_data.0,
              FFI_RESULT_OK,
@@ -127,13 +133,14 @@ mod tests {
         {
             let auth_h: *mut Authenticator = unsafe {
                 unwrap!(call_1(|ud, cb| {
-                                   create_acc(acc_locator.as_ptr(),
-                                              acc_password.as_ptr(),
-                                              invitation.as_ptr(),
-                                              ud,
-                                              net_event_cb,
-                                              cb)
-                               }))
+                    create_acc(acc_locator.as_ptr(),
+                               acc_password.as_ptr(),
+                               invitation.as_ptr(),
+                               ud,
+                               ud,
+                               net_event_cb,
+                               cb)
+                }))
             };
             assert!(!auth_h.is_null());
             unsafe { authenticator_free(auth_h) };
@@ -145,6 +152,7 @@ mod tests {
                                    login(acc_locator.as_ptr(),
                                          acc_password.as_ptr(),
                                          ud,
+                                         ud,
                                          net_event_cb,
                                          cb)
                                }))
@@ -155,6 +163,54 @@ mod tests {
 
         unsafe extern "C" fn net_event_cb(_user_data: *mut c_void, err_code: i32, _event: i32) {
             assert_eq!(err_code, 0);
+        }
+    }
+
+    #[cfg(all(test, feature = "use-mock-routing"))]
+    #[test]
+    fn network_status_callback() {
+        use ffi_utils::test_utils::{send_via_user_data, sender_as_user_data};
+        use safe_core::NetworkEvent;
+        use std::time::Duration;
+        use std::sync::mpsc;
+
+        let acc_locator = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
+        let acc_password = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
+        let invitation = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
+
+        {
+            let (tx, rx) = mpsc::channel();
+
+            let auth: *mut Authenticator = unsafe {
+                unwrap!(call_1(|ud, cb| {
+                    create_acc(acc_locator.as_ptr(),
+                               acc_password.as_ptr(),
+                               invitation.as_ptr(),
+                               sender_as_user_data(&tx),
+                               ud,
+                               net_event_cb,
+                               cb)
+                }))
+            };
+
+            unsafe {
+                unwrap!((*auth).send(move |client| {
+                                         client.simulate_network_disconnect();
+                                         None
+                                     }));
+            }
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
+
+            let disconnected: i32 = NetworkEvent::Disconnected.into();
+            assert_eq!(event, disconnected);
+
+            unsafe { authenticator_free(auth) };
+        }
+
+        unsafe extern "C" fn net_event_cb(user_data: *mut c_void, err_code: i32, event: i32) {
+            send_via_user_data(user_data, (err_code, event));
         }
     }
 }

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -366,7 +366,7 @@ fn containers_unknown_app() {
 
     // Invoke Authenticator's decode_ipc_msg and expect to get Failure back via
     // callback with error code for IpcError::UnknownApp
-    // Check that the returned FfiString is "safe_<app-id-base64>:payload" where payload is
+    // Check that the returned string is "safe_<app-id-base64>:payload" where payload is
     // IpcMsg::Resp(IpcResp::Auth(Err(UnknownApp)))"
     match decode_ipc_msg(&authenticator, &encoded_msg) {
         Err((code, Some(IpcMsg::Resp { resp: IpcResp::Auth(Err(IpcError::UnknownApp)), .. })))
@@ -418,7 +418,7 @@ fn containers_access_request() {
         }))
     };
 
-    // Check the FfiString to contain "safe-<app-id-base64>:payload" where payload is
+    // Check the string to contain "safe-<app-id-base64>:payload" where payload is
     // IpcMsg::Resp(IpcResp::Auth(Containers(Ok())))".
     assert!(encoded_containers_resp.starts_with(&format!("safe-{}", base64_app_id)));
 

--- a/safe_core/src/client/mock/mod.rs
+++ b/safe_core/src/client/mock/mod.rs
@@ -21,3 +21,53 @@ mod tests;
 mod vault;
 
 pub use self::routing::Routing;
+use routing::XorName;
+
+/// Identifier of immutable data
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ImmutableDataId(pub XorName);
+
+impl ImmutableDataId {
+    pub fn name(&self) -> &XorName {
+        &self.0
+    }
+}
+
+/// Identifier of mutable data
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct MutableDataId(pub XorName, pub u64);
+
+impl MutableDataId {
+    pub fn name(&self) -> &XorName {
+        &self.0
+    }
+}
+
+/// Identifier for a data (immutable or mutable)
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub enum DataId {
+    /// Identifier of immutable data.
+    Immutable(ImmutableDataId),
+    /// Identifier of mutable data.
+    Mutable(MutableDataId),
+}
+
+impl DataId {
+    /// Create `DataId` for immutable data.
+    pub fn immutable(name: XorName) -> Self {
+        DataId::Immutable(ImmutableDataId(name))
+    }
+
+    /// Create `DataId` for mutable data.
+    pub fn mutable(name: XorName, tag: u64) -> Self {
+        DataId::Mutable(MutableDataId(name, tag))
+    }
+
+    /// Get name of this identifier.
+    pub fn name(&self) -> &XorName {
+        match *self {
+            DataId::Immutable(ref id) => id.name(),
+            DataId::Mutable(ref id) => id.name(),
+        }
+    }
+}

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -901,18 +901,18 @@ impl Routing {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn set_network_limits(&mut self, max_ops_count: Option<u64>) {
         self.max_ops_countdown = max_ops_count.map(Cell::new)
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn simulate_disconnect(&self) {
         let sender = self.sender.clone();
-        let _ = std::thread::spawn(move || unwrap!(sender.send(Event::RestartRequired)));
+        let _ = std::thread::spawn(move || unwrap!(sender.send(Event::Terminate)));
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn set_simulate_timeout(&mut self, enable: bool) {
         self.timeout_simulation = enable;
     }
@@ -950,11 +950,5 @@ impl Routing {
                      count.set(ops - 1);
                      ops
                  })
-    }
-}
-
-impl Drop for Routing {
-    fn drop(&mut self) {
-        let _ = self.sender.send(Event::Terminate);
     }
 }

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -160,6 +160,19 @@ fn mutable_data_basics() {
     unwrap!(routing.put_mdata(client_mgr, data, msg_id, owner_key));
     expect_success!(routing_rx, msg_id, Response::PutMData);
 
+    // It should be possible to put an MData using the same name but a
+    // different type tag
+    let tag2 = 1001u64;
+
+    let data2 = unwrap!(MutableData::new(name,
+                                         tag2,
+                                         Default::default(),
+                                         Default::default(),
+                                         btree_set!(owner_key)));
+    let msg_id = MessageId::new();
+    unwrap!(routing.put_mdata(client_mgr, data2, msg_id, owner_key));
+    expect_success!(routing_rx, msg_id, Response::PutMData);
+
     // GetMDataVersion should respond with 0
     let msg_id = MessageId::new();
     unwrap!(routing.get_mdata_version(nae_mgr, name, tag, msg_id));
@@ -217,6 +230,12 @@ fn mutable_data_basics() {
     let entry = unwrap!(entries.get(&key1[..]));
     assert_eq!(entry.content, value1_v0);
     assert_eq!(entry.entry_version, 0);
+
+    // Second MData with a diff. type tag still should be empty
+    let msg_id = MessageId::new();
+    unwrap!(routing.list_mdata_entries(nae_mgr, name, tag2, msg_id));
+    let entries = expect_success!(routing_rx, msg_id, Response::ListMDataEntries);
+    assert!(entries.is_empty());
 
     // ListMDataKeys
     let msg_id = MessageId::new();

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use super::DataId;
 use routing::{AccountInfo, Authority, ClientError, ImmutableData, MutableData, XorName};
 use rust_sodium::crypto::sign;
 use std::collections::{BTreeSet, HashMap};
@@ -25,7 +26,7 @@ pub const DEFAULT_MAX_MUTATIONS: u64 = 100;
 #[derive(Deserialize, Serialize)]
 pub struct Vault {
     client_manager: HashMap<XorName, Account>,
-    nae_manager: HashMap<XorName, Data>,
+    nae_manager: HashMap<DataId, Data>,
 }
 
 impl Vault {
@@ -90,17 +91,17 @@ impl Vault {
     }
 
     // Check if data with the given name is in the storage.
-    pub fn contains_data(&self, name: &XorName) -> bool {
+    pub fn contains_data(&self, name: &DataId) -> bool {
         self.nae_manager.contains_key(name)
     }
 
     // Load data with the given name from the storage.
-    pub fn get_data(&self, name: &XorName) -> Option<Data> {
+    pub fn get_data(&self, name: &DataId) -> Option<Data> {
         self.nae_manager.get(name).cloned()
     }
 
     // Save the data to the storage.
-    pub fn insert_data(&mut self, name: XorName, data: Data) {
+    pub fn insert_data(&mut self, name: DataId, data: Data) {
         let _ = self.nae_manager.insert(name, data);
     }
 

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -462,7 +462,9 @@ impl Client {
             }
         };
 
-        let _ = net_tx.send(NetworkEvent::Connected);
+        if let Err(e) = net_tx.send(NetworkEvent::Connected) {
+            trace!("Couldn't send: {:?}", e);
+        }
 
         let joiner = spawn_routing_thread(routing_rx, core_tx, net_tx);
 
@@ -976,7 +978,8 @@ impl Client {
     }
 }
 
-#[cfg(all(test, feature = "use-mock-routing"))]
+#[cfg(any(all(test, feature = "use-mock-routing"),
+          all(feature = "testing", feature = "use-mock-routing")))]
 impl Client {
     #[doc(hidden)]
     pub fn set_network_limits(&self, max_ops_count: Option<u64>) {

--- a/safe_core/src/client/routing_event_loop.rs
+++ b/safe_core/src/client/routing_event_loop.rs
@@ -37,8 +37,9 @@ pub fn run<T>(routing_rx: &Receiver<Event>, mut core_tx: CoreMsgTx<T>, net_tx: &
                     break;
                 }
             }
-            Event::RestartRequired => {
-                if net_tx.send(NetworkEvent::Disconnected).is_err() {
+            Event::Terminate => {
+                if let Err(e) = net_tx.send(NetworkEvent::Disconnected) {
+                    trace!("Couldn't send NetworkEvent::Disconnected: {:?}", e);
                     break;
                 }
 
@@ -51,11 +52,11 @@ pub fn run<T>(routing_rx: &Receiver<Event>, mut core_tx: CoreMsgTx<T>, net_tx: &
                                  })
                 };
 
-                if core_tx.send(msg).is_err() {
-                    break;
+                if let Err(e) = core_tx.send(msg) {
+                    trace!("Couldn't restart routing: {:?}", e);
                 }
+                break;
             }
-            Event::Terminate => break,
             x => {
                 debug!("Routing Event {:?} is not handled in context of routing event loop.",
                        x);


### PR DESCRIPTION
+ Fix incorrect network events handling (expect `Event::Terminate` instead of `Event::RestartRequired`).
+ Add more tests for network event callbacks from the FFI point of view.
+ Improve functions signatures for `create_acc`, `login` in safe_authenticator and for `app_registered` and `app_unregistered` in safe_app.