### PR TITLE
New API in Authenticator to fetch a list of apps accessing arbitrary MD (MAID-2247)

### DIFF
--- a/safe_app/README.md
+++ b/safe_app/README.md
@@ -14,7 +14,7 @@ This is the crate for interfacing with application frontends. It contains code f
 To use it with the Mock:
 ```
 cargo build --features "use-mock-routing"
-cargo test --features "use-mock-routing"
+cargo test --features "use-mock-routing testing"
 ```
 
 To interface it with actual routing (default):

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -22,7 +22,7 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, catch_unwind_cb};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::{EncryptPubKeyHandle, EncryptSecKeyHandle, SignKeyHandle};
 use rust_sodium::crypto::{box_, sealedbox, sign};
-use safe_core::ffi::{AsymNonce, AsymSecretKey, PublicKey};
+use safe_core::ffi::{AsymNonce, AsymPublicKey, AsymSecretKey};
 use std::os::raw::c_void;
 use std::slice;
 use tiny_keccak::sha3_256;
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn app_pub_sign_key(
 #[no_mangle]
 pub unsafe extern "C" fn sign_key_new(
     app: *const App,
-    data: *const PublicKey,
+    data: *const AsymPublicKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, SignKeyHandle),
 ) {
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn sign_key_get(
     app: *const App,
     handle: SignKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PublicKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymPublicKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn enc_generate_key_pair(
 #[no_mangle]
 pub unsafe extern "C" fn enc_pub_key_new(
     app: *const App,
-    data: *const PublicKey,
+    data: *const AsymPublicKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, EncryptPubKeyHandle),
 ) {
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn enc_pub_key_get(
     app: *const App,
     handle: EncryptPubKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PublicKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymPublicKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -423,7 +423,7 @@ mod tests {
     use super::*;
     use ffi_utils::test_utils::{call_1, call_2, call_vec_u8};
     use rust_sodium::crypto::box_;
-    use safe_core::ffi::{AsymNonce, PublicKey, SignPublicKey};
+    use safe_core::ffi::{AsymNonce, AsymPublicKey, SignPublicKey};
     use test_utils::{create_app, run_now};
 
     #[test]
@@ -438,9 +438,9 @@ mod tests {
 
         // Copying app2 pubkey to app1 object cache
         // and app1 pubkey to app2 object cache
-        let pk2_raw: PublicKey =
+        let pk2_raw: AsymPublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
-        let pk1_raw: PublicKey =
+        let pk1_raw: AsymPublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app1, app1_pk1_h, ud, cb))) };
 
         let app1_pk2_h =
@@ -492,7 +492,7 @@ mod tests {
 
         // Copying app2 pubkey to app1 object cache
         // and app1 pubkey to app2 object cache
-        let pk2_raw: PublicKey =
+        let pk2_raw: AsymPublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
 
         let app1_pk2_h =
@@ -566,7 +566,7 @@ mod tests {
             app_enc_key1
         });
 
-        let app_enc_key1_raw: PublicKey = unsafe {
+        let app_enc_key1_raw: AsymPublicKey = unsafe {
             unwrap!(call_1(
                 |ud, cb| enc_pub_key_get(&app, app_enc_key1_h, ud, cb),
             ))

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -26,9 +26,12 @@ use std::os::raw::c_void;
 use std::slice;
 use tiny_keccak::sha3_256;
 
-type SecKey = [u8; box_::SECRETKEYBYTES];
-type PubKey = [u8; box_::PUBLICKEYBYTES];
-type Nonce = [u8; box_::NONCEBYTES];
+/// Private Key bytes array
+pub type SecKey = [u8; box_::SECRETKEYBYTES];
+/// Public Key bytes array
+pub type PubKey = [u8; box_::PUBLICKEYBYTES];
+/// Nonce bytes
+pub type Nonce = [u8; box_::NONCEBYTES];
 
 /// Get the public signing key of the app.
 #[no_mangle]

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -22,16 +22,10 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, catch_unwind_cb};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::{EncryptPubKeyHandle, EncryptSecKeyHandle, SignKeyHandle};
 use rust_sodium::crypto::{box_, sealedbox, sign};
+use safe_core::ffi::{AsymNonce, AsymSecretKey, PublicKey};
 use std::os::raw::c_void;
 use std::slice;
 use tiny_keccak::sha3_256;
-
-/// Private Key bytes array
-pub type SecKey = [u8; box_::SECRETKEYBYTES];
-/// Public Key bytes array
-pub type PubKey = [u8; box_::PUBLICKEYBYTES];
-/// Nonce bytes
-pub type Nonce = [u8; box_::NONCEBYTES];
 
 /// Get the public signing key of the app.
 #[no_mangle]
@@ -52,7 +46,7 @@ pub unsafe extern "C" fn app_pub_sign_key(
 #[no_mangle]
 pub unsafe extern "C" fn sign_key_new(
     app: *const App,
-    data: *const PubKey,
+    data: *const PublicKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, SignKeyHandle),
 ) {
@@ -70,7 +64,7 @@ pub unsafe extern "C" fn sign_key_get(
     app: *const App,
     handle: SignKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PubKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PublicKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -140,7 +134,7 @@ pub unsafe extern "C" fn enc_generate_key_pair(
 #[no_mangle]
 pub unsafe extern "C" fn enc_pub_key_new(
     app: *const App,
-    data: *const PubKey,
+    data: *const PublicKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, EncryptPubKeyHandle),
 ) {
@@ -158,7 +152,7 @@ pub unsafe extern "C" fn enc_pub_key_get(
     app: *const App,
     handle: EncryptPubKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PubKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const PublicKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -174,7 +168,7 @@ pub unsafe extern "C" fn enc_secret_key_get(
     app: *const App,
     handle: EncryptSecKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const SecKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymSecretKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -188,7 +182,7 @@ pub unsafe extern "C" fn enc_secret_key_get(
 #[no_mangle]
 pub unsafe extern "C" fn enc_secret_key_new(
     app: *const App,
-    data: *const SecKey,
+    data: *const AsymSecretKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, EncryptSecKeyHandle),
 ) {
@@ -414,7 +408,7 @@ pub unsafe extern "C" fn sha3_hash(
 #[no_mangle]
 pub unsafe extern "C" fn generate_nonce(
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const Nonce),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymNonce),
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
         let nonce = box_::gen_nonce();
@@ -428,7 +422,8 @@ pub unsafe extern "C" fn generate_nonce(
 mod tests {
     use super::*;
     use ffi_utils::test_utils::{call_1, call_2, call_vec_u8};
-    use rust_sodium::crypto::{box_, sign};
+    use rust_sodium::crypto::box_;
+    use safe_core::ffi::{AsymNonce, PublicKey, SignPublicKey};
     use test_utils::{create_app, run_now};
 
     #[test]
@@ -443,9 +438,9 @@ mod tests {
 
         // Copying app2 pubkey to app1 object cache
         // and app1 pubkey to app2 object cache
-        let pk2_raw: [u8; box_::PUBLICKEYBYTES] =
+        let pk2_raw: PublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
-        let pk1_raw: [u8; box_::PUBLICKEYBYTES] =
+        let pk1_raw: PublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app1, app1_pk1_h, ud, cb))) };
 
         let app1_pk2_h =
@@ -497,7 +492,7 @@ mod tests {
 
         // Copying app2 pubkey to app1 object cache
         // and app1 pubkey to app2 object cache
-        let pk2_raw: [u8; box_::PUBLICKEYBYTES] =
+        let pk2_raw: PublicKey =
             unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
 
         let app1_pk2_h =
@@ -542,7 +537,7 @@ mod tests {
             app_sign_key1
         });
 
-        let app_sign_key1_raw: [u8; sign::PUBLICKEYBYTES] =
+        let app_sign_key1_raw: SignPublicKey =
             unsafe { unwrap!(call_1(|ud, cb| sign_key_get(&app, app_sign_key1_h, ud, cb))) };
 
         let app_sign_key2_h = unsafe {
@@ -571,7 +566,7 @@ mod tests {
             app_enc_key1
         });
 
-        let app_enc_key1_raw: [u8; box_::PUBLICKEYBYTES] = unsafe {
+        let app_enc_key1_raw: PublicKey = unsafe {
             unwrap!(call_1(
                 |ud, cb| enc_pub_key_get(&app, app_enc_key1_h, ud, cb),
             ))
@@ -592,8 +587,7 @@ mod tests {
 
     #[test]
     fn nonce_smoke_test() {
-        let nonce: [u8; box_::NONCEBYTES] =
-            unsafe { unwrap!(call_1(|ud, cb| generate_nonce(ud, cb))) };
+        let nonce: AsymNonce = unsafe { unwrap!(call_1(|ud, cb| generate_nonce(ud, cb))) };
         assert_eq!(nonce.len(), box_::NONCEBYTES);
     }
 }

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -27,9 +27,12 @@ use safe_core::{FutureExt, SelfEncryptionStorage, immutable_data};
 use self_encryption::{SelfEncryptor, SequentialEncryptor};
 use std::os::raw::c_void;
 
-type SEWriterHandle = SelfEncryptorWriterHandle;
-type SEReaderHandle = SelfEncryptorReaderHandle;
-type XorNamePtr = *const [u8; XOR_NAME_LEN];
+/// Handle of a Self Encryptor Writer object
+pub type SEWriterHandle = SelfEncryptorWriterHandle;
+/// Handle of a Self Encryptor Reader object
+pub type SEReaderHandle = SelfEncryptorReaderHandle;
+/// Xor Name bytes
+pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Get a Self Encryptor
 #[no_mangle]
@@ -104,7 +107,7 @@ pub unsafe extern "C" fn idata_close_self_encryptor(
     se_h: SEWriterHandle,
     cipher_opt_h: CipherOptHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, XorNamePtr),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const XorNameArray),
 ) {
     let user_data = OpaqueCtx(user_data);
 
@@ -161,7 +164,7 @@ pub unsafe extern "C" fn idata_close_self_encryptor(
 #[no_mangle]
 pub unsafe extern "C" fn idata_fetch_self_encryptor(
     app: *const App,
-    name: XorNamePtr,
+    name: *const XorNameArray,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, SEReaderHandle),
 ) {
@@ -204,7 +207,7 @@ pub unsafe extern "C" fn idata_fetch_self_encryptor(
 #[no_mangle]
 pub unsafe extern "C" fn idata_serialised_size(
     app: *const App,
-    name: XorNamePtr,
+    name: *const XorNameArray,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, u64),
 ) {

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -22,8 +22,9 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, catch_unwind_cb, vec_clone_
 use futures::Future;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::{CipherOptHandle, SelfEncryptorReaderHandle, SelfEncryptorWriterHandle};
-use routing::{XOR_NAME_LEN, XorName};
+use routing::XorName;
 use safe_core::{FutureExt, SelfEncryptionStorage, immutable_data};
+use safe_core::ffi::XorNameArray;
 use self_encryption::{SelfEncryptor, SequentialEncryptor};
 use std::os::raw::c_void;
 
@@ -31,8 +32,6 @@ use std::os::raw::c_void;
 pub type SEWriterHandle = SelfEncryptorWriterHandle;
 /// Handle of a Self Encryptor Reader object
 pub type SEReaderHandle = SelfEncryptorReaderHandle;
-/// Xor Name bytes
-pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Get a Self Encryptor
 #[no_mangle]

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -28,11 +28,18 @@ use safe_core::MDataInfo;
 use std::os::raw::c_void;
 use std::slice;
 
+/// Array containing private key bytes
+pub type SecretKey = [u8; secretbox::KEYBYTES];
+/// Array containing nonce bytes
+pub type Nonce = [u8; secretbox::NONCEBYTES];
+/// Xor Name bytes
+pub type XorNameArray = [u8; XOR_NAME_LEN];
+
 /// Create non-encrypted mdata info with explicit data name.
 #[no_mangle]
 pub unsafe extern "C" fn mdata_info_new_public(
     app: *const App,
-    name: *const [u8; XOR_NAME_LEN],
+    name: *const XorNameArray,
     type_tag: u64,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, MDataInfoHandle),
@@ -52,10 +59,10 @@ pub unsafe extern "C" fn mdata_info_new_public(
 #[no_mangle]
 pub unsafe extern "C" fn mdata_info_new_private(
     app: *const App,
-    name: *const [u8; XOR_NAME_LEN],
+    name: *const XorNameArray,
     type_tag: u64,
-    secret_key: *const [u8; secretbox::KEYBYTES],
-    nonce: *const [u8; secretbox::NONCEBYTES],
+    secret_key: *const SecretKey,
+    nonce: *const Nonce,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, MDataInfoHandle),
 ) {
@@ -218,7 +225,7 @@ pub unsafe extern "C" fn mdata_info_extract_name_and_type_tag(
     app: *const App,
     info_h: MDataInfoHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const [u8; XOR_NAME_LEN], u64),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const XorNameArray, u64),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -22,18 +22,12 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, SafePtr, catch_unwind_cb,
                 vec_clone_from_raw_parts};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::MDataInfoHandle;
-use routing::{XOR_NAME_LEN, XorName};
+use routing::XorName;
 use rust_sodium::crypto::secretbox;
 use safe_core::MDataInfo;
+use safe_core::ffi::{SymNonce, SymSecretKey, XorNameArray};
 use std::os::raw::c_void;
 use std::slice;
-
-/// Array containing private key bytes
-pub type SecretKey = [u8; secretbox::KEYBYTES];
-/// Array containing nonce bytes
-pub type Nonce = [u8; secretbox::NONCEBYTES];
-/// Xor Name bytes
-pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Create non-encrypted mdata info with explicit data name.
 #[no_mangle]
@@ -61,8 +55,8 @@ pub unsafe extern "C" fn mdata_info_new_private(
     app: *const App,
     name: *const XorNameArray,
     type_tag: u64,
-    secret_key: *const SecretKey,
-    nonce: *const Nonce,
+    secret_key: *const SymSecretKey,
+    nonce: *const SymNonce,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, MDataInfoHandle),
 ) {

--- a/safe_app/src/ffi/mutable_data/metadata.rs
+++ b/safe_app/src/ffi/mutable_data/metadata.rs
@@ -26,7 +26,7 @@ use std::os::raw::c_void;
 /// Serialize metadata.
 #[no_mangle]
 pub unsafe extern "C" fn mdata_encode_metadata(
-    metadata: *const ffi::UserMetadata,
+    metadata: *const ffi::MetadataResponse,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, *const u8, usize),
 ) {

--- a/safe_authenticator/src/tests.rs
+++ b/safe_authenticator/src/tests.rs
@@ -43,7 +43,7 @@ use safe_core::ipc::req::ffi::AuthReq as FfiAuthReq;
 use safe_core::ipc::req::ffi::ContainersReq as FfiContainersReq;
 use safe_core::ipc::req::ffi::ShareMDataReq as FfiShareMDataReq;
 use safe_core::ipc::resp::{METADATA_KEY, UserMetadata};
-use safe_core::ipc::resp::ffi::UserMetadata as FfiUserMetadata;
+use safe_core::ipc::resp::ffi::MetadataResponse as FfiUserMetadata;
 use safe_core::nfs::{File, Mode, NfsError, file_helper};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::{CStr, CString};
@@ -1544,8 +1544,8 @@ fn share_some_mdatas_with_valid_metadata() {
     let mut metadatas = Vec::new();
     for i in 0..NUM_MDATAS {
         let metadata = UserMetadata {
-            name: format!("name {}", i),
-            description: format!("description {}", i),
+            name: Some(format!("name {}", i)),
+            description: Some(format!("description {}", i)),
         };
 
         let name = rand::random();

--- a/safe_core/src/ffi.rs
+++ b/safe_core/src/ffi.rs
@@ -15,12 +15,34 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-//! This module contains common FFI structures used by both authenticator and apps.
+//! This module contains common FFI types and structures used by both authenticator and apps.
 
 #![allow(unsafe_code)]
 
 use errors::CoreError;
 use ffi_utils::ReprC;
+use routing::XOR_NAME_LEN;
+use rust_sodium::crypto::{box_, secretbox, sign};
+
+/// Array containing public key bytes
+pub type PublicKey = [u8; box_::PUBLICKEYBYTES];
+/// Array containing private key bytes
+pub type AsymSecretKey = [u8; box_::SECRETKEYBYTES];
+/// Array containing nonce bytes
+pub type AsymNonce = [u8; box_::NONCEBYTES];
+
+/// Array containing private key bytes
+pub type SymSecretKey = [u8; secretbox::KEYBYTES];
+/// Array containing nonce bytes
+pub type SymNonce = [u8; secretbox::NONCEBYTES];
+
+/// Array containing sign public key bytes
+pub type SignPublicKey = [u8; sign::PUBLICKEYBYTES];
+/// Array containing sign private key bytes
+pub type SignSecretKey = [u8; sign::SECRETKEYBYTES];
+
+/// Array containing `XorName` bytes
+pub type XorNameArray = [u8; XOR_NAME_LEN];
 
 /// Represents the FFI-safe account info
 #[repr(C)]

--- a/safe_core/src/ffi.rs
+++ b/safe_core/src/ffi.rs
@@ -25,7 +25,7 @@ use routing::XOR_NAME_LEN;
 use rust_sodium::crypto::{box_, secretbox, sign};
 
 /// Array containing public key bytes
-pub type PublicKey = [u8; box_::PUBLICKEYBYTES];
+pub type AsymPublicKey = [u8; box_::PUBLICKEYBYTES];
 /// Array containing private key bytes
 pub type AsymSecretKey = [u8; box_::SECRETKEYBYTES];
 /// Array containing nonce bytes

--- a/safe_core/src/ipc/req/mod.rs
+++ b/safe_core/src/ipc/req/mod.rs
@@ -183,7 +183,7 @@ pub unsafe fn containers_from_repr_c(
 }
 
 /// Convert a `PermissionSet` into its C representation.
-fn permission_set_into_repr_c(perms: PermissionSet) -> ffi::PermissionSet {
+pub fn permission_set_into_repr_c(perms: PermissionSet) -> ffi::PermissionSet {
     ffi::PermissionSet {
         read: true,
         insert: perms.is_allowed(Action::Insert).unwrap_or(false),
@@ -235,7 +235,7 @@ pub struct AppExchangeInfo {
 }
 
 impl AppExchangeInfo {
-    /// Consumes the object and returns the wrapped raw pointer
+    /// Consumes the object and returns the wrapped raw pointer.
     ///
     /// You're now responsible for freeing this memory once you're done.
     pub fn into_repr_c(self) -> Result<ffi::AppExchangeInfo, IpcError> {

--- a/safe_core/src/ipc/resp/ffi.rs
+++ b/safe_core/src/ipc/resp/ffi.rs
@@ -68,7 +68,7 @@ pub struct AppKeys {
     /// Asymmetric sign private key.
     pub sign_sk: SignSecretKey,
     /// Asymmetric enc public key.
-    pub enc_pk: PublicKey,
+    pub enc_pk: AsymPublicKey,
     /// Asymmetric enc private key.
     pub enc_sk: AsymSecretKey,
 }

--- a/safe_core/src/ipc/resp/ffi.rs
+++ b/safe_core/src/ipc/resp/ffi.rs
@@ -17,13 +17,13 @@
 
 #![allow(unsafe_code)]
 
-use routing::XOR_NAME_LEN;
-use rust_sodium::crypto::{box_, secretbox, sign};
+use ffi::*;
+use rust_sodium::crypto::sign;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
 
-/// It represents the authentication response.
+/// Represents the authentication response.
 #[repr(C)]
 #[derive(Clone)]
 pub struct AuthGranted {
@@ -52,24 +52,24 @@ impl Drop for AuthGranted {
     }
 }
 
-/// Represents the needed keys to work with the data
+/// Represents the needed keys to work with the data.
 #[repr(C)]
 #[derive(Copy)]
 pub struct AppKeys {
     /// Owner signing public key
-    pub owner_key: [u8; sign::PUBLICKEYBYTES],
+    pub owner_key: SignPublicKey,
     /// Data symmetric encryption key
-    pub enc_key: [u8; secretbox::KEYBYTES],
+    pub enc_key: SymSecretKey,
     /// Asymmetric sign public key.
     ///
     /// This is the identity of the App in the Network.
-    pub sign_pk: [u8; sign::PUBLICKEYBYTES],
+    pub sign_pk: SignPublicKey,
     /// Asymmetric sign private key.
-    pub sign_sk: [u8; sign::SECRETKEYBYTES],
+    pub sign_sk: SignSecretKey,
     /// Asymmetric enc public key.
-    pub enc_pk: [u8; box_::PUBLICKEYBYTES],
+    pub enc_pk: PublicKey,
     /// Asymmetric enc private key.
-    pub enc_sk: [u8; box_::SECRETKEYBYTES],
+    pub enc_sk: AsymSecretKey,
 }
 
 impl Clone for AppKeys {
@@ -101,11 +101,11 @@ impl Clone for AppKeys {
 #[derive(Clone, Copy)]
 pub struct AccessContInfo {
     /// ID
-    pub id: [u8; XOR_NAME_LEN],
+    pub id: XorNameArray,
     /// Type tag
     pub tag: u64,
     /// Nonce
-    pub nonce: [u8; secretbox::NONCEBYTES],
+    pub nonce: SymNonce,
 }
 
 /// User metadata for mutable data


### PR DESCRIPTION
1. Created type definitions for FFI arrays and refactored out common ffi types.
2. Created a new API to fetch a list of apps that have access to an arbitrary MD.