### PR TITLE
refactor/safe-app: Create type definitions for arrays that are FFI input params

### DIFF
--- a/safe_app/README.md
+++ b/safe_app/README.md
@@ -14,7 +14,7 @@ This is the crate for interfacing with application frontends. It contains code f
 To use it with the Mock:
 ```
 cargo build --features "use-mock-routing"
-cargo test --features "use-mock-routing"
+cargo test --features "use-mock-routing testing"
 ```
 
 To interface it with actual routing (default):

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -27,9 +27,12 @@ use std::ptr;
 use std::slice;
 use tiny_keccak::sha3_256;
 
-type SecKey = [u8; box_::SECRETKEYBYTES];
-type PubKey = [u8; box_::PUBLICKEYBYTES];
-type Nonce = [u8; box_::NONCEBYTES];
+/// Private Key bytes array
+pub type SecKey = [u8; box_::SECRETKEYBYTES];
+/// Public Key bytes array
+pub type PubKey = [u8; box_::PUBLICKEYBYTES];
+/// Nonce bytes
+pub type Nonce = [u8; box_::NONCEBYTES];
 
 /// Get the public signing key of the app.
 #[no_mangle]

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -30,7 +30,7 @@ use std::ptr;
 
 type SEWriterHandle = SelfEncryptorWriterHandle;
 type SEReaderHandle = SelfEncryptorReaderHandle;
-type XorNamePtr = *const [u8; XOR_NAME_LEN];
+type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Get a Self Encryptor
 #[no_mangle]
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn idata_close_self_encryptor(app: *const App,
                                                     user_data: *mut c_void,
                                                     o_cb: extern "C" fn(*mut c_void,
                                                                         FfiResult,
-                                                                        XorNamePtr)) {
+                                                                        *const XorNameArray)) {
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn idata_close_self_encryptor(app: *const App,
 /// Fetch Self Encryptor
 #[no_mangle]
 pub unsafe extern "C" fn idata_fetch_self_encryptor(app: *const App,
-                                                    name: XorNamePtr,
+                                                    name: *const XorNameArray,
                                                     user_data: *mut c_void,
                                                     o_cb: extern "C" fn(*mut c_void,
                                                                         FfiResult,
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn idata_fetch_self_encryptor(app: *const App,
 /// Get serialised size of `ImmutableData`
 #[no_mangle]
 pub unsafe extern "C" fn idata_serialised_size(app: *const App,
-                                               name: XorNamePtr,
+                                               name: *const XorNameArray,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void, FfiResult, u64)) {
     let user_data = OpaqueCtx(user_data);

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -28,9 +28,12 @@ use self_encryption::{SelfEncryptor, SequentialEncryptor};
 use std::os::raw::c_void;
 use std::ptr;
 
-type SEWriterHandle = SelfEncryptorWriterHandle;
-type SEReaderHandle = SelfEncryptorReaderHandle;
-type XorNameArray = [u8; XOR_NAME_LEN];
+/// Handle of a Self Encryptor Writer object
+pub type SEWriterHandle = SelfEncryptorWriterHandle;
+/// Handle of a Self Encryptor Reader object
+pub type SEReaderHandle = SelfEncryptorReaderHandle;
+/// XoR Name bytes
+pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Get a Self Encryptor
 #[no_mangle]

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -32,7 +32,7 @@ use std::ptr;
 pub type SEWriterHandle = SelfEncryptorWriterHandle;
 /// Handle of a Self Encryptor Reader object
 pub type SEReaderHandle = SelfEncryptorReaderHandle;
-/// XoR Name bytes
+/// Xor Name bytes
 pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Get a Self Encryptor

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -28,9 +28,12 @@ use safe_core::MDataInfo;
 use std::os::raw::c_void;
 use std::slice;
 
-type SecretKey = [u8; secretbox::KEYBYTES];
-type Nonce = [u8; secretbox::NONCEBYTES];
-type XorNameArray = [u8; XOR_NAME_LEN];
+/// Array containing private key bytes
+pub type SecretKey = [u8; secretbox::KEYBYTES];
+/// Array containing nonce bytes
+pub type Nonce = [u8; secretbox::NONCEBYTES];
+/// XoR Name bytes
+pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Create non-encrypted mdata info with explicit data name.
 #[no_mangle]
@@ -210,10 +213,11 @@ pub unsafe extern "C" fn mdata_info_decrypt(app: *const App,
 pub unsafe extern "C" fn mdata_info_extract_name_and_type_tag(app: *const App,
                                                               info_h: MDataInfoHandle,
                                                               user_data: *mut c_void,
-                                                              o_cb: extern "C" fn(*mut c_void,
-                                                                                  FfiResult,
-                                                                                  *const XorNameArray,
-                                                                                  u64))
+                                                              o_cb: extern "C" fn(
+                                                                              *mut c_void,
+                                                                              FfiResult,
+                                                                              *const XorNameArray,
+                                                                              u64))
 {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -28,10 +28,14 @@ use safe_core::MDataInfo;
 use std::os::raw::c_void;
 use std::slice;
 
+type SecretKey = [u8; secretbox::KEYBYTES];
+type Nonce = [u8; secretbox::NONCEBYTES];
+type XorNameArray = [u8; XOR_NAME_LEN];
+
 /// Create non-encrypted mdata info with explicit data name.
 #[no_mangle]
 pub unsafe extern "C" fn mdata_info_new_public(app: *const App,
-                                               name: *const [u8; XOR_NAME_LEN],
+                                               name: *const XorNameArray,
                                                type_tag: u64,
                                                user_data: *mut c_void,
                                                o_cb: extern "C" fn(*mut c_void,
@@ -51,10 +55,10 @@ pub unsafe extern "C" fn mdata_info_new_public(app: *const App,
 /// provided private key.
 #[no_mangle]
 pub unsafe extern "C" fn mdata_info_new_private(app: *const App,
-                                                name: *const [u8; XOR_NAME_LEN],
+                                                name: *const XorNameArray,
                                                 type_tag: u64,
-                                                secret_key: *const [u8; secretbox::KEYBYTES],
-                                                nonce: *const [u8; secretbox::NONCEBYTES],
+                                                secret_key: *const SecretKey,
+                                                nonce: *const Nonce,
                                                 user_data: *mut c_void,
                                                 o_cb: extern "C" fn(*mut c_void,
                                                                     FfiResult,
@@ -208,8 +212,7 @@ pub unsafe extern "C" fn mdata_info_extract_name_and_type_tag(app: *const App,
                                                               user_data: *mut c_void,
                                                               o_cb: extern "C" fn(*mut c_void,
                                                                                   FfiResult,
-                                                                                  *const [u8;
-                                                                                   XOR_NAME_LEN],
+                                                                                  *const XorNameArray,
                                                                                   u64))
 {
     catch_unwind_cb(user_data, o_cb, || {

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -32,7 +32,7 @@ use std::slice;
 pub type SecretKey = [u8; secretbox::KEYBYTES];
 /// Array containing nonce bytes
 pub type Nonce = [u8; secretbox::NONCEBYTES];
-/// XoR Name bytes
+/// Xor Name bytes
 pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Create non-encrypted mdata info with explicit data name.


### PR DESCRIPTION
- Create type definitions for arrays that are input params of some FFI functions, keeping the type as part of the FFI functions declarations for more clarity.
- Minor correction to the README as to how to run the safe-app tests.