### PR TITLE
fix/mock-vault: increase mutations limit to conform with actual vaults

### DIFF
--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -23,7 +23,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::time::SystemTime;
 use tiny_keccak::sha3_256;
 
-pub const DEFAULT_MAX_MUTATIONS: u64 = 500;
+pub const DEFAULT_MAX_MUTATIONS: u64 = 1000;
 
 #[derive(Deserialize, Serialize)]
 pub struct Storage {


### PR DESCRIPTION
A number of limits for new accounts has been increased to 1000