### PR TITLE
refactor/safe-authenticator: improve API to get network config

### DIFF
--- a/ffi_utils/src/catch_unwind.rs
+++ b/ffi_utils/src/catch_unwind.rs
@@ -40,10 +40,9 @@ pub fn catch_unwind_error_code<'a, F, E>(f: F) -> i32
 }
 
 /// Catch panics. On error call the callback.
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 pub fn catch_unwind_cb<'a, U, C, F, E>(user_data: U, cb: C, f: F)
     where U: Into<*mut c_void>,
-          C: Callback,
+          C: Callback + Copy,
           F: FnOnce() -> Result<(), E>,
           E: Debug + Display + ErrorCode + From<&'a str>
 {

--- a/ffi_utils/src/lib.rs
+++ b/ffi_utils/src/lib.rs
@@ -86,6 +86,7 @@ pub trait ErrorCode {
 
 /// FFI result wrapper
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiResult {
     /// Unique error code
     pub error_code: i32,

--- a/ffi_utils/src/test_utils.rs
+++ b/ffi_utils/src/test_utils.rs
@@ -109,12 +109,10 @@ pub unsafe fn call_vec_u8<F>(f: F) -> Result<Vec<u8>, i32>
     unwrap!(rx.recv())
 }
 
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn callback_0(user_data: *mut c_void, res: FfiResult) {
     unsafe { send_via_user_data(user_data, res.error_code) }
 }
 
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn callback_1<E, T>(user_data: *mut c_void, res: FfiResult, arg: T::C)
     where E: Debug,
           T: ReprC<Error = E>
@@ -129,7 +127,6 @@ extern "C" fn callback_1<E, T>(user_data: *mut c_void, res: FfiResult, arg: T::C
     }
 }
 
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn callback_2<E0, E1, T0, T1>(user_data: *mut c_void,
                                          res: FfiResult,
                                          arg0: T0::C,
@@ -149,10 +146,9 @@ extern "C" fn callback_2<E0, E1, T0, T1>(user_data: *mut c_void,
     }
 }
 
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn callback_vec<E, T, U>(user_data: *mut c_void,
                                     res: FfiResult,
-                                    array: T::C,
+                                    array: *const U,
                                     size: usize)
     where E: Debug,
           T: ReprC<C = *const U, Error = E>
@@ -173,7 +169,6 @@ extern "C" fn callback_vec<E, T, U>(user_data: *mut c_void,
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn callback_vec_u8(user_data: *mut c_void, res: FfiResult, ptr: *const u8, len: usize) {
     unsafe {
         let result = if res.error_code == 0 {

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -339,7 +339,6 @@ mod tests {
                 }
             }
 
-            #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
             extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
                 unsafe {
                     let ctx = ctx as *mut Context;
@@ -420,7 +419,6 @@ mod tests {
                 }
             }
 
-            #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
             extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
                 unsafe {
                     let ctx = ctx as *mut Context;

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -190,7 +190,6 @@ mod tests {
             unsafe { app_free(app) };
         }
 
-        #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
         unsafe extern "C" fn net_event_cb(user_data: *mut c_void, res: FfiResult, event: i32) {
             send_via_user_data(user_data, (res.error_code, event));
         }

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -369,7 +369,6 @@ mod tests {
 
         let (tx, rx) = mpsc::channel::<Value>();
 
-        #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
         extern "C" fn get_cb(user_data: *mut c_void,
                              res: FfiResult,
                              ptr: *const u8,
@@ -434,7 +433,6 @@ mod tests {
             }
         }
 
-        #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
         extern "C" fn done_cb(user_data: *mut c_void, res: FfiResult) {
             assert_eq!(res.error_code, 0);
             let user_data = user_data as *mut (Sender<_>, BTreeMap<Vec<u8>, Value>);

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -1247,7 +1247,6 @@ fn entries_crud_ffi() {
         }
     }
 
-    #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
     extern "C" fn get_value_cb(user_data: *mut c_void,
                                res: FfiResult,
                                val: *const u8,
@@ -1280,7 +1279,6 @@ fn entries_crud_ffi() {
         }
     }
 
-    #[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
     extern "C" fn iter_done_cb(user_data: *mut c_void, _res: FfiResult) {
         unsafe {
             send_via_user_data::<Option<Vec<u8>>>(user_data, None);

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -91,10 +91,8 @@ pub fn app_info(client: &Client, app_id: &str) -> Box<AuthFuture<Option<AppInfo>
 /// an error code + description & an encoded `IpcMsg::Resp` in case of an error
 #[cfg_attr(feature="cargo-clippy", allow(type_complexity))]
 pub fn decode_ipc_msg(client: &Client,
-                      msg: &str)
+                      msg: IpcMsg)
                       -> Box<AuthFuture<Result<IpcMsg, (i32, CString, CString)>>> {
-    let msg = fry!(decode_msg(msg));
-
     match msg {
         IpcMsg::Req {
             req: IpcReq::Auth(auth_req),
@@ -161,6 +159,45 @@ pub fn decode_ipc_msg(client: &Client,
     }
 }
 
+/// Decodes a given encoded IPC message without requiring an authorised account
+#[no_mangle]
+pub unsafe extern "C" fn auth_unregistered_decode_ipc_msg(msg: *const c_char,
+                                                          user_data: *mut c_void,
+                                                          o_unregistered: extern "C" fn(*mut c_void,
+                                                                                        u32),
+                                                          o_err: extern "C" fn(*mut c_void,
+                                                                  FfiResult,
+                                                                  *const c_char))
+{
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data.0, o_err, || -> Result<_, AuthError> {
+        let msg_raw = CStr::from_ptr(msg).to_str()?;
+        let msg = decode_msg(msg_raw)?;
+
+        match msg {
+            IpcMsg::Req {
+                req: IpcReq::Unregistered,
+                req_id,
+            } => {
+                o_unregistered(user_data.0, req_id);
+            }
+            _ => {
+                let (error_code, description) =
+                    ffi_error!(AuthError::Unexpected("Unexpected msg type".to_owned()));
+                o_err(user_data.0,
+                      FfiResult {
+                          error_code,
+                          description: description.as_ptr(),
+                      },
+                      ptr::null_mut());
+            }
+        }
+
+        Ok(())
+    })
+}
+
 /// Decodes a given encoded IPC message and calls a corresponding callback
 #[no_mangle]
 pub unsafe extern "C" fn auth_decode_ipc_msg(auth: *const Authenticator,
@@ -169,7 +206,6 @@ pub unsafe extern "C" fn auth_decode_ipc_msg(auth: *const Authenticator,
                                              o_auth: extern "C" fn(*mut c_void,
                                                                    u32,
                                                                    *const FfiAuthReq),
-                                             o_unregistered: extern "C" fn(*mut c_void, u32),
                                              o_containers: extern "C" fn(*mut c_void,
                                                                          u32,
                                                                          *const FfiContainersReq),
@@ -180,9 +216,11 @@ pub unsafe extern "C" fn auth_decode_ipc_msg(auth: *const Authenticator,
 
     catch_unwind_cb(user_data.0, o_err, || -> Result<_, AuthError> {
         let msg_raw = CStr::from_ptr(msg).to_str()?;
+        let msg = decode_msg(msg_raw)?;
+
         (*auth)
             .send(move |client| {
-                decode_ipc_msg(client, msg_raw)
+                decode_ipc_msg(client, msg)
                     .and_then(move |msg| {
                         match msg {
                             Ok(IpcMsg::Req {
@@ -190,12 +228,6 @@ pub unsafe extern "C" fn auth_decode_ipc_msg(auth: *const Authenticator,
                                    req_id,
                                }) => {
                                 o_auth(user_data.0, req_id, &auth_req.into_repr_c()?);
-                            }
-                            Ok(IpcMsg::Req {
-                                   req: IpcReq::Unregistered,
-                                   req_id,
-                               }) => {
-                                o_unregistered(user_data.0, req_id);
                             }
                             Ok(IpcMsg::Req {
                                    req: IpcReq::Containers(cont_req),
@@ -211,6 +243,7 @@ pub unsafe extern "C" fn auth_decode_ipc_msg(auth: *const Authenticator,
                                       },
                                       err.as_ptr());
                             }
+                            Ok(IpcMsg::Req { .. }) |
                             Ok(IpcMsg::Resp { .. }) |
                             Ok(IpcMsg::Revoked { .. }) |
                             Ok(IpcMsg::Err(..)) => {
@@ -364,8 +397,7 @@ pub unsafe extern "C" fn authenticator_revoke_app(auth: *const Authenticator,
 
 /// Encodes a response to unregistered client authentication request
 #[no_mangle]
-pub unsafe extern "C" fn encode_unregistered_resp(auth: *const Authenticator,
-                                                  req_id: u32,
+pub unsafe extern "C" fn encode_unregistered_resp(req_id: u32,
                                                   is_granted: bool,
                                                   user_data: *mut c_void,
                                                   o_cb: extern "C" fn(*mut c_void,
@@ -389,27 +421,16 @@ pub unsafe extern "C" fn encode_unregistered_resp(auth: *const Authenticator,
                  },
                  resp.as_ptr());
         } else {
-            (*auth)
-                .send(move |client| {
-                    let bootstrap_cfg = try_cb!(client.bootstrap_config().map_err(AuthError::from),
-                                                user_data,
-                                                o_cb);
+            let bootstrap_cfg = Client::bootstrap_config()?;
 
-                    let resp = try_cb!(encode_response(&IpcMsg::Resp {
-                                                 req_id: req_id,
-                                                 resp: IpcResp::Unregistered(Ok(bootstrap_cfg)),
-                                             },
-                                            "unregistered")
-                                    .map_err(AuthError::from),
-                            user_data,
-                            o_cb);
+            let resp = encode_response(&IpcMsg::Resp {
+                                            req_id: req_id,
+                                            resp: IpcResp::Unregistered(Ok(bootstrap_cfg)),
+                                        },
+                                       "unregistered")?;
 
-                    o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr());
-
-                    None
-                })?;
+            o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr());
         }
-
         Ok(())
     })
 }
@@ -495,7 +516,7 @@ pub unsafe extern "C" fn encode_auth_resp(auth: *const Authenticator,
                                 AppState::Authenticated => {
                                     // Return info of the already registered app
                                     let app_keys = app.keys.clone();
-                                    let bootstrap_config = fry!(c4.bootstrap_config());
+                                    let bootstrap_config = fry!(Client::bootstrap_config());
 
                                     access_container(&c4)
                                         .and_then(move |dir| {
@@ -946,7 +967,6 @@ fn encode_auth_resp_impl(client: &Client,
     let c5 = client.clone();
     let c6 = client.clone();
     let c7 = client.clone();
-    let c8 = client.clone();
 
     let sign_pk = app.keys.sign_pk;
     let app_keys = app.keys.clone();
@@ -1002,7 +1022,7 @@ fn encode_auth_resp_impl(client: &Client,
         .and_then(move |(dir, app_keys)| {
                       Ok(AuthGranted {
                              app_keys: app_keys,
-                             bootstrap_config: c8.bootstrap_config()?,
+                             bootstrap_config: Client::bootstrap_config()?,
                              access_container: AccessContInfo::from_mdata_info(dir)?,
                          })
                   })

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -65,12 +65,8 @@ pub fn register_app(authenticator: &Authenticator,
         req: IpcReq::Auth(auth_req.clone()),
     };
 
-    // Serialise it as base64 payload in "safe_auth:payload"
-    let encoded_msg = ipc::encode_msg(&msg, "safe-auth")?;
-
     // Invoke `decode_ipc_msg` and expect to get AuthReq back.
-    let ipc_req = run(authenticator,
-                      move |client| decode_ipc_msg(client, &encoded_msg));
+    let ipc_req = run(authenticator, move |client| decode_ipc_msg(client, msg));
     match ipc_req {
         Ok(IpcMsg::Req { req: IpcReq::Auth(_), .. }) => (),
         x => return Err(AuthError::Unexpected(format!("Unexpected {:?}", x))),

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -884,7 +884,6 @@ extern "C" fn unregistered_cb(user_data: *mut c_void, req_id: u32) {
     }
 }
 
-#[cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
 extern "C" fn err_cb(user_data: *mut c_void, res: FfiResult, response: *const c_char) {
     unsafe {
         let ipc_resp = if response.is_null() {

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use Authenticator;
-use errors::{AuthError, ERR_UNKNOWN_APP};
+use errors::{AuthError, ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
 use ffi::apps::*;
 use ffi_utils::{FfiResult, ReprC, StringError, base64_encode, from_c_str};
 use ffi_utils::test_utils::{call_1, call_vec, send_via_user_data, sender_as_user_data};
@@ -133,6 +133,15 @@ fn config_root_dir() {
 fn app_authentication() {
     let authenticator = create_account_and_login();
 
+    // Try to send IpcResp::Auth - it should fail
+    let msg = IpcMsg::Revoked { app_id: "hello".to_string() };
+    let encoded_msg = unwrap!(ipc::encode_msg(&msg, "safe-auth"));
+    match decode_ipc_msg(&authenticator, &encoded_msg) {
+        Err((ERR_INVALID_MSG, None)) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    // Try to send IpcReq::Auth - it should pass
     let req_id = ipc::gen_req_id();
     let app_exchange_info = unwrap!(rand_app());
     let app_id = app_exchange_info.id.clone();
@@ -251,8 +260,30 @@ fn app_authentication() {
 }
 
 // Test unregistered client authentication.
+// First, try to send a full auth request - it must fail with "Forbidden".
+// Then try to send a request for IpcReq::Unregistered, which must pass.
+// Next we invoke encode_unregistered_resp and it must return the network
+// configuration.
+// Try the same thing again when logged in - it must pass.
 #[test]
 fn unregistered_authentication() {
+    // Try to send IpcReq::Auth - it should fail
+    let msg = IpcMsg::Req {
+        req_id: ipc::gen_req_id(),
+        req: IpcReq::Auth(AuthReq {
+                              app: unwrap!(rand_app()),
+                              app_container: true,
+                              containers: create_containers_req(),
+                          }),
+    };
+    let encoded_msg = unwrap!(ipc::encode_msg(&msg, "safe-auth"));
+
+    match unregistered_decode_ipc_msg(&encoded_msg) {
+        Err((ERR_OPERATION_FORBIDDEN, None)) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    // Try to send IpcReq::Unregistered - it should pass
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id: req_id,
@@ -293,10 +324,26 @@ fn unregistered_authentication() {
     };
 
     assert_eq!(bootstrap_cfg, BootstrapConfig::default());
+
+    // Try to send IpcReq::Unregistered to logged in authenticator
+    let authenticator = create_account_and_login();
+
+    let received_req_id = match unwrap!(decode_ipc_msg(&authenticator, &encoded_msg)) {
+        IpcMsg::Req {
+            req_id,
+            req: IpcReq::Unregistered,
+        } => req_id,
+        x => panic!("Unexpected {:?}", x),
+    };
+
+    assert_eq!(received_req_id, req_id);
 }
 
+// Authenticate an app - it must pass.
+// Authenticate the same app again - it must return the correct response
+// with the same app details.
 #[test]
-fn authenticated_app_cannot_be_authenticated_again() {
+fn authenticated_app_can_be_authenticated_again() {
     let authenticator = create_account_and_login();
 
     let auth_req = AuthReq {
@@ -797,6 +844,7 @@ fn decode_ipc_msg(authenticator: &Authenticator,
                             sender_as_user_data(&tx),
                             auth_cb,
                             containers_cb,
+                            unregistered_cb,
                             err_cb);
     };
 
@@ -808,17 +856,6 @@ fn decode_ipc_msg(authenticator: &Authenticator,
 
 fn unregistered_decode_ipc_msg(msg: &str) -> Result<IpcMsg, (i32, Option<IpcMsg>)> {
     let (tx, rx) = mpsc::channel::<Result<IpcMsg, (i32, Option<IpcMsg>)>>();
-
-    extern "C" fn unregistered_cb(user_data: *mut c_void, req_id: u32) {
-        unsafe {
-            let msg = IpcMsg::Req {
-                req_id: req_id,
-                req: IpcReq::Unregistered,
-            };
-
-            send_via_user_data(user_data, Ok::<_, (i32, Option<IpcMsg>)>(msg))
-        }
-    }
 
     let ffi_msg = unwrap!(CString::new(msg));
 
@@ -833,6 +870,17 @@ fn unregistered_decode_ipc_msg(msg: &str) -> Result<IpcMsg, (i32, Option<IpcMsg>
     match rx.recv_timeout(Duration::from_secs(15)) {
         Ok(r) => r,
         Err(_) => Err((-1, None)),
+    }
+}
+
+extern "C" fn unregistered_cb(user_data: *mut c_void, req_id: u32) {
+    unsafe {
+        let msg = IpcMsg::Req {
+            req_id: req_id,
+            req: IpcReq::Unregistered,
+        };
+
+        send_via_user_data(user_data, Ok::<_, (i32, Option<IpcMsg>)>(msg))
     }
 }
 

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -916,7 +916,7 @@ impl Routing {
         self.timeout_simulation = enable;
     }
 
-    pub fn bootstrap_config(&self) -> Result<BootstrapConfig, InterfaceError> {
+    pub fn bootstrap_config() -> Result<BootstrapConfig, InterfaceError> {
         Ok(BootstrapConfig::default())
     }
 

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -877,8 +877,8 @@ impl Client {
     }
 
     /// Returns the `crust::Config` associated with the `crust::Service` (if any).
-    pub fn bootstrap_config(&self) -> Result<BootstrapConfig, CoreError> {
-        Ok(self.inner().routing.bootstrap_config()?)
+    pub fn bootstrap_config() -> Result<BootstrapConfig, CoreError> {
+        Ok(Routing::bootstrap_config()?)
     }
 
     fn update_account_packet(&self) -> Box<CoreFuture<()>> {

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -142,7 +142,7 @@ impl Client {
     {
         trace!("Creating unregistered client.");
 
-        let (routing, routing_rx) = setup_routing(None, config)?;
+        let (routing, routing_rx) = setup_routing(None, config.clone())?;
         let net_tx_clone = net_tx.clone();
         let core_tx_clone = core_tx.clone();
         let joiner = spawn_routing_thread(routing_rx, core_tx_clone, net_tx_clone);
@@ -152,7 +152,7 @@ impl Client {
                          routing: routing,
                          hooks: HashMap::with_capacity(10),
                          cache: LruCache::new(IMMUT_DATA_CACHE_SIZE),
-                         client_type: ClientType::Unregistered,
+                         client_type: ClientType::unreg(config),
                          timeout: Duration::from_secs(REQUEST_TIMEOUT_SECS),
                          joiner: joiner,
                          session_packet_version: 0,
@@ -408,7 +408,7 @@ impl Client {
         where T: 'static
     {
         trace!("Attempting to log into an acc using client keys.");
-        let (routing, routing_rx) = setup_routing(Some(keys.clone().into()), Some(config))?;
+        let (routing, routing_rx) = setup_routing(Some(keys.clone().into()), Some(config.clone()))?;
         let net_tx_clone = net_tx.clone();
         let core_tx_clone = core_tx.clone();
         let joiner = spawn_routing_thread(routing_rx, core_tx_clone, net_tx_clone);
@@ -418,7 +418,7 @@ impl Client {
                          routing: routing,
                          hooks: HashMap::with_capacity(10),
                          cache: LruCache::new(IMMUT_DATA_CACHE_SIZE),
-                         client_type: ClientType::from_keys(keys, owner),
+                         client_type: ClientType::from_keys(keys, owner, config),
                          timeout: Duration::from_secs(REQUEST_TIMEOUT_SECS),
                          joiner: joiner,
                          session_packet_version: 0,
@@ -438,13 +438,14 @@ impl Client {
     pub fn restart_routing<T>(&self, core_tx: CoreMsgTx<T>, net_tx: NetworkTx)
         where T: 'static
     {
-        let opt_id = if let ClientType::Registered { ref acc, .. } = self.inner().client_type {
-            Some(acc.maid_keys.clone().into())
-        } else {
-            None
+        let opt_id = match self.inner().client_type {
+            ClientType::Registered { ref acc, .. } => Some(acc.maid_keys.clone().into()),
+            ClientType::FromKeys { ref keys, .. } => Some(keys.clone().into()),
+            ClientType::Unregistered { .. } => None,
         };
 
-        let (routing, routing_rx) = match setup_routing(opt_id, None) {
+        let (routing, routing_rx) = match setup_routing(opt_id,
+                                                        self.inner().client_type.config()) {
             Ok(elt) => elt,
             Err(e) => {
                 info!("Could not restart routing (will re-attempt, unless dropped): {:?}",
@@ -1034,7 +1035,7 @@ impl UserCred {
 
 #[cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 enum ClientType {
-    Unregistered,
+    Unregistered { config: Option<BootstrapConfig> },
     Registered {
         acc: Account,
         acc_loc: XorName,
@@ -1045,18 +1046,20 @@ enum ClientType {
         keys: ClientKeys,
         owner_key: sign::PublicKey,
         cm_addr: Authority<XorName>,
+        config: BootstrapConfig,
     },
 }
 
 impl ClientType {
-    fn from_keys(keys: ClientKeys, owner_key: sign::PublicKey) -> Self {
+    fn from_keys(keys: ClientKeys, owner_key: sign::PublicKey, config: BootstrapConfig) -> Self {
         let digest = sha3_256(&owner_key.0);
         let cm_addr = Authority::ClientManager(XorName(digest));
 
         ClientType::FromKeys {
-            keys: keys,
-            owner_key: owner_key,
-            cm_addr: cm_addr,
+            keys,
+            owner_key,
+            cm_addr,
+            config,
         }
     }
 
@@ -1066,10 +1069,22 @@ impl ClientType {
            cm_addr: Authority<XorName>)
            -> Self {
         ClientType::Registered {
-            acc: acc,
-            acc_loc: acc_loc,
-            user_cred: user_cred,
-            cm_addr: cm_addr,
+            acc,
+            acc_loc,
+            user_cred,
+            cm_addr,
+        }
+    }
+
+    fn unreg(config: Option<BootstrapConfig>) -> Self {
+        ClientType::Unregistered { config }
+    }
+
+    fn config(&self) -> Option<BootstrapConfig> {
+        match *self {
+            ClientType::Registered { .. } => None,
+            ClientType::Unregistered { ref config, .. } => config.clone(),
+            ClientType::FromKeys { ref config, .. } => Some(config.clone()),
         }
     }
 
@@ -1077,7 +1092,7 @@ impl ClientType {
         match *self {
             ClientType::Registered { ref acc, .. } => Ok(acc),
             ClientType::FromKeys { .. } |
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1085,7 +1100,7 @@ impl ClientType {
         match *self {
             ClientType::Registered { ref mut acc, .. } => Ok(acc),
             ClientType::FromKeys { .. } |
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1093,7 +1108,7 @@ impl ClientType {
         match *self {
             ClientType::Registered { acc_loc, .. } => Ok(acc_loc),
             ClientType::FromKeys { .. } |
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1101,7 +1116,7 @@ impl ClientType {
         match *self {
             ClientType::Registered { ref user_cred, .. } => Ok(user_cred),
             ClientType::FromKeys { .. } |
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1109,7 +1124,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { ref cm_addr, .. } |
             ClientType::Registered { ref cm_addr, .. } => Ok(cm_addr),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1117,7 +1132,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { owner_key, .. } => Ok(owner_key),
             ClientType::Registered { ref acc, .. } => Ok(acc.maid_keys.sign_pk),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1125,7 +1140,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { ref keys, .. } => Ok(keys.sign_pk),
             ClientType::Registered { ref acc, .. } => Ok(acc.maid_keys.sign_pk),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1133,7 +1148,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { ref keys, .. } => Ok(keys.sign_sk.clone()),
             ClientType::Registered { ref acc, .. } => Ok(acc.maid_keys.sign_sk.clone()),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1141,7 +1156,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { ref keys, .. } => Ok(keys.enc_pk),
             ClientType::Registered { ref acc, .. } => Ok(acc.maid_keys.enc_pk),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 
@@ -1149,7 +1164,7 @@ impl ClientType {
         match *self {
             ClientType::FromKeys { ref keys, .. } => Ok(keys.enc_sk.clone()),
             ClientType::Registered { ref acc, .. } => Ok(acc.maid_keys.enc_sk.clone()),
-            ClientType::Unregistered => Err(CoreError::OperationForbidden),
+            ClientType::Unregistered { .. } => Err(CoreError::OperationForbidden),
         }
     }
 }


### PR DESCRIPTION
Expose an API for IPC to get config without needing to sign in. Now safe_authenticator adds new functions that don't require to provide authenticator handle for getting bootstrap config for unregistered apps.