### PR TITLE
fix/mock-vault: fix mock vault deserialisation (MAID-2262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "safe_core"
 version = "0.25.1"
 dependencies = [
  "base64 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.2.0",

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.25.1"
 
 [dependencies]
 base64 = "~0.4.1"
+bincode = { version = "~0.8.0", optional = true }
 chrono = { version = "~0.4.0", features = ["serde"] }
 ffi_utils = { path = "../ffi_utils", version = "~0.2.0" }
 fs2 = "~0.4.2"
@@ -34,7 +35,7 @@ docopt = "~0.7.0"
 rustc-serialize = "~0.3.23"
 
 [features]
-use-mock-routing = []
+use-mock-routing = ["bincode"]
 testing = []
 
 [[example]]

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -43,6 +43,8 @@
 #![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments))]
 
 extern crate base64;
+#[cfg(feature = "use-mock-routing")]
+extern crate bincode;
 extern crate chrono;
 extern crate ffi_utils;
 #[cfg(feature = "use-mock-routing")]


### PR DESCRIPTION
`maidsafe_utilities` introduced a new change that turned out to be a regression: in some cases when a deserialised struct is serialised again, the binary representation might be different.

This is now an error in the serialisation functions in `maidsafe_utilities` because it can prevent tampering of serialised messages. At the same time, this error prevented mock-vault from loading successfully in some edge cases. This commit fixes that by temporarily using `bincode` to deserialise the mock-vault data, and now we make sure to output error messages, if there are any (previously they were silenced).