### PR TITLE
fix/mock-vault: fix mock vault write mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,6 @@ name = "safe_core"
 version = "0.26.0"
 dependencies = [
  "base64 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.2.0",

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.26.0"
 
 [dependencies]
 base64 = "~0.4.1"
-bincode = { version = "~0.8.0", optional = true }
 chrono = { version = "~0.4.0", features = ["serde"] }
 ffi_utils = { path = "../ffi_utils", version = "~0.2.0" }
 fs2 = "~0.4.2"
@@ -35,7 +34,7 @@ docopt = "~0.7.0"
 rustc-serialize = "~0.3.23"
 
 [features]
-use-mock-routing = ["bincode"]
+use-mock-routing = []
 testing = []
 
 [[example]]

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -17,8 +17,8 @@
 
 use super::Account;
 use super::DataId;
-use bincode::{Infinite, deserialize, serialize};
 use fs2::FileExt;
+use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::{Authority, ClientError, ImmutableData, MutableData, XorName};
 use rust_sodium::crypto::sign;
 use std::collections::HashMap;
@@ -269,7 +269,7 @@ impl Store for FileStore {
                 }
             }
 
-            match deserialize::<Cache>(&raw_data) {
+            match deserialise::<Cache>(&raw_data) {
                 Ok(cache) => {
                     self.sync_time = Some(mtime);
                     result = Some(cache);
@@ -290,7 +290,8 @@ impl Store for FileStore {
         // the lock.
         if let Some((mut file, writing)) = self.file.take() {
             if writing {
-                let raw_data = unwrap!(serialize(&cache, Infinite));
+                let raw_data = unwrap!(serialise(&cache));
+                unwrap!(file.set_len(0));
                 unwrap!(file.write_all(&raw_data));
                 unwrap!(file.sync_all());
 

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -43,8 +43,6 @@
 #![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments))]
 
 extern crate base64;
-#[cfg(feature = "use-mock-routing")]
-extern crate bincode;
 extern crate chrono;
 extern crate ffi_utils;
 #[cfg(feature = "use-mock-routing")]


### PR DESCRIPTION
When mock-vault saved the changes to disk it didn't truncate the previous file contents. This could cause different hard-to-catch bugs, including the one reported in MAID-2262.