### PR TITLE
refactor/all: change network re-connect fns

### DIFF
--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -73,7 +73,7 @@ impl CipherOpt {
     /// Decrypt something encrypted by CipherOpt::encrypt()
     pub fn decrypt(cipher_text: &[u8],
                    app_ctx: &AppContext,
-                   client: &Client)
+                   client: &Client<AppContext>)
                    -> Result<Vec<u8>, AppError> {
         if cipher_text.is_empty() {
             return Ok(Vec::new());
@@ -351,7 +351,7 @@ mod tests {
         })
     }
 
-    fn decrypt_and_check(client: &Client,
+    fn decrypt_and_check(client: &Client<AppContext>,
                          context: &AppContext,
                          cipher_text: &[u8],
                          orig_plain_text: &[u8])

--- a/safe_app/src/ffi/helper.rs
+++ b/safe_app/src/ffi/helper.rs
@@ -35,7 +35,7 @@ pub unsafe fn send_sync<C, F>(app: *const App,
                               f: F)
                               -> Result<(), AppError>
     where C: Callback + Copy + Send + 'static,
-          F: FnOnce(&Client, &AppContext) -> Result<C::Args, AppError> + Send + 'static
+          F: FnOnce(&Client<AppContext>, &AppContext) -> Result<C::Args, AppError> + Send + 'static
 {
     let user_data = OpaqueCtx(user_data);
 
@@ -66,7 +66,7 @@ pub unsafe fn send_with_mdata_info<C, F, U, E>(app: *const App,
                                                f: F)
                                                -> Result<(), AppError>
     where C: Callback + Copy + Send + 'static,
-          F: FnOnce(&Client, &AppContext, &MDataInfo) -> U + Send + 'static,
+          F: FnOnce(&Client<AppContext>, &AppContext, &MDataInfo) -> U + Send + 'static,
           U: Future<Item = C::Args, Error = E> + 'static,
           E: Debug + 'static,
           AppError: From<E>

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -225,6 +225,10 @@ mod tests {
 
             let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
             assert_eq!(err_code, 0);
+            assert_eq!(event, disconnected);
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
             assert_eq!(event, connected);
 
             unsafe { app_free(app) };

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -118,6 +118,30 @@ pub unsafe extern "C" fn app_registered(app_id: *const c_char,
     })
 }
 
+/// Try to restore a failed connection with the network.
+#[no_mangle]
+pub unsafe extern "C" fn app_reconnect(app: *mut App,
+                                       user_data: *mut c_void,
+                                       o_cb: extern "C" fn(*mut c_void, FfiResult)) {
+    let user_data = OpaqueCtx(user_data);
+    let res = (*app).send(move |client, _| {
+                              try_cb!(client.restart_routing().map_err(AppError::from),
+                                      user_data.0,
+                                      o_cb);
+                              o_cb(user_data.0, FFI_RESULT_OK);
+                              None
+                          });
+    if let Err(e) = res {
+        let e = AppError::from(e);
+        let (error_code, description) = ffi_error!(e);
+        o_cb(user_data.0,
+             FfiResult {
+                 error_code,
+                 description: description.as_ptr(),
+             });
+    }
+}
+
 /// Discard and clean up the previously allocated app instance.
 /// Use this only if the app is obtained from one of the auth
 /// functions in this crate. Using `app` after a call to this
@@ -148,7 +172,7 @@ unsafe fn call_network_observer(event: Result<NetworkEvent, AppError>,
 mod tests {
     use super::*;
     use App;
-    use ffi_utils::test_utils::{call_1, send_via_user_data, sender_as_user_data};
+    use ffi_utils::test_utils::{call_0, call_1, send_via_user_data, sender_as_user_data};
     use maidsafe_utilities::serialisation::serialise;
     use safe_core::NetworkEvent;
     use safe_core::ipc::BootstrapConfig;
@@ -186,6 +210,22 @@ mod tests {
 
             let disconnected: i32 = NetworkEvent::Disconnected.into();
             assert_eq!(event, disconnected);
+
+            // Reconnect with the network
+            unsafe { unwrap!(call_0(|ud, cb| app_reconnect(app, ud, cb))) };
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
+
+            let connected: i32 = NetworkEvent::Connected.into();
+            assert_eq!(event, connected);
+
+            // The reconnection should be fine if we're already connected.
+            unsafe { unwrap!(call_0(|ud, cb| app_reconnect(app, ud, cb))) };
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
+            assert_eq!(event, connected);
 
             unsafe { app_free(app) };
         }

--- a/safe_app/src/object_cache.rs
+++ b/safe_app/src/object_cache.rs
@@ -19,6 +19,7 @@
 //! across FFI boundaries.
 
 use super::errors::AppError;
+use AppContext;
 use ffi::cipher_opt::CipherOpt;
 use lru_cache::LruCache;
 use routing::{EntryAction, PermissionSet, User, Value};
@@ -84,8 +85,8 @@ pub struct ObjectCache {
     mdata_entry_actions: Store<BTreeMap<Vec<u8>, EntryAction>>,
     mdata_permissions: Store<BTreeMap<User, MDataPermissionSetHandle>>,
     mdata_permission_set: Store<PermissionSet>,
-    se_reader: Store<SelfEncryptor<SelfEncryptionStorage>>,
-    se_writer: Store<SequentialEncryptor<SelfEncryptionStorage>>,
+    se_reader: Store<SelfEncryptor<SelfEncryptionStorage<AppContext>>>,
+    se_writer: Store<SequentialEncryptor<SelfEncryptionStorage<AppContext>>>,
     sign_key: Store<sign::PublicKey>,
 }
 
@@ -229,14 +230,14 @@ impl_cache!(mdata_permission_set,
             insert_mdata_permission_set,
             remove_mdata_permission_set);
 impl_cache!(se_reader,
-            SelfEncryptor<SelfEncryptionStorage>,
+            SelfEncryptor<SelfEncryptionStorage<AppContext>>,
             SelfEncryptorReaderHandle,
             InvalidSelfEncryptorHandle,
             get_se_reader,
             insert_se_reader,
             remove_se_reader);
 impl_cache!(se_writer,
-            SequentialEncryptor<SelfEncryptionStorage>,
+            SequentialEncryptor<SelfEncryptionStorage<AppContext>>,
             SelfEncryptorWriterHandle,
             InvalidSelfEncryptorHandle,
             get_se_writer,

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -39,7 +39,7 @@ pub fn gen_app_exchange_info() -> AppExchangeInfo {
 /// Run the given closure inside the app's event loop. The return value of
 /// the closure is returned immediately.
 pub fn run_now<F, R>(app: &App, f: F) -> R
-    where F: FnOnce(&Client, &AppContext) -> R + Send + 'static,
+    where F: FnOnce(&Client<AppContext>, &AppContext) -> R + Send + 'static,
           R: Send + 'static
 {
     let (tx, rx) = mpsc::channel();
@@ -56,7 +56,7 @@ pub fn run_now<F, R>(app: &App, f: F) -> R
 /// return a future which will then be driven to completion and its result
 /// returned.
 pub fn run<F, I, T>(app: &App, f: F) -> T
-    where F: FnOnce(&Client, &AppContext) -> I + Send + 'static,
+    where F: FnOnce(&Client<AppContext>, &AppContext) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = AppError> + 'static,
           T: Send + 'static
 {

--- a/safe_authenticator/src/access_container.rs
+++ b/safe_authenticator/src/access_container.rs
@@ -26,7 +26,9 @@ use safe_core::ipc::resp::access_container_enc_key;
 use safe_core::utils::{symmetric_decrypt, symmetric_encrypt};
 
 /// Retrieves the authenticator configuration file
-pub fn access_container(client: &Client) -> Box<AuthFuture<MDataInfo>> {
+pub fn access_container<T>(client: &Client<T>) -> Box<AuthFuture<MDataInfo>>
+    where T: 'static
+{
     let parent = fry!(client.config_root_dir());
     let key = fry!(parent.enc_entry_key(b"access-container"));
 
@@ -52,11 +54,13 @@ pub fn access_container_nonce(access_container: &MDataInfo)
 }
 
 /// Gets an access container entry
-pub fn access_container_entry(client: &Client,
-                              access_container: &MDataInfo,
-                              app_id: &str,
-                              app_keys: AppKeys)
-                              -> Box<AuthFuture<(u64, Option<AccessContainerEntry>)>> {
+pub fn access_container_entry<T>(client: &Client<T>,
+                                 access_container: &MDataInfo,
+                                 app_id: &str,
+                                 app_keys: AppKeys)
+                                 -> Box<AuthFuture<(u64, Option<AccessContainerEntry>)>>
+    where T: 'static
+{
     let nonce = fry!(access_container_nonce(access_container));
     let key = fry!(access_container_enc_key(app_id, &app_keys.enc_key, nonce));
 
@@ -77,13 +81,15 @@ pub fn access_container_entry(client: &Client,
 }
 
 /// Adds a new entry to the authenticator access container
-pub fn put_access_container_entry(client: &Client,
-                                  access_container: &MDataInfo,
-                                  app_id: &str,
-                                  app_keys: &AppKeys,
-                                  permissions: &AccessContainerEntry,
-                                  version: Option<u64>)
-                                  -> Box<AuthFuture<()>> {
+pub fn put_access_container_entry<T>(client: &Client<T>,
+                                     access_container: &MDataInfo,
+                                     app_id: &str,
+                                     app_keys: &AppKeys,
+                                     permissions: &AccessContainerEntry,
+                                     version: Option<u64>)
+                                     -> Box<AuthFuture<()>>
+    where T: 'static
+{
     let nonce = fry!(access_container_nonce(access_container));
     let key = fry!(access_container_enc_key(app_id, &app_keys.enc_key, nonce));
     let plaintext = fry!(serialise(&permissions));

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -247,7 +247,12 @@ mod tests {
 
             let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
             assert_eq!(err_code, 0);
+            assert_eq!(event, disconnected);
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
             assert_eq!(event, connected);
+
 
             unsafe { authenticator_free(auth) };
         }

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -108,6 +108,30 @@ pub unsafe extern "C" fn login(account_locator: *const c_char,
     })
 }
 
+/// Try to restore a failed connection with the network.
+#[no_mangle]
+pub unsafe extern "C" fn auth_reconnect(auth: *mut Authenticator,
+                                        user_data: *mut c_void,
+                                        o_cb: extern "C" fn(*mut c_void, FfiResult)) {
+    let user_data = OpaqueCtx(user_data);
+    let res = (*auth).send(move |client| {
+                               try_cb!(client.restart_routing().map_err(AuthError::from),
+                                       user_data.0,
+                                       o_cb);
+                               o_cb(user_data.0, FFI_RESULT_OK);
+                               None
+                           });
+    if let Err(e) = res {
+        let e = AuthError::from(e);
+        let (error_code, description) = ffi_error!(e);
+        o_cb(user_data.0,
+             FfiResult {
+                 error_code,
+                 description: description.as_ptr(),
+             });
+    }
+}
+
 /// Discard and clean up the previously allocated authenticator instance.
 /// Use this only if the authenticator is obtained from one of the auth
 /// functions in this crate (`create_acc`, `login`, `create_unregistered`).
@@ -171,6 +195,7 @@ mod tests {
     #[cfg(all(test, feature = "use-mock-routing"))]
     #[test]
     fn network_status_callback() {
+        use ffi_utils::test_utils::call_0;
         use ffi_utils::test_utils::{send_via_user_data, sender_as_user_data};
         use safe_core::NetworkEvent;
         use std::time::Duration;
@@ -207,6 +232,22 @@ mod tests {
 
             let disconnected: i32 = NetworkEvent::Disconnected.into();
             assert_eq!(event, disconnected);
+
+            // Reconnect with the network
+            unsafe { unwrap!(call_0(|ud, cb| auth_reconnect(auth, ud, cb))) };
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
+
+            let connected: i32 = NetworkEvent::Connected.into();
+            assert_eq!(event, connected);
+
+            // The reconnection should be fine if we're already connected.
+            unsafe { unwrap!(call_0(|ud, cb| auth_reconnect(auth, ud, cb))) };
+
+            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            assert_eq!(err_code, 0);
+            assert_eq!(event, connected);
 
             unsafe { authenticator_free(auth) };
         }

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -117,7 +117,7 @@ pub struct Authenticator {
 impl Authenticator {
     /// Send a message to the authenticator event loop
     pub fn send<F>(&self, f: F) -> Result<(), AuthError>
-        where F: FnOnce(&Client) -> Option<Box<Future<Item = (), Error = ()>>> + Send + 'static
+        where F: FnOnce(&Client<()>) -> Option<Box<Future<Item = (), Error = ()>>> + Send + 'static
     {
         let msg = CoreMsg::new(|client, _| f(client));
         let core_tx = unwrap!(self.core_tx.lock());

--- a/safe_authenticator/src/public_id.rs
+++ b/safe_authenticator/src/public_id.rs
@@ -28,7 +28,9 @@ const PUBLIC_ID_USER_ROOT_ENTRY_KEY: &'static [u8] = b"_publicId";
 const PUBLIC_ID_CONFIG_ROOT_ENTRY_KEY: &'static [u8] = b"public-id";
 
 /// Create mutable data for Public ID.
-pub fn create<T: Into<String>>(client: &Client, public_id: T) -> Box<AuthFuture<()>> {
+pub fn create<S: Into<String>, T: 'static>(client: &Client<T>,
+                                           public_id: S)
+                                           -> Box<AuthFuture<()>> {
     // TODO: This could be optimized by executing the operations in parallel.
     // The operations to parallelise are:
     //     1. Insert the Public ID mdata info into the user root.
@@ -119,7 +121,7 @@ pub fn create<T: Into<String>>(client: &Client, public_id: T) -> Box<AuthFuture<
 }
 
 /// Retrieve the Public ID string.
-pub fn get(client: &Client) -> Box<AuthFuture<String>> {
+pub fn get<T: 'static>(client: &Client<T>) -> Box<AuthFuture<String>> {
     let client = client.clone();
 
     client

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -98,7 +98,7 @@ pub fn register_app(authenticator: &Authenticator,
 /// should return a future which will then be driven to completion and its result
 /// returned.
 pub fn try_run<F, I, T>(authenticator: &Authenticator, f: F) -> Result<T, AuthError>
-    where F: FnOnce(&Client) -> I + Send + 'static,
+    where F: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = AuthError> + 'static,
           T: Send + 'static
 {
@@ -121,7 +121,7 @@ pub fn try_run<F, I, T>(authenticator: &Authenticator, f: F) -> Result<T, AuthEr
 
 /// Like `try_run`, but expects success.
 pub fn run<F, I, T>(authenticator: &Authenticator, f: F) -> T
-    where F: FnOnce(&Client) -> I + Send + 'static,
+    where F: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = AuthError> + 'static,
           T: Send + 'static
 {

--- a/safe_core/examples/gen_invites.rs
+++ b/safe_core/examples/gen_invites.rs
@@ -107,7 +107,7 @@ fn main() {
     }
 
     if args.flag_get_pk {
-        let sign_pk = unwrap!(Client::sign_pk_from_seed(&seed));
+        let sign_pk = unwrap!(Client::<()>::sign_pk_from_seed(&seed));
         return println!("Public Signing Key: {:?}", sign_pk.0);
     }
 

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -955,3 +955,9 @@ impl Routing {
         self.full_id.public_id().signing_public_key()
     }
 }
+
+impl Drop for Routing {
+    fn drop(&mut self) {
+        let _ = self.sender.send(Event::Terminate);
+    }
+}

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -449,8 +449,6 @@ impl<T: 'static> Client<T> {
 
         let (routing, routing_rx) = setup_routing(opt_id, self.inner().client_type.config())?;
 
-        self.inner().net_tx.send(NetworkEvent::Connected)?;
-
         let joiner = spawn_routing_thread(routing_rx,
                                           self.inner().core_tx.clone(),
                                           self.inner().net_tx.clone());
@@ -458,6 +456,8 @@ impl<T: 'static> Client<T> {
         self.inner_mut().hooks.clear();
         self.inner_mut().routing = routing;
         self.inner_mut().joiner = joiner;
+
+        self.inner().net_tx.send(NetworkEvent::Connected)?;
 
         Ok(())
     }

--- a/safe_core/src/errors.rs
+++ b/safe_core/src/errors.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use futures::sync::mpsc::SendError;
 use maidsafe_utilities::serialisation::SerialisationError;
 use routing::{ClientError, InterfaceError, RoutingError};
 use routing::messaging;
@@ -72,6 +73,18 @@ pub enum CoreError {
 impl<'a> From<&'a str> for CoreError {
     fn from(error: &'a str) -> CoreError {
         CoreError::Unexpected(error.to_string())
+    }
+}
+
+impl From<String> for CoreError {
+    fn from(error: String) -> CoreError {
+        CoreError::Unexpected(error)
+    }
+}
+
+impl<T> From<SendError<T>> for CoreError {
+    fn from(error: SendError<T>) -> CoreError {
+        CoreError::from(format!("Couldn't send message to the channel: {}", error))
     }
 }
 

--- a/safe_core/src/event_loop.rs
+++ b/safe_core/src/event_loop.rs
@@ -29,7 +29,7 @@ pub type CoreMsgRx<T> = mpsc::UnboundedReceiver<CoreMsg<T>>;
 
 /// The final future which the event loop will run.
 pub type TailFuture = Box<Future<Item = (), Error = ()>>;
-type TailFutureFn<T> = FnMut(&Client, &T) -> Option<TailFuture> + Send + 'static;
+type TailFutureFn<T> = FnMut(&Client<T>, &T) -> Option<TailFuture> + Send + 'static;
 
 /// The message format that core event loop understands.
 pub struct CoreMsg<T>(Option<Box<TailFutureFn<T>>>);
@@ -42,7 +42,7 @@ impl<T> CoreMsg<T> {
     /// return value of the given closure is optionally a future, it will be
     /// registered in the event loop.
     pub fn new<F>(f: F) -> Self
-        where F: FnOnce(&Client, &T) -> Option<TailFuture> + Send + 'static
+        where F: FnOnce(&Client<T>, &T) -> Option<TailFuture> + Send + 'static
     {
         let mut f = Some(f);
         CoreMsg(Some(Box::new(move |client, context| -> Option<TailFuture> {
@@ -60,7 +60,7 @@ impl<T> CoreMsg<T> {
 
 /// Run the core event loop. This will block until the event loop is alive.
 /// Hence must typically be called inside a spawned thread.
-pub fn run<T>(mut el: Core, client: &Client, context: &T, el_rx: CoreMsgRx<T>) {
+pub fn run<T>(mut el: Core, client: &Client<T>, context: &T, el_rx: CoreMsgRx<T>) {
     let el_h = el.handle();
 
     let keep_alive = el_rx.for_each(|core_msg| {

--- a/safe_core/src/immutable_data.rs
+++ b/safe_core/src/immutable_data.rs
@@ -34,10 +34,10 @@ enum DataTypeEncoding {
 /// Create and obtain immutable data out of the given raw bytes. The API will
 /// encrypt the right content if the keys are provided and will ensure the
 /// maximum immutable data chunk size is respected.
-pub fn create(client: &Client,
-              value: &[u8],
-              encryption_key: Option<secretbox::Key>)
-              -> Box<CoreFuture<ImmutableData>> {
+pub fn create<T: 'static>(client: &Client<T>,
+                          value: &[u8],
+                          encryption_key: Option<secretbox::Key>)
+                          -> Box<CoreFuture<ImmutableData>> {
     trace!("Creating conformant ImmutableData.");
 
     let client = client.clone();
@@ -65,10 +65,10 @@ pub fn create(client: &Client,
 
 /// Get the raw bytes from `ImmutableData` created via `create()` function in
 /// this module.
-pub fn extract_value(client: &Client,
-                     data: &ImmutableData,
-                     decryption_key: Option<secretbox::Key>)
-                     -> Box<CoreFuture<Vec<u8>>> {
+pub fn extract_value<T: 'static>(client: &Client<T>,
+                                 data: &ImmutableData,
+                                 decryption_key: Option<secretbox::Key>)
+                                 -> Box<CoreFuture<Vec<u8>>> {
     let client = client.clone();
 
     unpack(client.clone(), data)
@@ -93,10 +93,10 @@ pub fn extract_value(client: &Client,
 /// Get immutable data from the network and extract its value, decrypting it in
 /// the process (if keys provided).  This is a convenience function combining
 /// `get` and `extract_value` into one function.
-pub fn get_value(client: &Client,
-                 name: &XorName,
-                 decryption_key: Option<secretbox::Key>)
-                 -> Box<CoreFuture<Vec<u8>>> {
+pub fn get_value<T: 'static>(client: &Client<T>,
+                             name: &XorName,
+                             decryption_key: Option<secretbox::Key>)
+                             -> Box<CoreFuture<Vec<u8>>> {
     let client2 = client.clone();
     client
         .get_idata(*name)
@@ -106,7 +106,7 @@ pub fn get_value(client: &Client,
 
 // TODO: consider rewriting these two function to not use recursion.
 
-fn pack(client: Client, value: Vec<u8>) -> Box<CoreFuture<ImmutableData>> {
+fn pack<T: 'static>(client: Client<T>, value: Vec<u8>) -> Box<CoreFuture<ImmutableData>> {
     let data = ImmutableData::new(value);
     let serialised_data = fry!(serialise(&data));
 
@@ -127,7 +127,7 @@ fn pack(client: Client, value: Vec<u8>) -> Box<CoreFuture<ImmutableData>> {
     }
 }
 
-fn unpack(client: Client, data: &ImmutableData) -> Box<CoreFuture<Vec<u8>>> {
+fn unpack<T: 'static>(client: Client<T>, data: &ImmutableData) -> Box<CoreFuture<Vec<u8>>> {
     match fry!(deserialise(data.value())) {
         DataTypeEncoding::Serialised(value) => ok!(value),
         DataTypeEncoding::DataMap(data_map) => {

--- a/safe_core/src/nfs/data_map.rs
+++ b/safe_core/src/nfs/data_map.rs
@@ -27,7 +27,7 @@ use self_encryption::DataMap;
 use utils::FutureExt;
 
 // GET `DataMap` from the network.
-pub fn get(client: &Client, name: &XorName) -> Box<NfsFuture<DataMap>> {
+pub fn get<T: 'static>(client: &Client<T>, name: &XorName) -> Box<NfsFuture<DataMap>> {
     immutable_data::get_value(client, name, None)
         .map_err(From::from)
         .and_then(move |content| deserialise(&content).map_err(From::from))
@@ -35,7 +35,7 @@ pub fn get(client: &Client, name: &XorName) -> Box<NfsFuture<DataMap>> {
 }
 
 // PUT `DataMap` on the network.
-pub fn put(client: &Client, data_map: &DataMap) -> Box<NfsFuture<XorName>> {
+pub fn put<T: 'static>(client: &Client<T>, data_map: &DataMap) -> Box<NfsFuture<XorName>> {
     let client = client.clone();
     let client2 = client.clone();
 

--- a/safe_core/src/nfs/dir.rs
+++ b/safe_core/src/nfs/dir.rs
@@ -25,7 +25,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use utils::FutureExt;
 
 /// create a new directory emulation
-pub fn create_dir(client: &Client, is_public: bool) -> Box<NfsFuture<MDataInfo>> {
+pub fn create_dir<T: 'static>(client: &Client<T>, is_public: bool) -> Box<NfsFuture<MDataInfo>> {
     match client.owner_key() {
         Ok(pub_key) => {
             let dir = if is_public {

--- a/safe_core/src/nfs/reader.rs
+++ b/safe_core/src/nfs/reader.rs
@@ -25,17 +25,17 @@ use utils::FutureExt;
 /// Reader is used to read contents of a File. It can read in chunks if the
 /// file happens to be very large
 #[allow(dead_code)]
-pub struct Reader {
-    client: Client,
-    self_encryptor: SelfEncryptor<SelfEncryptionStorage>,
+pub struct Reader<T> {
+    client: Client<T>,
+    self_encryptor: SelfEncryptor<SelfEncryptionStorage<T>>,
 }
 
-impl Reader {
+impl<T: 'static> Reader<T> {
     /// Create a new instance of Reader
-    pub fn new(client: Client,
-               storage: SelfEncryptionStorage,
+    pub fn new(client: Client<T>,
+               storage: SelfEncryptionStorage<T>,
                file: &File)
-               -> Box<NfsFuture<Reader>> {
+               -> Box<NfsFuture<Reader<T>>> {
         data_map::get(&client, file.data_map_name())
             .and_then(move |data_map| {
                           let self_encryptor = SelfEncryptor::new(storage, data_map)?;

--- a/safe_core/src/nfs/std_dirs.rs
+++ b/safe_core/src/nfs/std_dirs.rs
@@ -28,7 +28,7 @@ use utils::FutureExt;
 /// A registration helper function to create the set of default dirs
 /// in the users root directory.
 /// Note: It does not check whether those might exits already.
-pub fn create_std_dirs(client: Client) -> Box<NfsFuture<()>> {
+pub fn create_std_dirs<T: 'static>(client: Client<T>) -> Box<NfsFuture<()>> {
     let root_dir = fry!(client.user_root_dir());
     let mut creations = vec![];
     for _ in DEFAULT_PRIVATE_DIRS.iter() {

--- a/safe_core/src/nfs/writer.rs
+++ b/safe_core/src/nfs/writer.rs
@@ -35,25 +35,25 @@ pub enum Mode {
 
 /// Writer is used to write contents to a File and especially in chunks if the
 /// file happens to be too large
-pub struct Writer {
-    client: Client,
+pub struct Writer<T> {
+    client: Client<T>,
     file: File,
     parent: MDataInfo,
     file_name: String,
-    self_encryptor: SequentialEncryptor<SelfEncryptionStorage>,
+    self_encryptor: SequentialEncryptor<SelfEncryptionStorage<T>>,
     version: Option<u64>,
 }
 
-impl Writer {
+impl<T: 'static> Writer<T> {
     /// Create new instance of Writer
-    pub fn new(client: Client,
-               storage: SelfEncryptionStorage,
+    pub fn new(client: Client<T>,
+               storage: SelfEncryptionStorage<T>,
                mode: Mode,
                parent: MDataInfo,
                file: File,
                file_name: String,
                version: Option<u64>)
-               -> Box<NfsFuture<Writer>> {
+               -> Box<NfsFuture<Writer<T>>> {
         let fut = match mode {
             Mode::Modify => {
                 data_map::get(&client, file.data_map_name())

--- a/safe_core/src/self_encryption_storage.rs
+++ b/safe_core/src/self_encryption_storage.rs
@@ -24,18 +24,18 @@ use std::fmt::{self, Display, Formatter};
 
 /// Network storage is the concrete type which self-encryption crate will use
 /// to put or get data from the network
-pub struct SelfEncryptionStorage {
-    client: Client,
+pub struct SelfEncryptionStorage<T> {
+    client: Client<T>,
 }
 
-impl SelfEncryptionStorage {
+impl<T> SelfEncryptionStorage<T> {
     /// Create a new SelfEncryptionStorage instance
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client<T>) -> Self {
         SelfEncryptionStorage { client: client }
     }
 }
 
-impl Storage for SelfEncryptionStorage {
+impl<T: 'static> Storage for SelfEncryptionStorage<T> {
     type Error = SelfEncryptionStorageError;
 
     fn get(&self, name: &[u8]) -> Box<Future<Item = Vec<u8>, Error = Self::Error>> {

--- a/safe_core/src/utils/test_utils.rs
+++ b/safe_core/src/utils/test_utils.rs
@@ -56,7 +56,7 @@ pub fn get_max_sized_secret_keys(len: usize) -> Vec<sign::SecretKey> {
 /// Create random registered client and run it inside an event loop. Use this to
 /// create Client automatically and randomly,
 pub fn random_client<Run, I, T, E>(r: Run) -> T
-    where Run: FnOnce(&Client) -> I + Send + 'static,
+    where Run: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = E> + 'static,
           T: Send + 'static,
           E: Debug
@@ -69,7 +69,7 @@ pub fn random_client<Run, I, T, E>(r: Run) -> T
 /// create Client automatically and randomly,
 pub fn random_client_with_net_obs<NetObs, Run, I, T, E>(n: NetObs, r: Run) -> T
     where NetObs: FnMut(NetworkEvent) + 'static,
-          Run: FnOnce(&Client) -> I + Send + 'static,
+          Run: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = E> + 'static,
           T: Send + 'static,
           E: Debug
@@ -93,8 +93,8 @@ pub fn random_client_with_net_obs<NetObs, Run, I, T, E>(n: NetObs, r: Run) -> T
 /// unregistered or as a result of successful login. Use this to create Client
 /// manually,
 pub fn setup_client<Create, Run, I, T, E>(c: Create, r: Run) -> T
-    where Create: FnOnce(Handle, CoreMsgTx<()>, NetworkTx) -> Result<Client, CoreError>,
-          Run: FnOnce(&Client) -> I + Send + 'static,
+    where Create: FnOnce(Handle, CoreMsgTx<()>, NetworkTx) -> Result<Client<()>, CoreError>,
+          Run: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = E> + 'static,
           T: Send + 'static,
           E: Debug
@@ -111,9 +111,9 @@ pub fn setup_client_with_net_obs<Create, NetObs, Run, I, T, E>(c: Create,
                                                                mut n: NetObs,
                                                                r: Run)
                                                                -> T
-    where Create: FnOnce(Handle, CoreMsgTx<()>, NetworkTx) -> Result<Client, CoreError>,
+    where Create: FnOnce(Handle, CoreMsgTx<()>, NetworkTx) -> Result<Client<()>, CoreError>,
           NetObs: FnMut(NetworkEvent) + 'static,
-          Run: FnOnce(&Client) -> I + Send + 'static,
+          Run: FnOnce(&Client<()>) -> I + Send + 'static,
           I: IntoFuture<Item = T, Error = E> + 'static,
           T: Send + 'static,
           E: Debug


### PR DESCRIPTION
Now when the network connection is failed, we do not reconnect to the network automatically - it should be done by a user. For this purpose several new FFI functions have been added - `app_reconnect` and `auth_reconnect`.

Because of this change we have to store `core_tx` channel with the client. That means that `Client` now has to accept a type parameter for the message context - so all `Client` signatures have been changed to `Client<T>`.