### PR TITLE
MAID-2083: Test Cases

### DIFF
--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -120,12 +120,50 @@ mod tests {
     use errors::AppError;
     use ffi::access_container::*;
     use ffi_utils::{ReprC, from_c_str};
-    use ffi_utils::test_utils::{call_1, call_vec};
+    use ffi_utils::test_utils::{call_0, call_1, call_vec};
     use safe_core::DIR_TAG;
     use safe_core::ipc::req::{Permission, container_perms_from_repr_c};
     use std::collections::{BTreeSet, HashMap};
     use std::ffi::CString;
-    use test_utils::{create_app_with_access, run_now};
+    use test_utils::{create_app_with_access, run, run_now};
+
+    // Test refreshing access info by fetching it from the network.
+    #[test]
+    fn refresh_access_info() {
+        // Shared container
+        let mut container_permissions = HashMap::new();
+        let _ = container_permissions.insert(
+            "_videos".to_string(),
+            btree_set![Permission::Read, Permission::Insert],
+        );
+
+        let app = create_app_with_access(container_permissions.clone());
+
+        run(&app, move |_client, context| {
+            let reg = unwrap!(context.as_registered()).clone();
+            assert!(reg.access_info.borrow().is_empty());
+            Ok(())
+        });
+
+        unsafe {
+            unwrap!(call_0(
+                |ud, cb| access_container_refresh_access_info(&app, ud, cb),
+            ))
+        }
+
+        run(&app, move |_client, context| {
+            let reg = unwrap!(context.as_registered()).clone();
+            assert!(!reg.access_info.borrow().is_empty());
+
+            let access_info = reg.access_info.borrow();
+            assert_eq!(
+                unwrap!(access_info.get("_videos")).1,
+                *unwrap!(container_permissions.get("_videos"))
+            );
+
+            Ok(())
+        });
+    }
 
     // Test getting info about access containers and their mutable data.
     #[test]

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -127,6 +127,7 @@ mod tests {
     use std::ffi::CString;
     use test_utils::{create_app_with_access, run_now};
 
+    // Test getting info about access containers and their mutable data.
     #[test]
     fn get_access_info() {
         let mut container_permissions = HashMap::new();

--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -195,6 +195,7 @@ mod tests {
     use safe_core::{Client, utils};
     use test_utils::{create_app, run_now};
 
+    // Test plaintext "encryption" and decryption.
     #[test]
     fn app_0_to_app_0_plain() {
         let app_0 = create_app();
@@ -227,6 +228,7 @@ mod tests {
         });
     }
 
+    // Test symmetric encryption and decryption.
     #[test]
     fn app_0_to_app_0_sym() {
         let app_0 = create_app();
@@ -259,6 +261,7 @@ mod tests {
         });
     }
 
+    // Test asymmetric encryption and decryption.
     // NOTE: rustfmt is behaving erratically on this function. Disabling it for now.
     #[cfg_attr(rustfmt, rustfmt_skip)]
     #[test]
@@ -309,6 +312,7 @@ mod tests {
         });
     }
 
+    // Test creating and freeing the different possible cipher option handles.
     #[test]
     fn create_and_free() {
         let app = create_app();

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -162,18 +162,18 @@ pub unsafe extern "C" fn enc_pub_key_get(
     })
 }
 
-/// Retrieve the private encryption key as raw array.
+/// Free encryption key from memory
 #[no_mangle]
-pub unsafe extern "C" fn enc_secret_key_get(
+pub unsafe extern "C" fn enc_pub_key_free(
     app: *const App,
-    handle: EncryptSecKeyHandle,
+    handle: EncryptPubKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymSecretKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let key = context.object_cache().get_secret_key(handle)?;
-            Ok(&key.0)
+            let _ = context.object_cache().remove_encrypt_key(handle)?;
+            Ok(())
         })
     })
 }
@@ -194,18 +194,18 @@ pub unsafe extern "C" fn enc_secret_key_new(
     })
 }
 
-/// Free encryption key from memory
+/// Retrieve the private encryption key as raw array.
 #[no_mangle]
-pub unsafe extern "C" fn enc_pub_key_free(
+pub unsafe extern "C" fn enc_secret_key_get(
     app: *const App,
-    handle: EncryptPubKeyHandle,
+    handle: EncryptSecKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymSecretKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {
-            let _ = context.object_cache().remove_encrypt_key(handle)?;
-            Ok(())
+            let key = context.object_cache().get_secret_key(handle)?;
+            Ok(&key.0)
         })
     })
 }
@@ -421,7 +421,7 @@ pub unsafe extern "C" fn generate_nonce(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ffi_utils::test_utils::{call_1, call_2, call_vec_u8};
+    use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8};
     use rust_sodium::crypto::box_;
     use safe_core::ffi::{AsymNonce, AsymPublicKey, SignPublicKey};
     use test_utils::{create_app, run_now};
@@ -554,11 +554,17 @@ mod tests {
         });
 
         assert_eq!(app_sign_key1, app_sign_key2);
+
+        unsafe {
+            unwrap!(call_0(
+                |ud, cb| sign_key_free(&app, app_sign_key2_h, ud, cb),
+            ))
+        }
     }
 
-    // Test creating and fetching encryption keys.
+    // Test creating and fetching public encryption keys.
     #[test]
-    fn enc_key_basics() {
+    fn enc_public_key_basics() {
         let app = create_app();
         let app_enc_key1_h = unsafe { unwrap!(call_1(|ud, cb| app_pub_enc_key(&app, ud, cb))) };
 
@@ -587,6 +593,64 @@ mod tests {
         });
 
         assert_eq!(app_enc_key1, app_enc_key2);
+
+        unsafe {
+            unwrap!(call_0(
+                |ud, cb| enc_pub_key_free(&app, app_enc_key2_h, ud, cb),
+            ))
+        }
+    }
+
+    // Test creating and fetching secret encryption keys.
+    #[test]
+    fn enc_secret_key_basics() {
+        let app = create_app();
+        let (app_public_key_h, app_secret_key1_h) =
+            unsafe { unwrap!(call_2(|ud, cb| enc_generate_key_pair(&app, ud, cb))) };
+
+        let app_public_key1: AsymPublicKey = unsafe {
+            unwrap!(call_1(
+                |ud, cb| enc_pub_key_get(&app, app_public_key_h, ud, cb),
+            ))
+        };
+        let app_secret_key1: AsymSecretKey = unsafe {
+            unwrap!(call_1(
+                |ud, cb| enc_secret_key_get(&app, app_secret_key1_h, ud, cb),
+            ))
+        };
+
+        let app_secret_key1 = run_now(&app, move |_client, context| {
+            let app_public_key2 = unwrap!(context.object_cache().get_encrypt_key(app_public_key_h));
+            assert_eq!(box_::PublicKey(app_public_key1), *app_public_key2);
+
+            let app_secret_key2 = unwrap!(context.object_cache().get_secret_key(app_secret_key1_h));
+            assert_eq!(box_::SecretKey(app_secret_key1), *app_secret_key2);
+
+            app_secret_key1
+        });
+
+        let app_secret_key1_raw: AsymSecretKey = unsafe {
+            unwrap!(call_1(
+                |ud, cb| enc_secret_key_get(&app, app_secret_key1_h, ud, cb),
+            ))
+        };
+
+        let app_secret_key2_h = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                enc_secret_key_new(&app, &app_secret_key1_raw, ud, cb)
+            }))
+        };
+
+        run_now(&app, move |_, context| {
+            let app_secret_key2 = unwrap!(context.object_cache().get_secret_key(app_secret_key2_h));
+            assert_eq!(box_::SecretKey(app_secret_key1), *app_secret_key2);
+        });
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                enc_secret_key_free(&app, app_secret_key2_h, ud, cb)
+            }))
+        }
     }
 
     // Test that generated nonces are the correct length.
@@ -594,5 +658,27 @@ mod tests {
     fn nonce_smoke_test() {
         let nonce: AsymNonce = unsafe { unwrap!(call_1(|ud, cb| generate_nonce(ud, cb))) };
         assert_eq!(nonce.len(), box_::NONCEBYTES);
+    }
+
+    // Test that generated sha3 hashes are the correct length.
+    #[test]
+    fn sha3_smoke_test() {
+        let data = b"test message";
+        let sha3 = unsafe {
+            unwrap!(call_vec_u8(
+                |ud, cb| sha3_hash(data.as_ptr(), data.len(), ud, cb),
+            ))
+        };
+
+        assert_eq!(sha3.len(), 256 / 8);
+
+        let data = b"";
+        let sha3 = unsafe {
+            unwrap!(call_vec_u8(
+                |ud, cb| sha3_hash(data.as_ptr(), data.len(), ud, cb),
+            ))
+        };
+
+        assert_eq!(sha3.len(), 256 / 8);
     }
 }

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -22,7 +22,7 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, catch_unwind_cb, vec_clone_
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::{EncryptPubKeyHandle, EncryptSecKeyHandle, SignKeyHandle};
 use rust_sodium::crypto::{box_, sealedbox, sign};
-use safe_core::ffi::{AsymNonce, AsymPublicKey, AsymSecretKey};
+use safe_core::ffi::{AsymNonce, AsymPublicKey, AsymSecretKey, SignPublicKey};
 use std::os::raw::c_void;
 use std::slice;
 use tiny_keccak::sha3_256;
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn app_pub_sign_key(
 #[no_mangle]
 pub unsafe extern "C" fn sign_key_new(
     app: *const App,
-    data: *const AsymPublicKey,
+    data: *const SignPublicKey,
     user_data: *mut c_void,
     o_cb: extern "C" fn(*mut c_void, FfiResult, SignKeyHandle),
 ) {
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn sign_key_get(
     app: *const App,
     handle: SignKeyHandle,
     user_data: *mut c_void,
-    o_cb: extern "C" fn(*mut c_void, FfiResult, *const AsymPublicKey),
+    o_cb: extern "C" fn(*mut c_void, FfiResult, *const SignPublicKey),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, move |_, context| {

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -426,6 +426,7 @@ mod tests {
     use safe_core::ffi::{AsymNonce, AsymPublicKey, SignPublicKey};
     use test_utils::{create_app, run_now};
 
+    // Test encrypting and decrypting messages between apps.
     #[test]
     fn encrypt_decrypt() {
         let app1 = create_app();
@@ -482,6 +483,7 @@ mod tests {
         assert_eq!(&decrypted, data);
     }
 
+    // Test encrypting and decrypting sealed box messages between apps.
     #[test]
     fn encrypt_decrypt_sealed() {
         let app1 = create_app();
@@ -524,6 +526,7 @@ mod tests {
         assert_eq!(&decrypted, data);
     }
 
+    // Test creating and fetching sign keys.
     #[test]
     fn sign_key_basics() {
         let app = create_app();
@@ -553,6 +556,7 @@ mod tests {
         assert_eq!(app_sign_key1, app_sign_key2);
     }
 
+    // Test creating and fetching encryption keys.
     #[test]
     fn enc_key_basics() {
         let app = create_app();
@@ -585,6 +589,7 @@ mod tests {
         assert_eq!(app_enc_key1, app_enc_key2);
     }
 
+    // Test that generated nonces are the correct length.
     #[test]
     fn nonce_smoke_test() {
         let nonce: AsymNonce = unsafe { unwrap!(call_1(|ud, cb| generate_nonce(ud, cb))) };

--- a/safe_app/src/ffi/immutable_data.rs
+++ b/safe_app/src/ffi/immutable_data.rs
@@ -351,12 +351,14 @@ mod tests {
     use safe_core::utils;
     use test_utils::create_app;
 
+    // Test immutable data operations.
     #[test]
     fn immut_data_operations() {
         let app = create_app();
 
         let plain_text = unwrap!(utils::generate_random_vector::<u8>(10));
 
+        // Write idata to self encryptor handle
         unsafe {
             let cipher_opt_h = unwrap!(call_1(|ud, cb| cipher_opt_new_symmetric(&app, ud, cb)));
             let se_writer_h = unwrap!(call_1(|ud, cb| idata_new_self_encryptor(&app, ud, cb)));
@@ -395,15 +397,15 @@ mod tests {
             });
             assert_eq!(res, Err(AppError::InvalidSelfEncryptorHandle.error_code()));
 
-            // Invalid Self encryptor reader.
+            // Invalid self encryptor reader.
             let res: Result<u64, _> = call_1(|ud, cb| idata_size(&app, 0, ud, cb));
             assert_eq!(res, Err(AppError::InvalidSelfEncryptorHandle.error_code()));
 
-            // Invalid Self encryptor reader.
+            // Invalid self encryptor reader.
             let res: Result<u64, _> = call_1(|ud, cb| idata_size(&app, se_writer_h, ud, cb));
             assert_eq!(res, Err(AppError::InvalidSelfEncryptorHandle.error_code()));
 
-            // Invalid Self encryptor reader.
+            // Invalid self encryptor reader.
             let res: u64 = unwrap!(call_1(|ud, cb| idata_serialised_size(&app, &name, ud, cb)));
             assert!(res > 0);
 

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -315,6 +315,28 @@ mod tests {
         assert_eq!(decoded_req, req);
     }
 
+    // Test encoding and decoding unregistered requests.
+    #[test]
+    fn encode_unregistered_req_basics() {
+        let (req_id, encoded): (u32, String) =
+            unsafe { unwrap!(call_2(|ud, cb| encode_unregistered_req(ud, cb))) };
+
+        // Decode it and verify it's the same we encoded.
+        assert!(encoded.starts_with("safe-auth:"));
+        let msg = unwrap!(ipc::decode_msg(&encoded));
+
+        let (decoded_req_id, decoded_req) = match msg {
+            IpcMsg::Req {
+                req_id,
+                req: IpcReq::Unregistered,
+            } => (req_id, IpcReq::Unregistered),
+            x => panic!("Unexpected {:?}", x),
+        };
+
+        assert_eq!(decoded_req_id, req_id);
+        assert_eq!(decoded_req, IpcReq::Unregistered);
+    }
+
     // Test encoding and decoding requests to share mutable data
     #[test]
     fn encode_share_mdata_basics() {
@@ -377,12 +399,6 @@ mod tests {
         let encoded = unwrap!(ipc::encode_msg(&msg, "app-id"));
         let encoded = unwrap!(CString::new(encoded));
 
-        struct Context {
-            unexpected_cb: bool,
-            req_id: u32,
-            auth_granted: Option<AuthGranted>,
-        };
-
         let context = unsafe {
             let mut context = Context {
                 unexpected_cb: false,
@@ -437,13 +453,6 @@ mod tests {
                 }
             }
 
-            extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
-                unsafe {
-                    let ctx = ctx as *mut Context;
-                    (*ctx).unexpected_cb = true;
-                }
-            }
-
             let context_ptr: *mut Context = &mut context;
             decode_ipc_msg(
                 encoded.as_ptr(),
@@ -477,14 +486,10 @@ mod tests {
         let encoded = unwrap!(ipc::encode_msg(&msg, "app-id"));
         let encoded = unwrap!(CString::new(encoded));
 
-        struct Context {
-            unexpected_cb: bool,
-            req_id: u32,
-        };
-
         let mut context = Context {
             unexpected_cb: false,
             req_id: 0,
+            auth_granted: None,
         };
 
         unsafe {
@@ -532,10 +537,84 @@ mod tests {
                 }
             }
 
-            extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
+            let context_ptr: *mut Context = &mut context;
+            decode_ipc_msg(
+                encoded.as_ptr(),
+                context_ptr as *mut c_void,
+                auth_cb,
+                unregistered_cb,
+                containers_cb,
+                share_mdata_cb,
+                revoked_cb,
+                err_cb,
+            );
+        }
+
+        assert!(!context.unexpected_cb);
+        assert_eq!(context.req_id, req_id);
+    }
+
+    // Test that `decode_ipc_msg` calls the `o_unregistered` callback.
+    #[test]
+    fn decode_ipc_msg_with_unregistered_granted() {
+        let req_id = ipc::gen_req_id();
+
+        let msg = IpcMsg::Resp {
+            req_id: req_id,
+            resp: IpcResp::Unregistered(Ok(BootstrapConfig::default())),
+        };
+
+        let encoded = unwrap!(ipc::encode_msg(&msg, "app-id"));
+        let encoded = unwrap!(CString::new(encoded));
+
+        let mut context = Context {
+            unexpected_cb: false,
+            req_id: 0,
+            auth_granted: None,
+        };
+
+        unsafe {
+            extern "C" fn auth_cb(
+                ctx: *mut c_void,
+                _req_id: u32,
+                _auth_granted: *const FfiAuthGranted,
+            ) {
                 unsafe {
                     let ctx = ctx as *mut Context;
                     (*ctx).unexpected_cb = true;
+                }
+            }
+
+            extern "C" fn containers_cb(ctx: *mut c_void, _req_id: u32) {
+                unsafe {
+                    let ctx = ctx as *mut Context;
+                    (*ctx).unexpected_cb = true;
+                }
+            }
+
+            extern "C" fn share_mdata_cb(ctx: *mut c_void, _req_id: u32) {
+                unsafe {
+                    let ctx = ctx as *mut Context;
+                    (*ctx).unexpected_cb = true;;
+                }
+            }
+
+            extern "C" fn revoked_cb(ctx: *mut c_void) {
+                unsafe {
+                    let ctx = ctx as *mut Context;
+                    (*ctx).unexpected_cb = true;
+                }
+            }
+
+            extern "C" fn unregistered_cb(
+                ctx: *mut c_void,
+                req_id: u32,
+                _bootstrap_cfg_ptr: *const u8,
+                _bootstrap_cfg_len: usize,
+            ) {
+                unsafe {
+                    let ctx = ctx as *mut Context;
+                    (*ctx).req_id = req_id;
                 }
             }
 
@@ -569,14 +648,10 @@ mod tests {
         let encoded = unwrap!(ipc::encode_msg(&msg, "app-id"));
         let encoded = unwrap!(CString::new(encoded));
 
-        struct Context {
-            unexpected_cb: bool,
-            req_id: u32,
-        };
-
         let mut context = Context {
             unexpected_cb: false,
             req_id: 0,
+            auth_granted: None,
         };
 
         unsafe {
@@ -624,13 +699,6 @@ mod tests {
                 }
             }
 
-            extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
-                unsafe {
-                    let ctx = ctx as *mut Context;
-                    (*ctx).unexpected_cb = true;
-                }
-            }
-
             let context_ptr: *mut Context = &mut context;
             decode_ipc_msg(
                 encoded.as_ptr(),
@@ -661,6 +729,19 @@ mod tests {
             sign_sk: sign_sk,
             enc_pk: enc_pk,
             enc_sk: enc_sk,
+        }
+    }
+
+    struct Context {
+        unexpected_cb: bool,
+        req_id: u32,
+        auth_granted: Option<AuthGranted>,
+    }
+
+    extern "C" fn err_cb(ctx: *mut c_void, _res: FfiResult, _req_id: u32) {
+        unsafe {
+            let ctx = ctx as *mut Context;
+            (*ctx).unexpected_cb = true;
         }
     }
 }

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -250,6 +250,7 @@ mod tests {
     use std::os::raw::c_void;
     use test_utils::gen_app_exchange_info;
 
+    // Test encoding and decoding authorization requests.
     #[test]
     fn encode_auth_req_basics() {
         let req = AuthReq {
@@ -279,6 +280,7 @@ mod tests {
         assert_eq!(decoded_req, req);
     }
 
+    // Test encoding and decoding containers requests.
     #[test]
     fn encode_containers_req_basics() {
         let mut container_permissions = HashMap::new();
@@ -313,6 +315,7 @@ mod tests {
         assert_eq!(decoded_req, req);
     }
 
+    // Test encoding and decoding requests to share mutable data
     #[test]
     fn encode_share_mdata_basics() {
         let req = ShareMDataReq {
@@ -349,6 +352,7 @@ mod tests {
         assert_eq!(decoded_req, req);
     }
 
+    // Test that `decode_ipc_msg` calls the `o_auth` callback.
     #[test]
     fn decode_ipc_msg_with_auth_granted() {
         let req_id = ipc::gen_req_id();
@@ -460,6 +464,7 @@ mod tests {
         assert_eq!(unwrap!(context.auth_granted), auth_granted);
     }
 
+    // Test that `decode_ipc_msg` calls the `o_containers` callback.
     #[test]
     fn decode_ipc_msg_with_containers_granted() {
         let req_id = ipc::gen_req_id();
@@ -551,6 +556,7 @@ mod tests {
         assert_eq!(context.req_id, req_id);
     }
 
+    // Test that `decode_ipc_msg` calls the `o_share_mdata` callback.
     #[test]
     fn decode_ipc_msg_with_share_mdata_granted() {
         let req_id = ipc::gen_req_id();

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -78,12 +78,27 @@ pub unsafe extern "C" fn app_output_log_path(
 mod tests {
     use super::*;
     use config_file_handler::current_bin_dir;
-    use ffi_utils::test_utils::call_0;
+    use ffi_utils::test_utils::{call_0, call_1};
     use std::env;
     use std::fs::{self, File};
     use std::io::Read;
     use std::thread;
     use std::time::Duration;
+
+    // Test path where log file is created.
+    #[test]
+    fn output_log_path() {
+        let name = "_test path";
+        let path_str = unwrap!(CString::new(name));
+
+        let path: String = unsafe {
+            unwrap!(call_1(
+                |ud, cb| app_output_log_path(path_str.as_ptr(), ud, cb),
+            ))
+        };
+
+        assert!(path.contains(name));
+    }
 
     // Test logging errors to file.
     #[test]

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -85,6 +85,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    // Test logging errors to file.
     #[test]
     fn file_logging() {
         setup_log_config();

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -300,6 +300,7 @@ mod tests {
     use safe_core::MDataInfo;
     use test_utils::{create_app, run_now};
 
+    // Test creating non-encrypted mdata info.
     #[test]
     fn create_public() {
         let app = create_app();
@@ -318,6 +319,7 @@ mod tests {
         })
     }
 
+    // Test creating encrypted mdata info.
     #[test]
     fn create_private() {
         let app = create_app();
@@ -358,6 +360,7 @@ mod tests {
         });
     }
 
+    // Test serialising and deserialising mdata_info.
     #[test]
     fn serialise_deserialise() {
         let app = create_app();

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -200,6 +200,7 @@ mod tests {
     use safe_core::ffi::AccountInfo;
     use test_utils::create_app;
 
+    // Test account usage statistics before and after a mutation.
     #[test]
     fn account_info() {
         let app = create_app();
@@ -229,6 +230,7 @@ mod tests {
         unsafe { app_free(app) };
     }
 
+    // Test disconnection and reconnection with apps.
     #[cfg(all(test, feature = "use-mock-routing"))]
     #[test]
     fn network_status_callback() {

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -19,18 +19,6 @@
 
 #![allow(unsafe_code)]
 
-use super::App;
-use super::errors::AppError;
-use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, ReprC, catch_unwind_cb, from_c_str};
-use futures::Future;
-use maidsafe_utilities::serialisation::deserialise;
-use safe_core::{FutureExt, NetworkEvent};
-use safe_core::ffi::AccountInfo as FfiAccountInfo;
-use safe_core::ipc::{AuthGranted, BootstrapConfig};
-use safe_core::ipc::resp::ffi::AuthGranted as FfiAuthGranted;
-use std::os::raw::{c_char, c_void};
-use std::slice;
-
 /// Access container
 pub mod access_container;
 /// Cipher Options
@@ -51,6 +39,18 @@ pub mod mutable_data;
 pub mod nfs;
 
 mod helper;
+
+use super::App;
+use super::errors::AppError;
+use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, ReprC, catch_unwind_cb, from_c_str};
+use futures::Future;
+use maidsafe_utilities::serialisation::deserialise;
+use safe_core::{FutureExt, NetworkEvent};
+use safe_core::ffi::AccountInfo as FfiAccountInfo;
+use safe_core::ipc::{AuthGranted, BootstrapConfig};
+use safe_core::ipc::resp::ffi::AuthGranted as FfiAuthGranted;
+use std::os::raw::{c_char, c_void};
+use std::slice;
 
 /// Create unregistered app.
 /// The `user_data` parameter corresponds to the first parameter of the
@@ -195,18 +195,10 @@ unsafe fn call_network_observer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use App;
-    use ffi_utils::test_utils::{call_0, call_1, send_via_user_data, sender_as_user_data};
-    use maidsafe_utilities::serialisation::serialise;
+    use ffi_utils::test_utils::call_1;
     use routing::ImmutableData;
-    use safe_core::NetworkEvent;
     use safe_core::ffi::AccountInfo;
-    use safe_core::ipc::BootstrapConfig;
-    use std::os::raw::c_void;
-    use std::sync::mpsc;
-    use std::time::Duration;
     use test_utils::create_app;
-
 
     // Test account usage statistics before and after a mutation.
     #[test]
@@ -242,6 +234,15 @@ mod tests {
     #[cfg(all(test, feature = "use-mock-routing"))]
     #[test]
     fn network_status_callback() {
+        use App;
+        use ffi_utils::test_utils::{call_0, send_via_user_data, sender_as_user_data};
+        use maidsafe_utilities::serialisation::serialise;
+        use safe_core::NetworkEvent;
+        use std::os::raw::c_void;
+        use safe_core::ipc::BootstrapConfig;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
         {
             let (tx, rx) = mpsc::channel();
 

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -238,8 +238,8 @@ mod tests {
         use ffi_utils::test_utils::{call_0, send_via_user_data, sender_as_user_data};
         use maidsafe_utilities::serialisation::serialise;
         use safe_core::NetworkEvent;
-        use std::os::raw::c_void;
         use safe_core::ipc::BootstrapConfig;
+        use std::os::raw::c_void;
         use std::sync::mpsc;
         use std::time::Duration;
 

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -195,10 +195,18 @@ unsafe fn call_network_observer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ffi_utils::test_utils::call_1;
+    use App;
+    use ffi_utils::test_utils::{call_0, call_1, send_via_user_data, sender_as_user_data};
+    use maidsafe_utilities::serialisation::serialise;
     use routing::ImmutableData;
+    use safe_core::NetworkEvent;
     use safe_core::ffi::AccountInfo;
+    use safe_core::ipc::BootstrapConfig;
+    use std::os::raw::c_void;
+    use std::sync::mpsc;
+    use std::time::Duration;
     use test_utils::create_app;
+
 
     // Test account usage statistics before and after a mutation.
     #[test]
@@ -234,15 +242,6 @@ mod tests {
     #[cfg(all(test, feature = "use-mock-routing"))]
     #[test]
     fn network_status_callback() {
-        use App;
-        use ffi_utils::test_utils::{call_0, send_via_user_data, sender_as_user_data};
-        use maidsafe_utilities::serialisation::serialise;
-        use safe_core::NetworkEvent;
-        use safe_core::ipc::BootstrapConfig;
-        use std::os::raw::c_void;
-        use std::sync::mpsc;
-        use std::time::Duration;
-
         {
             let (tx, rx) = mpsc::channel();
 

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -361,6 +361,7 @@ mod tests {
     use std::sync::mpsc::{self, Sender};
     use test_utils::{create_app, run_now};
 
+    // Test entry FFI operations.
     #[test]
     fn entries() {
         let app = create_app();

--- a/safe_app/src/ffi/mutable_data/entry_actions.rs
+++ b/safe_app/src/ffi/mutable_data/entry_actions.rs
@@ -145,6 +145,7 @@ mod tests {
     use safe_core::utils;
     use test_utils::{create_app, run_now};
 
+    // Test entry action basics such as insert, update, and delete.
     #[test]
     fn basics() {
         let app = create_app();

--- a/safe_app/src/ffi/mutable_data/metadata.rs
+++ b/safe_app/src/ffi/mutable_data/metadata.rs
@@ -37,3 +37,35 @@ pub unsafe extern "C" fn mdata_encode_metadata(
         Ok(())
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use ffi::mutable_data::metadata::mdata_encode_metadata;
+    use ffi_utils::test_utils::call_vec_u8;
+    use maidsafe_utilities::serialisation::deserialise;
+    use safe_core::ipc::resp::UserMetadata;
+
+    // Test serializing and deserializing metadata.
+    #[test]
+    fn serialize_metadata() {
+        let metadata1 = UserMetadata {
+            name: None,
+            description: Some(String::from("test")),
+        };
+
+        let metadata_resp = match metadata1.clone().into_md_response(Default::default(), 0) {
+            Ok(val) => val,
+            _ => panic!("An error occurred"),
+        };
+
+        let serialised = unsafe {
+            unwrap!(call_vec_u8(
+                |ud, cb| mdata_encode_metadata(&metadata_resp, ud, cb),
+            ))
+        };
+
+        let metadata2 = unwrap!(deserialise::<UserMetadata>(&serialised));
+
+        assert_eq!(metadata1, metadata2);
+    }
+}

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -15,1162 +15,351 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use errors::ERR_NO_SUCH_ENTRY;
-use futures::Future;
-use maidsafe_utilities::thread;
-use rand::{OsRng, Rng};
-use routing::{Action, ClientError, EntryAction, MutableData, PermissionSet, User, Value,
-              XOR_NAME_LEN, XorName};
-use rust_sodium::crypto::sign;
-use safe_core::{CoreError, DIR_TAG, FutureExt};
-use safe_core::utils::test_utils::random_client;
-use std::collections::{BTreeMap, BTreeSet};
+use errors::{ERR_ACCESS_DENIED, ERR_INVALID_SUCCESSOR, ERR_NO_SUCH_ENTRY, ERR_NO_SUCH_KEY};
+use ffi::mdata_info::*;
+use ffi::mutable_data::*;
+use ffi::mutable_data::entries::*;
+use ffi::mutable_data::entry_actions::*;
+use ffi::mutable_data::permissions::*;
+use ffi_utils::{FfiResult, vec_clone_from_raw_parts};
+use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8, send_via_user_data,
+                            sender_as_user_data};
+use object_cache::{MDataInfoHandle, MDataPermissionSetHandle, MDataPermissionsHandle};
+use routing::XOR_NAME_LEN;
 use std::sync::mpsc;
 use std::time::Duration;
-use test_utils::{create_app, run};
+use test_utils::create_app;
 
-// MD created by App. App lists its own sign_pk in owners field: Put should
-// fail - Rejected by MaidManagers. Should pass when it lists the owner's
-// sign_pk instead
+// The usual test to insert, update, delete and list all permissions from the FFI point of view.
 #[test]
-fn md_created_by_app_1() {
+fn permissions_crud_ffi() {
     let app = create_app();
-    run(&app, |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
 
-        let owners = btree_set![unwrap!(client.public_signing_key())];
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(
-            name,
-            DIR_TAG,
-            BTreeMap::new(),
-            BTreeMap::new(),
-            owners,
-        ));
-        let cl2 = client.clone();
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("Put should be rejected by MaidManagers"),
-                    Err(CoreError::RoutingClientError(ClientError::InvalidOwners)) => (),
-                    Err(x) => panic!("Expected ClientError::InvalidOwners. Got {:?}", x),
-                }
-                let mut owners = BTreeSet::new();
-                owners.insert(unwrap!(cl2.owner_key()));
-                let mdata = unwrap!(MutableData::new(
-                    name,
-                    DIR_TAG,
-                    BTreeMap::new(),
-                    BTreeMap::new(),
-                    owners,
-                ));
-                cl2.put_mdata(mdata)
-            })
-            .map_err(|e| panic!("{:?}", e))
-    });
-}
+    // Create a permissions set
+    let perm_set_h: MDataPermissionSetHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_permission_set_new(&app, ud, cb))) };
 
-// MD created by App properly: Should pass. App tries to change ownership -
-// Should Fail by MaidManagers. App creates its own account with the
-// maid-managers. Now it tries changing ownership by routing it through it's MM
-// instead of owners. It should still fail as DataManagers should enforce that
-// the request is coming from MM of the owner (listed in the owners field of the
-// stored MD).
-#[test]
-fn md_created_by_app_2() {
-    let app = create_app();
-    let (tx, rx) = mpsc::channel();
-    let (alt_client_tx, alt_client_rx) = mpsc::channel();
-    unwrap!(app.send(move |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
-        let sign_pk = unwrap!(client.public_signing_key());
+    // Test permission setting
+    {
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_allow(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }));
+        }
 
-        let mut permissions = BTreeMap::new();
-        let _ = permissions.insert(
-            User::Key(sign_pk),
-            PermissionSet::new().allow(Action::ManagePermissions),
-        );
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
 
-        let owners = btree_set![unwrap!(client.owner_key())];
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_deny(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }));
+        }
 
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(
-            name,
-            DIR_TAG,
-            permissions,
-            BTreeMap::new(),
-            owners,
-        ));
-        let name2 = name;
-        let cl2 = client.clone();
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                unwrap!(res);
-                cl2.change_mdata_owner(name, DIR_TAG, sign_pk, 1)
-            })
-            .then(move |res| -> Result<_, ()> {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                unwrap!(alt_client_tx.send((name2, sign_pk)));
-                Ok(())
-            })
-            .into_box()
-            .into()
-    }));
-    let _joiner = thread::named("Alt client", || {
-        random_client(move |client| {
-            let (name, sign_pk) = unwrap!(alt_client_rx.recv());
-            let cl2 = client.clone();
-            let cl3 = client.clone();
-            client
-                .list_auth_keys_and_version()
-                .then(move |res| {
-                    let (_, version) = unwrap!(res);
-                    cl2.ins_auth_key(sign_pk, version + 1)
-                })
-                .then(move |res| {
-                    unwrap!(res);
-                    cl3.change_mdata_owner(name, DIR_TAG, sign_pk, 1)
-                })
-                .then(move |res| -> Result<(), ()> {
-                    match res {
-                        Ok(()) => panic!("It should fail"),
-                        Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                        Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                    }
-                    unwrap!(tx.send(()));
-                    Ok(())
-                })
-        });
-    });
-    unwrap!(rx.recv());
-}
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Denied);
 
-// MD created by owner and given to a permitted App. Owner has listed that app
-// is allowed to insert only. App tries to insert - should pass. App tries to
-// update - should fail. App tries to change permission to allow itself to
-// update - should fail to change permissions.
-#[test]
-fn md_created_by_app_3() {
-    let app = create_app();
-    let (tx, rx) = mpsc::channel();
-    let (app_sign_pk_tx, app_sign_pk_rx) = mpsc::channel();
-    let (name_tx, name_rx) = mpsc::channel();
-    unwrap!(app.send(move |client, _app_context| {
-        let sign_pk = unwrap!(client.public_signing_key());
-        unwrap!(app_sign_pk_tx.send(sign_pk));
-        let name: XorName = unwrap!(name_rx.recv());
-        let mut actions = BTreeMap::new();
-        let _ = actions.insert(
-            vec![1, 2, 3, 4],
-            EntryAction::Ins(Value {
-                content: vec![2, 3, 5],
-                entry_version: 1,
-            }),
-        );
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let name2 = name;
-        client
-            .mutate_mdata_entries(name, DIR_TAG, actions)
-            .then(move |res| {
-                unwrap!(res);
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(
-                    vec![1, 2, 3, 4],
-                    EntryAction::Update(Value {
-                        content: vec![2, 8, 5],
-                        entry_version: 2,
-                    }),
-                );
-                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                let user = User::Key(sign_pk);
-                let permissions = PermissionSet::new().allow(Action::Update);
-                cl3.set_mdata_user_permissions(name2, DIR_TAG, user, permissions, 2)
-            })
-            .then(move |res| -> Result<_, ()> {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                unwrap!(tx.send(()));
-                Ok(())
-            })
-            .into_box()
-            .into()
-    }));
-    let _joiner = thread::named("Alt client", || {
-        random_client(move |client| {
-            let app_sign_pk = unwrap!(app_sign_pk_rx.recv());
-            let mut rng = unwrap!(OsRng::new());
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_clear(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }));
+        }
 
-            let mut permissions = BTreeMap::new();
-            let _ = permissions.insert(
-                User::Key(app_sign_pk),
-                PermissionSet::new().allow(Action::Insert),
-            );
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::NotSet);
 
-            let mut owners = BTreeSet::new();
-            owners.insert(unwrap!(client.owner_key()));
-
-            let name: XorName = rng.gen();
-
-            let mdata = unwrap!(MutableData::new(
-                name,
-                DIR_TAG,
-                permissions,
-                BTreeMap::new(),
-                owners,
-            ));
-            let cl2 = client.clone();
-            let cl3 = client.clone();
-
-            client.list_auth_keys_and_version()
-                .then(move |res| {
-                    let (_, version) = unwrap!(res);
-                    cl2.ins_auth_key(app_sign_pk, version + 1)
-                })
-                .then(move |res| {
-                    unwrap!(res);
-                    cl3.put_mdata(mdata)
-                })
-                .map(move |()| unwrap!(name_tx.send(name)))
-                .map_err(|e| panic!("{:?}", e))
-        });
-    });
-    unwrap!(rx.recv());
-}
-
-// MD created by owner and given to a permitted App. Owner has listed that app
-// is allowed to manage-permissions only. App tries to insert - should fail. App
-// tries to update - should fail. App tries to change permission to allow itself
-// to insert and delete - should pass to change permissions. Now App tires to
-// insert again - should pass. App tries to update. Should fail. App tries to
-// delete - should pass.
-#[test]
-fn md_created_by_app_4() {
-    let app = create_app();
-    let (tx, rx) = mpsc::channel();
-    let (app_sign_pk_tx, app_sign_pk_rx) = mpsc::channel();
-    let (name_tx, name_rx) = mpsc::channel();
-    unwrap!(app.send(move |client, _app_context| {
-        let sign_pk = unwrap!(client.public_signing_key());
-        unwrap!(app_sign_pk_tx.send(sign_pk));
-        let name: XorName = unwrap!(name_rx.recv());
-        let mut actions = BTreeMap::new();
-        let _ = actions.insert(
-            vec![1, 2, 3, 4],
-            EntryAction::Ins(Value {
-                content: vec![2, 3, 5],
-                entry_version: 1,
-            }),
-        );
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let cl4 = client.clone();
-        let cl5 = client.clone();
-        let cl6 = client.clone();
-        let name2 = name;
-        let name3 = name;
-        let name4 = name;
-        let name5 = name;
-        client.mutate_mdata_entries(name, DIR_TAG, actions)
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(vec![1, 8, 3, 4],
-                                       EntryAction::Update(Value {
-                                           content: vec![2, 8, 5],
-                                           entry_version: 2,
-                                       }));
-                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                let user = User::Key(sign_pk);
-                let permissions = PermissionSet::new().allow(Action::Insert).allow(Action::Delete);
-                cl3.set_mdata_user_permissions(name2, DIR_TAG, user,
-                                               permissions, 1)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(vec![1, 2, 3, 4],
-                                       EntryAction::Ins(Value {
-                                           content: vec![2, 3, 5],
-                                           entry_version: 1,
-                                       }));
-                cl4.mutate_mdata_entries(name3, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(vec![1, 2, 3, 4],
-                                       EntryAction::Update(Value {
-                                           content: vec![2, 8, 5],
-                                           entry_version: 2,
-                                       }));
-                cl5.mutate_mdata_entries(name4, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(vec![1, 2, 3, 4],
-                                       EntryAction::Del(2));
-                cl6.mutate_mdata_entries(name5, DIR_TAG, actions)
-            })
-            .map(move |()| unwrap!(tx.send(())))
-            .map_err(|e| panic!("{:?}", e))
-            .into_box()
-            .into()
-    }));
-    let _joiner = thread::named("Alt client", || {
-        random_client(move |client| {
-            let app_sign_pk = unwrap!(app_sign_pk_rx.recv());
-            let mut rng = unwrap!(OsRng::new());
-
-            let mut permissions = BTreeMap::new();
-            let _ = permissions.insert(
-                User::Key(app_sign_pk),
-                PermissionSet::new().allow(Action::ManagePermissions),
-            );
-
-            let mut data = BTreeMap::new();
-            let _ = data.insert(
-                vec![1, 8, 3, 4],
-                Value {
-                    content: vec![1],
-                    entry_version: 1,
-                },
-            );
-
-            let mut owners = BTreeSet::new();
-            owners.insert(unwrap!(client.owner_key()));
-
-            let name: XorName = rng.gen();
-
-            let mdata = unwrap!(MutableData::new(name, DIR_TAG, permissions, data, owners));
-            let cl2 = client.clone();
-            let cl3 = client.clone();
-
-            client.list_auth_keys_and_version()
-                .then(move |res| {
-                    let (_, version) = unwrap!(res);
-                    cl2.ins_auth_key(app_sign_pk, version + 1)
-                })
-                .then(move |res| {
-                    unwrap!(res);
-                    cl3.put_mdata(mdata)
-                })
-                .map(move |()| unwrap!(name_tx.send(name)))
-                .map_err(|e| panic!("{:?}", e))
-        });
-    });
-    unwrap!(rx.recv());
-}
-
-// MD created by App1, with permission to insert by anyone and permission to
-// manage-permissions only for itself - should pass. App2 created via another
-// random client2 tries to insert (going via client2's MM) into MD of App1 -
-// should Pass. App1 should be able to read the data - should pass. App1 changes
-// permission to remove the anyone access - should pass. App2 tries to insert
-// another data in MD - should fail. App1 tries to get all data from MD - should
-// pass and should have no change (since App2 failed to insert)
-#[test]
-fn multiple_apps() {
-    let app1 = create_app();
-    let app2 = create_app();
-    let (tx, rx) = mpsc::channel();
-    let (name_tx, name_rx) = mpsc::channel();
-    let (entry_tx, entry_rx) = mpsc::channel();
-    let (mutate_again_tx, mutate_again_rx) = mpsc::channel();
-    let (final_check_tx, final_check_rx) = mpsc::channel();
-    unwrap!(app1.send(move |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
-        let sign_pk = unwrap!(client.public_signing_key());
-
-        let mut permissions = BTreeMap::new();
-        let _ = permissions.insert(User::Anyone, PermissionSet::new().allow(Action::Insert));
-        let _ = permissions.insert(
-            User::Key(sign_pk),
-            PermissionSet::new().allow(Action::ManagePermissions),
-        );
-
-        let mut owners = BTreeSet::new();
-        owners.insert(unwrap!(client.owner_key()));
-
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(
-            name,
-            DIR_TAG,
-            permissions,
-            BTreeMap::new(),
-            owners,
-        ));
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let cl4 = client.clone();
-        let name2 = name;
-        let name3 = name;
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                unwrap!(res);
-                unwrap!(name_tx.send(name));
-                let entry_key: Vec<u8> = unwrap!(entry_rx.recv());
-                cl2.get_mdata_value(name, DIR_TAG, entry_key.clone()).map(
-                    move |v| (v, entry_key),
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(
+                    &app,
+                    perm_set_h,
+                    MDataAction::ManagePermissions,
+                    ud,
+                    cb,
                 )
-            })
-            .then(move |res| {
-                let (value, entry_key) = unwrap!(res);
-                assert_eq!(
-                    value,
-                    Value {
-                        content: vec![8],
-                        entry_version: 1,
-                    }
-                );
-                cl3.del_mdata_user_permissions(name2, DIR_TAG, User::Anyone, 1)
-                    .map(move |()| entry_key)
-            })
-            .then(move |res| {
-                let entry_key = unwrap!(res);
-                unwrap!(mutate_again_tx.send(()));
-                unwrap!(final_check_rx.recv());
-                cl4.list_mdata_keys(name3, DIR_TAG).map(
-                    move |x| (x, entry_key),
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::NotSet);
+
+        // Allow Insert and ManagePermissions
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_allow(&app, perm_set_h, MDataAction::Insert, ud, cb)
+            }));
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_allow(&app, perm_set_h, MDataAction::ManagePermissions, ud, cb)
+            }))
+        };
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(
+                    &app,
+                    perm_set_h,
+                    MDataAction::ManagePermissions,
+                    ud,
+                    cb,
                 )
-            })
-            .then(move |res| -> Result<_, ()> {
-                let (keys, entry_key) = unwrap!(res);
-                assert_eq!(keys.len(), 1);
-                assert!(keys.contains(&entry_key));
-                unwrap!(tx.send(()));
-                Ok(())
-            })
-            .into_box()
-            .into()
-    }));
-    unwrap!(app2.send(move |client, _app_context| {
-        let name = unwrap!(name_rx.recv());
-        let entry_key = vec![1, 2, 3];
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
+    }
 
-        let mut actions = BTreeMap::new();
-        let _ = actions.insert(
-            entry_key.clone(),
-            EntryAction::Ins(Value {
-                content: vec![8],
-                entry_version: 1,
-            }),
-        );
+    // Create permissions
+    let perms_h: MDataPermissionsHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_permissions_new(&app, ud, cb))) };
 
-        let cl2 = client.clone();
-        client
-            .mutate_mdata_entries(name, DIR_TAG, actions)
-            .then(move |res| {
-                unwrap!(res);
-                unwrap!(entry_tx.send(entry_key));
-                unwrap!(mutate_again_rx.recv());
+    {
+        // Create permissions for anyone
+        let len: usize = unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permissions_insert(&app, perms_h, USER_ANYONE, perm_set_h, ud, cb)
+            }));
+            unwrap!(call_1(
+                |ud, cb| mdata_permissions_len(&app, perms_h, ud, cb),
+            ))
+        };
+        assert_eq!(len, 1);
 
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(
-                    vec![2, 2, 2],
-                    EntryAction::Ins(Value {
-                        content: vec![21],
-                        entry_version: 1,
-                    }),
-                );
+        let perm_set2_h = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permissions_get(&app, perms_h, USER_ANYONE, ud, cb)
+            }))
+        };
 
-                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
-            })
-            .then(move |res| -> Result<_, ()> {
-                match res {
-                    Ok(()) => panic!("It should fail"),
-                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
-                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
-                }
-                unwrap!(final_check_tx.send(()));
-                Ok(())
-            })
-            .into_box()
-            .into()
-    }));
-    unwrap!(rx.recv());
-}
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set2_h, MDataAction::Insert, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
 
-// MD created by App with itself allowed to manage-permissions. Insert
-// permission to allow a random-key to perform update operation - should
-// pass. Delete this permission without incrementing version of MD - should fail
-// version check. Querry the permissions list - should continue to have the
-// listed permission for the random-key. Querry the version of the MD in network
-// - should pass. Send request to delete that permission again with propely
-// incremented version from info from the fetched version - should pass. Querry
-// the permissions list - should no longer have the listed permission for the
-// random-key.
-#[test]
-fn permissions_and_version() {
-    let app = create_app();
-    run(&app, |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
-        let sign_pk = unwrap!(client.public_signing_key());
-        let (random_key, _) = sign::gen_keypair();
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set2_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::NotSet);
 
-        let mut permissions = BTreeMap::new();
-        let _ = permissions.insert(
-            User::Key(sign_pk),
-            PermissionSet::new().allow(Action::ManagePermissions),
-        );
+        let (tx, rx) = mpsc::channel::<Option<(SignKeyHandle, MDataPermissionSetHandle)>>();
+        let ud = sender_as_user_data(&tx);
 
-        let mut owners = BTreeSet::new();
-        owners.insert(unwrap!(client.owner_key()));
+        unsafe { mdata_permissions_for_each(&app, perms_h, ud, iter_perms_cb, iter_perms_done_cb) };
 
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(
-            name,
-            DIR_TAG,
-            permissions,
-            BTreeMap::new(),
-            owners,
-        ));
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let cl4 = client.clone();
-        let cl5 = client.clone();
-        let cl6 = client.clone();
-        let cl7 = client.clone();
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                unwrap!(res);
-                let permissions = PermissionSet::new().allow(Action::Update);
-                cl2.set_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), permissions, 1)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl3.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), 1)
-            })
-            .then(move |res| {
-                match res {
-                    Ok(()) => panic!("It should fail with invalid successor"),
-                    Err(CoreError::RoutingClientError(ClientError::InvalidSuccessor(..))) => (),
-                    Err(x) => panic!("Expected ClientError::InvalidSuccessor. Got {:?}", x),
-                }
-                cl4.list_mdata_permissions(name, DIR_TAG)
-            })
-            .then(move |res| {
-                let permissions = unwrap!(res);
-                assert_eq!(permissions.len(), 2);
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                        Action::ManagePermissions,
-                    ),
-                    Some(true)
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Insert),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Update),
-                    Some(true)
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Delete),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(random_key)))
-                        .is_allowed(Action::ManagePermissions),
-                    None
-                );
-                cl5.get_mdata_version(name, DIR_TAG)
-            })
-            .then(move |res| {
-                let v = unwrap!(res);
-                assert_eq!(v, 1);
-                cl6.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), v + 1)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl7.list_mdata_permissions(name, DIR_TAG)
-            })
-            .map(move |permissions| {
-                assert_eq!(permissions.len(), 1);
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                    None
-                );
-                assert_eq!(
-                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                        Action::ManagePermissions,
-                    ),
-                    Some(true)
+        let mut result: Vec<Option<(SignKeyHandle, MDataPermissionSetHandle)>> = Vec::new();
+        result.push(unwrap!(rx.recv_timeout(Duration::from_millis(1000))));
+        result.push(unwrap!(rx.recv_timeout(Duration::from_millis(1000))));
+        assert_eq!(result.len(), 2);
+    }
+
+    // Try to create an empty public MD
+    let md_info_pub_h: MDataInfoHandle = unsafe {
+        unwrap!(call_1(
+            |ud, cb| mdata_info_random_public(&app, 10000, ud, cb),
+        ))
+    };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| {
+            mdata_put(&app, md_info_pub_h, perms_h, ENTRIES_EMPTY, ud, cb)
+        }))
+    };
+
+    {
+        let read_perm_set_h: MDataPermissionSetHandle = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_list_user_permissions(&app, md_info_pub_h, USER_ANYONE, ud, cb)
+            }))
+        };
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, read_perm_set_h, MDataAction::Insert, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, read_perm_set_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::NotSet);
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(
+                    &app,
+                    read_perm_set_h,
+                    MDataAction::ManagePermissions,
+                    ud,
+                    cb,
+                )
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
+
+        // Create a new permissions set
+        let perm_set_new_h: MDataPermissionSetHandle =
+            unsafe { unwrap!(call_1(|ud, cb| mdata_permission_set_new(&app, ud, cb))) };
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| {
+                mdata_permission_set_allow(
+                    &app,
+                    perm_set_new_h,
+                    MDataAction::ManagePermissions,
+                    ud,
+                    cb,
+                )
+            }))
+        };
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(
+                    &app,
+                    perm_set_h,
+                    MDataAction::ManagePermissions,
+                    ud,
+                    cb,
+                )
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
+
+        let result = unsafe {
+            // Should fail due to invalid version
+            call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    md_info_pub_h,
+                    USER_ANYONE,
+                    perm_set_new_h,
+                    0,
+                    ud,
+                    cb,
                 );
             })
-            .map_err(|e| panic!("{:?}", e))
-    });
-}
+        };
 
-// The usual test to insert, update, delete and list all permissions. put in
-// some permissions, fetch (list) all of them, add some more, list again, delete
-// one or two, list again - all should pass and do the expected (i.e. after list
-// do assert that it contains all the expected stuff, don't just pass test if
-// the list was successful)
-#[test]
-fn permissions_crud() {
-    let app = create_app();
-    run(&app, |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
-        let sign_pk = unwrap!(client.public_signing_key());
-        let (random_key_a, _) = sign::gen_keypair();
-        let (random_key_b, _) = sign::gen_keypair();
+        match result {
+            Err(ERR_INVALID_SUCCESSOR) => (),
+            _ => panic!("Changed permissions without permission"),
+        };
 
-        let mut permissions = BTreeMap::new();
-        let _ = permissions.insert(
-            User::Key(sign_pk),
-            PermissionSet::new().allow(Action::ManagePermissions),
-        );
-
-        let mut owners = BTreeSet::new();
-        owners.insert(unwrap!(client.owner_key()));
-
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(
-            name,
-            DIR_TAG,
-            permissions,
-            BTreeMap::new(),
-            owners,
-        ));
-
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let cl4 = client.clone();
-        let cl5 = client.clone();
-        let cl6 = client.clone();
-        let cl7 = client.clone();
-        let cl8 = client.clone();
-        let cl9 = client.clone();
-        let cl10 = client.clone();
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                unwrap!(res);
-                let permissions = PermissionSet::new().allow(Action::Insert).allow(
-                    Action::Delete,
-                );
-                cl2.set_mdata_user_permissions(
-                    name,
-                    DIR_TAG,
-                    User::Key(random_key_a),
-                    permissions,
+        let result = unsafe {
+            // Should succeed
+            unwrap!(call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    md_info_pub_h,
+                    USER_ANYONE,
+                    perm_set_new_h,
                     1,
-                )
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl3.list_mdata_permissions(name, DIR_TAG)
-            })
-            .then(move |res| {
-                {
-                    let permissions = unwrap!(res);
-                    assert_eq!(permissions.len(), 2);
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                            Action::ManagePermissions,
-                        ),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Insert),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Delete),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::ManagePermissions),
-                        None
-                    );
-                }
+                    ud,
+                    cb,
+                );
+            }));
 
-                let permissions = PermissionSet::new().deny(Action::Insert);
-                cl4.set_mdata_user_permissions(
-                    name,
-                    DIR_TAG,
-                    User::Key(random_key_b),
-                    permissions,
-                    2,
-                )
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl5.list_mdata_permissions(name, DIR_TAG)
-            })
-            .then(move |res| {
-                {
-                    let permissions = unwrap!(res);
-                    assert_eq!(permissions.len(), 3);
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                            Action::ManagePermissions,
-                        ),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Insert),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::Delete),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_a)))
-                            .is_allowed(Action::ManagePermissions),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Insert),
-                        Some(false)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::ManagePermissions),
-                        None
-                    );
-                }
+            // Delete the permission set - should succeed
+            unwrap!(call_0(|ud, cb| {
+                mdata_del_user_permissions(&app, md_info_pub_h, USER_ANYONE, 2, ud, cb);
+            }));
 
-                let permissions = PermissionSet::new().deny(Action::Insert);
-                cl6.set_mdata_user_permissions(
-                    name,
-                    DIR_TAG,
-                    User::Key(random_key_b),
-                    permissions,
+            // Try to change permissions - should fail
+            call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    md_info_pub_h,
+                    USER_ANYONE,
+                    perm_set_new_h,
                     3,
-                )
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl7.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key_a), 4)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl8.list_mdata_permissions(name, DIR_TAG)
-            })
-            .then(move |res| {
-                {
-                    let permissions = unwrap!(res);
-                    assert_eq!(permissions.len(), 2);
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                            Action::ManagePermissions,
-                        ),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Insert),
-                        Some(false)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::ManagePermissions),
-                        None
-                    );
-                }
-
-                let permissions = PermissionSet::new().deny(Action::Insert).deny(
-                    Action::Delete,
+                    ud,
+                    cb,
                 );
-                cl9.set_mdata_user_permissions(
-                    name,
-                    DIR_TAG,
-                    User::Key(random_key_b),
-                    permissions,
-                    5,
-                )
             })
-            .then(move |res| {
-                unwrap!(res);
-                cl10.list_mdata_permissions(name, DIR_TAG)
-            })
-            .then(move |res| -> Result<_, ()> {
-                {
-                    let permissions = unwrap!(res);
-                    assert_eq!(permissions.len(), 2);
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
-                            Action::ManagePermissions,
-                        ),
-                        Some(true)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Insert),
-                        Some(false)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Update),
-                        None
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::Delete),
-                        Some(false)
-                    );
-                    assert_eq!(
-                        unwrap!(permissions.get(&User::Key(random_key_b)))
-                            .is_allowed(Action::ManagePermissions),
-                        None
-                    );
-                }
+        };
 
-                Ok(())
+        match result {
+            Err(ERR_ACCESS_DENIED) => (),
+            _ => panic!("Changed permissions without permission"),
+        };
+
+        let result: Result<MDataPermissionSetHandle, i32> = unsafe {
+            call_1(|ud, cb| {
+                mdata_list_user_permissions(&app, md_info_pub_h, USER_ANYONE, ud, cb)
             })
-            .map_err(|e| panic!("{:?}", e))
-    });
+        };
+
+        match result {
+            Err(ERR_NO_SUCH_KEY) => (),
+            _ => panic!("User permissions listed without key"),
+        }
+    }
+
+    extern "C" fn iter_perms_cb(
+        user_data: *mut c_void,
+        key_h: SignKeyHandle,
+        perm_set_h: MDataPermissionSetHandle,
+    ) {
+        assert_eq!(key_h, USER_ANYONE);
+
+        let result: Option<(SignKeyHandle, MDataPermissionSetHandle)> = Some((key_h, perm_set_h));
+        unsafe {
+            send_via_user_data(user_data, result);
+        }
+    }
+
+    extern "C" fn iter_perms_done_cb(user_data: *mut c_void, _res: FfiResult) {
+        unsafe {
+            send_via_user_data::<Option<(SignKeyHandle, MDataPermissionSetHandle)>>(
+                user_data,
+                None,
+            );
+        }
+    }
 }
 
-// The usual test to insert, update, delete and list all entry-keys/values. same
-// thing from `permissions_crud` with entry-key/value - the difference is that
-// after delete you should still get all the keys - delete does not actually
-// delete the entry, only blanks out the entry-value (null vector), the version
-// however should have been bumped - so check for those.
-#[test]
-fn entries_crud() {
-    let app = create_app();
-    run(&app, |client, _app_context| {
-        let mut rng = unwrap!(OsRng::new());
-        let sign_pk = unwrap!(client.public_signing_key());
-
-        let mut permissions = BTreeMap::new();
-        let _ = permissions.insert(
-            User::Key(sign_pk),
-            PermissionSet::new()
-                .allow(Action::Insert)
-                .allow(Action::Update)
-                .allow(Action::Delete),
-        );
-
-        let mut data = BTreeMap::new();
-        let _ = data.insert(
-            vec![0, 0, 1],
-            Value {
-                content: vec![1],
-                entry_version: 1,
-            },
-        );
-        let _ = data.insert(
-            vec![0, 1, 0],
-            Value {
-                content: vec![2, 8],
-                entry_version: 1,
-            },
-        );
-
-        let mut owners = BTreeSet::new();
-        owners.insert(unwrap!(client.owner_key()));
-
-        let name: XorName = rng.gen();
-        let mdata = unwrap!(MutableData::new(name, DIR_TAG, permissions, data, owners));
-
-        let cl2 = client.clone();
-        let cl3 = client.clone();
-        let cl4 = client.clone();
-        let cl5 = client.clone();
-        client
-            .put_mdata(mdata)
-            .then(move |res| {
-                unwrap!(res);
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(
-                    vec![0, 1, 1],
-                    EntryAction::Ins(Value {
-                        content: vec![2, 3, 17],
-                        entry_version: 1,
-                    }),
-                );
-                let _ = actions.insert(
-                    vec![0, 1, 0],
-                    EntryAction::Update(Value {
-                        content: vec![2, 8, 64],
-                        entry_version: 2,
-                    }),
-                );
-                let _ = actions.insert(vec![0, 0, 1], EntryAction::Del(2));
-                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl3.list_mdata_entries(name, DIR_TAG)
-            })
-            .then(move |res| {
-                let entries = unwrap!(res);
-                assert_eq!(entries.len(), 3);
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 0, 1])),
-                    Value {
-                        content: vec![],
-                        entry_version: 2,
-                    }
-                );
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 1, 0])),
-                    Value {
-                        content: vec![2, 8, 64],
-                        entry_version: 2,
-                    }
-                );
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 1, 1])),
-                    Value {
-                        content: vec![2, 3, 17],
-                        entry_version: 1,
-                    }
-                );
-                let mut actions = BTreeMap::new();
-                let _ = actions.insert(
-                    vec![1, 0, 0],
-                    EntryAction::Ins(Value {
-                        content: vec![4, 4, 4, 4],
-                        entry_version: 1,
-                    }),
-                );
-                let _ = actions.insert(
-                    vec![0, 1, 0],
-                    EntryAction::Update(Value {
-                        content: vec![64, 8, 1],
-                        entry_version: 3,
-                    }),
-                );
-                let _ = actions.insert(vec![0, 1, 1], EntryAction::Del(2));
-                cl4.mutate_mdata_entries(name, DIR_TAG, actions)
-            })
-            .then(move |res| {
-                unwrap!(res);
-                cl5.list_mdata_entries(name, DIR_TAG)
-            })
-            .then(|res| -> Result<_, ()> {
-                let entries = unwrap!(res);
-                assert_eq!(entries.len(), 4);
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 0, 1])),
-                    Value {
-                        content: vec![],
-                        entry_version: 2,
-                    }
-                );
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 1, 0])),
-                    Value {
-                        content: vec![64, 8, 1],
-                        entry_version: 3,
-                    }
-                );
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![0, 1, 1])),
-                    Value {
-                        content: vec![],
-                        entry_version: 2,
-                    }
-                );
-                assert_eq!(
-                    *unwrap!(entries.get(&vec![1, 0, 0])),
-                    Value {
-                        content: vec![4, 4, 4, 4],
-                        entry_version: 1,
-                    }
-                );
-                Ok(())
-            })
-            .map_err(|e| panic!("{:?}", e))
-    });
-}
-
-// Test `MutableData` functions from the FFI point of view.
+//  The usual test to insert, update, delete and list all entry-keys/values from the FFI point of
+//  view.
 #[test]
 fn entries_crud_ffi() {
-    use ffi::mdata_info::*;
-    use ffi::mutable_data::*;
-    use ffi::mutable_data::entry_actions::*;
-    use ffi::mutable_data::permissions::*;
-    use ffi::mutable_data::entries::*;
-    use ffi_utils::{FfiResult, vec_clone_from_raw_parts};
-    use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8, send_via_user_data,
-                                sender_as_user_data};
-    use object_cache::{MDataInfoHandle, MDataPermissionSetHandle, MDataPermissionsHandle};
-
     let app = create_app();
 
     const KEY: &[u8] = b"hello";
     const VALUE: &[u8] = b"world";
 
     // Create a permissions set
-    let perms_set_h: MDataPermissionSetHandle =
+    let perm_set_h: MDataPermissionSetHandle =
         unsafe { unwrap!(call_1(|ud, cb| mdata_permission_set_new(&app, ud, cb))) };
 
     unsafe {
         unwrap!(call_0(|ud, cb| {
-            mdata_permission_set_allow(&app, perms_set_h, MDataAction::Insert, ud, cb)
+            mdata_permission_set_allow(&app, perm_set_h, MDataAction::Insert, ud, cb)
         }))
     };
 
-    let permission_value: PermissionValue = unsafe {
-        unwrap!(call_1(|ud, cb| {
-            mdata_permission_set_is_allowed(&app, perms_set_h, MDataAction::Insert, ud, cb)
-        }))
-    };
-    assert_eq!(permission_value, PermissionValue::Allowed);
-
-    let permission_value: PermissionValue = unsafe {
-        unwrap!(call_1(|ud, cb| {
-            mdata_permission_set_is_allowed(&app, perms_set_h, MDataAction::Update, ud, cb)
-        }))
-    };
-    assert_eq!(permission_value, PermissionValue::NotSet);
-
-    // Create permissions for anyone
+    // Create permissions
     let perms_h: MDataPermissionsHandle =
         unsafe { unwrap!(call_1(|ud, cb| mdata_permissions_new(&app, ud, cb))) };
 
     unsafe {
         unwrap!(call_0(|ud, cb| {
-            mdata_permissions_insert(&app, perms_h, USER_ANYONE, perms_set_h, ud, cb)
+            mdata_permissions_insert(&app, perms_h, USER_ANYONE, perm_set_h, ud, cb)
         }))
-    };
+    }
 
     // Try to create an empty public MD
     let md_info_pub_h: MDataInfoHandle = unsafe {
@@ -1197,16 +386,25 @@ fn entries_crud_ffi() {
     }
 
     // Try to create a MD instance using the same name & a different type tag - it should pass.
-    let (xor_name, _type_tag): ([u8; XOR_NAME_LEN], u64) = unsafe {
+    let (xor_name, type_tag): ([u8; XOR_NAME_LEN], u64) = unsafe {
         unwrap!(call_2(|ud, cb| {
             mdata_info_extract_name_and_type_tag(&app, md_info_pub_h, ud, cb)
         }))
     };
+    assert_eq!(type_tag, 10000);
+
     let md_info_pub_2_h: MDataInfoHandle = unsafe {
         unwrap!(call_1(|ud, cb| {
             mdata_info_new_public(&app, &xor_name, 10001, ud, cb)
         }))
     };
+    let (xor_name2, type_tag2): ([u8; XOR_NAME_LEN], u64) = unsafe {
+        unwrap!(call_2(|ud, cb| {
+            mdata_info_extract_name_and_type_tag(&app, md_info_pub_2_h, ud, cb)
+        }))
+    };
+    assert_eq!(xor_name, xor_name2);
+    assert_eq!(type_tag2, 10001);
 
     unsafe {
         unwrap!(call_0(|ud, cb| {
@@ -1267,25 +465,34 @@ fn entries_crud_ffi() {
     };
     assert_eq!(ver, 0);
 
-    // Check permissions
-    let read_perms_h: MDataPermissionSetHandle = unsafe {
-        unwrap!(call_1(|ud, cb| {
-            mdata_list_user_permissions(&app, md_info_pub_h, USER_ANYONE, ud, cb)
-        }))
-    };
-    let permission_value: PermissionValue = unsafe {
-        unwrap!(call_1(|ud, cb| {
-            mdata_permission_set_is_allowed(&app, read_perms_h, MDataAction::Insert, ud, cb)
-        }))
-    };
-    assert_eq!(permission_value, PermissionValue::Allowed);
+    // Check that permissions on the public MD haven't changed
+    {
+        let read_perms_h: MDataPermissionsHandle = unsafe {
+            unwrap!(call_1(
+                |ud, cb| mdata_list_permissions(&app, md_info_pub_h, ud, cb),
+            ))
+        };
 
-    let permission_value: PermissionValue = unsafe {
-        unwrap!(call_1(|ud, cb| {
-            mdata_permission_set_is_allowed(&app, read_perms_h, MDataAction::Update, ud, cb)
-        }))
-    };
-    assert_eq!(permission_value, PermissionValue::NotSet);
+        let perm_set_h = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permissions_get(&app, read_perms_h, USER_ANYONE, ud, cb)
+            }))
+        };
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set_h, MDataAction::Insert, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::Allowed);
+
+        let permission_value: PermissionValue = unsafe {
+            unwrap!(call_1(|ud, cb| {
+                mdata_permission_set_is_allowed(&app, perm_set_h, MDataAction::Update, ud, cb)
+            }))
+        };
+        assert_eq!(permission_value, PermissionValue::NotSet);
+    }
 
     // Try to create a private MD
     let md_info_priv_h = unsafe {
@@ -1293,12 +500,26 @@ fn entries_crud_ffi() {
             |ud, cb| mdata_info_random_private(&app, 10001, ud, cb),
         ))
     };
+    let (_xor_name, type_tag): ([u8; XOR_NAME_LEN], u64) = unsafe {
+        unwrap!(call_2(|ud, cb| {
+            mdata_info_extract_name_and_type_tag(&app, md_info_priv_h, ud, cb)
+        }))
+    };
+    assert_eq!(type_tag, 10001);
 
     unsafe {
         unwrap!(call_0(|ud, cb| {
             mdata_put(&app, md_info_priv_h, perms_h, ENTRIES_EMPTY, ud, cb)
         }))
     };
+
+    // Check the version of a private MD
+    let ver: u64 = unsafe {
+        unwrap!(call_1(
+            |ud, cb| mdata_get_version(&app, md_info_priv_h, ud, cb),
+        ))
+    };
+    assert_eq!(ver, 0);
 
     // Try to add entries to a private MD
     let key_enc = unsafe {
@@ -1537,6 +758,22 @@ fn entries_crud_ffi() {
         } else {
             panic!("Failed test: expected Some(Vec<u8>), got None");
         }
+    }
+
+    // Free everything.
+    unsafe {
+        unwrap!(call_0(
+            |ud, cb| mdata_permission_set_free(&app, perm_set_h, ud, cb),
+        ));
+        unwrap!(call_0(
+            |ud, cb| mdata_permissions_free(&app, perms_h, ud, cb),
+        ));
+        unwrap!(call_0(
+            |ud, cb| mdata_info_free(&app, md_info_pub_h, ud, cb),
+        ));
+        unwrap!(call_0(
+            |ud, cb| mdata_info_free(&app, md_info_priv_h, ud, cb),
+        ));
     }
 
     extern "C" fn get_value_cb(

--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -489,6 +489,13 @@ mod tests {
             }))
         };
 
+        let size: Result<u64, i32> = unsafe { call_1(|ud, cb| file_size(&app, write_h, ud, cb)) };
+        match size {
+            Err(code) if code == AppError::InvalidFileMode.error_code() => (),
+            Err(x) => panic!("Unexpected: {:?}", x),
+            Ok(_) => panic!("Unexpected success"),
+        }
+
         let written_file: NativeFile = unsafe {
             unwrap!(call_0(|ud, cb| {
                 file_write(&app, write_h, content.as_ptr(), content.len(), ud, cb)
@@ -522,6 +529,8 @@ mod tests {
         };
         assert_eq!(version, 0);
 
+        let size0 = file.size();
+
         // Read the content
         let read_write_h = unsafe {
             unwrap!(call_1(|ud, cb| {
@@ -535,6 +544,9 @@ mod tests {
                 )
             }))
         };
+
+        let size1: u64 = unsafe { unwrap!(call_1(|ud, cb| file_size(&app, read_write_h, ud, cb))) };
+        assert_eq!(size0, size1);
 
         let retrieved_content = unsafe {
             unwrap!(call_vec_u8(|ud, cb| {
@@ -616,6 +628,9 @@ mod tests {
                 )
             }))
         };
+
+        let size: u64 = unsafe { unwrap!(call_1(|ud, cb| file_size(&app, read_h, ud, cb))) };
+        assert_eq!(size, orig_file.size());
 
         let retrieved_content = unsafe {
             unwrap!(call_vec_u8(|ud, cb| {

--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -389,6 +389,11 @@ mod tests {
         (app, container_info_h)
     }
 
+    // Test the basics of NFS.
+    // 1. Fetching a non-existing file should fail.
+    // 2. Create an empty file.
+    // 3. Fetch it back, assert that all file info is correct.
+    // 4. Delete the file.
     #[test]
     fn basics() {
         let (app, container_info_h) = setup();

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -436,6 +436,7 @@ mod tests {
     use test_utils::{create_app_with_access, run};
     use test_utils::gen_app_exchange_info;
 
+    // Test refreshing access info by fetching it from the network.
     #[test]
     fn refresh_access_info() {
         // Shared container
@@ -464,6 +465,7 @@ mod tests {
         });
     }
 
+    // Test fetching containers that an app has access to.
     #[test]
     fn get_access_info() {
         let mut container_permissions = HashMap::new();

--- a/safe_app/src/object_cache.rs
+++ b/safe_app/src/object_cache.rs
@@ -334,6 +334,7 @@ mod tests {
     use super::*;
     use rust_sodium::crypto::sign;
 
+    // Test resetting the object cache.
     #[test]
     fn reset() {
         let object_cache = ObjectCache::new();

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -26,7 +26,7 @@ use safe_core::ipc::req::{AuthReq, containers_from_repr_c, ffi};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::mpsc;
 
-/// Generates an `AppExchangeInfo` strucutre for a mock application
+/// Generates an `AppExchangeInfo` structure for a mock application
 pub fn gen_app_exchange_info() -> AppExchangeInfo {
     AppExchangeInfo {
         id: unwrap!(utils::generate_random_string(10)),

--- a/safe_app/src/tests.rs
+++ b/safe_app/src/tests.rs
@@ -1,0 +1,1120 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use errors::ERR_NO_SUCH_ENTRY;
+use futures::Future;
+use maidsafe_utilities::thread;
+use rand::{OsRng, Rng};
+use routing::{Action, ClientError, EntryAction, MutableData, PermissionSet, User, Value,
+              XOR_NAME_LEN, XorName};
+use rust_sodium::crypto::sign;
+use safe_core::{CoreError, DIR_TAG, FutureExt};
+use safe_core::utils::test_utils::random_client;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::mpsc;
+use std::time::Duration;
+
+// MD created by App. App lists its own sign_pk in owners field: Put should
+// fail - Rejected by MaidManagers. Should pass when it lists the owner's
+// sign_pk instead
+#[test]
+fn md_created_by_app_1() {
+    let app = create_app();
+    run(&app, |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+
+        let owners = btree_set![unwrap!(client.public_signing_key())];
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(
+            name,
+            DIR_TAG,
+            BTreeMap::new(),
+            BTreeMap::new(),
+            owners,
+        ));
+        let cl2 = client.clone();
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("Put should be rejected by MaidManagers"),
+                    Err(CoreError::RoutingClientError(ClientError::InvalidOwners)) => (),
+                    Err(x) => panic!("Expected ClientError::InvalidOwners. Got {:?}", x),
+                }
+                let mut owners = BTreeSet::new();
+                owners.insert(unwrap!(cl2.owner_key()));
+                let mdata = unwrap!(MutableData::new(
+                    name,
+                    DIR_TAG,
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                    owners,
+                ));
+                cl2.put_mdata(mdata)
+            })
+            .map_err(|e| panic!("{:?}", e))
+    });
+}
+
+// MD created by App properly: Should pass. App tries to change ownership -
+// Should Fail by MaidManagers. App creates its own account with the
+// maid-managers. Now it tries changing ownership by routing it through it's MM
+// instead of owners. It should still fail as DataManagers should enforce that
+// the request is coming from MM of the owner (listed in the owners field of the
+// stored MD).
+#[test]
+fn md_created_by_app_2() {
+    let app = create_app();
+    let (tx, rx) = mpsc::channel();
+    let (alt_client_tx, alt_client_rx) = mpsc::channel();
+    unwrap!(app.send(move |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+        let sign_pk = unwrap!(client.public_signing_key());
+
+        let mut permissions = BTreeMap::new();
+        let _ = permissions.insert(
+            User::Key(sign_pk),
+            PermissionSet::new().allow(Action::ManagePermissions),
+        );
+
+        let owners = btree_set![unwrap!(client.owner_key())];
+
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(
+            name,
+            DIR_TAG,
+            permissions,
+            BTreeMap::new(),
+            owners,
+        ));
+        let name2 = name;
+        let cl2 = client.clone();
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                unwrap!(res);
+                cl2.change_mdata_owner(name, DIR_TAG, sign_pk, 1)
+            })
+            .then(move |res| -> Result<_, ()> {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                unwrap!(alt_client_tx.send((name2, sign_pk)));
+                Ok(())
+            })
+            .into_box()
+            .into()
+    }));
+    let _joiner = thread::named("Alt client", || {
+        random_client(move |client| {
+            let (name, sign_pk) = unwrap!(alt_client_rx.recv());
+            let cl2 = client.clone();
+            let cl3 = client.clone();
+            client
+                .list_auth_keys_and_version()
+                .then(move |res| {
+                    let (_, version) = unwrap!(res);
+                    cl2.ins_auth_key(sign_pk, version + 1)
+                })
+                .then(move |res| {
+                    unwrap!(res);
+                    cl3.change_mdata_owner(name, DIR_TAG, sign_pk, 1)
+                })
+                .then(move |res| -> Result<(), ()> {
+                    match res {
+                        Ok(()) => panic!("It should fail"),
+                        Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                        Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                    }
+                    unwrap!(tx.send(()));
+                    Ok(())
+                })
+        });
+    });
+    unwrap!(rx.recv());
+}
+
+// MD created by owner and given to a permitted App. Owner has listed that app
+// is allowed to insert only. App tries to insert - should pass. App tries to
+// update - should fail. App tries to change permission to allow itself to
+// update - should fail to change permissions.
+#[test]
+fn md_created_by_app_3() {
+    let app = create_app();
+    let (tx, rx) = mpsc::channel();
+    let (app_sign_pk_tx, app_sign_pk_rx) = mpsc::channel();
+    let (name_tx, name_rx) = mpsc::channel();
+    unwrap!(app.send(move |client, _app_context| {
+        let sign_pk = unwrap!(client.public_signing_key());
+        unwrap!(app_sign_pk_tx.send(sign_pk));
+        let name: XorName = unwrap!(name_rx.recv());
+        let mut actions = BTreeMap::new();
+        let _ = actions.insert(
+            vec![1, 2, 3, 4],
+            EntryAction::Ins(Value {
+                content: vec![2, 3, 5],
+                entry_version: 1,
+            }),
+        );
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let name2 = name;
+        client
+            .mutate_mdata_entries(name, DIR_TAG, actions)
+            .then(move |res| {
+                unwrap!(res);
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(
+                    vec![1, 2, 3, 4],
+                    EntryAction::Update(Value {
+                        content: vec![2, 8, 5],
+                        entry_version: 2,
+                    }),
+                );
+                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                let user = User::Key(sign_pk);
+                let permissions = PermissionSet::new().allow(Action::Update);
+                cl3.set_mdata_user_permissions(name2, DIR_TAG, user, permissions, 2)
+            })
+            .then(move |res| -> Result<_, ()> {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                unwrap!(tx.send(()));
+                Ok(())
+            })
+            .into_box()
+            .into()
+    }));
+    let _joiner = thread::named("Alt client", || {
+        random_client(move |client| {
+            let app_sign_pk = unwrap!(app_sign_pk_rx.recv());
+            let mut rng = unwrap!(OsRng::new());
+
+            let mut permissions = BTreeMap::new();
+            let _ = permissions.insert(
+                User::Key(app_sign_pk),
+                PermissionSet::new().allow(Action::Insert),
+            );
+
+            let mut owners = BTreeSet::new();
+            owners.insert(unwrap!(client.owner_key()));
+
+            let name: XorName = rng.gen();
+
+            let mdata = unwrap!(MutableData::new(
+                name,
+                DIR_TAG,
+                permissions,
+                BTreeMap::new(),
+                owners,
+            ));
+            let cl2 = client.clone();
+            let cl3 = client.clone();
+
+            client.list_auth_keys_and_version()
+                .then(move |res| {
+                    let (_, version) = unwrap!(res);
+                    cl2.ins_auth_key(app_sign_pk, version + 1)
+                })
+                .then(move |res| {
+                    unwrap!(res);
+                    cl3.put_mdata(mdata)
+                })
+                .map(move |()| unwrap!(name_tx.send(name)))
+                .map_err(|e| panic!("{:?}", e))
+        });
+    });
+    unwrap!(rx.recv());
+}
+
+// MD created by owner and given to a permitted App. Owner has listed that app
+// is allowed to manage-permissions only. App tries to insert - should fail. App
+// tries to update - should fail. App tries to change permission to allow itself
+// to insert and delete - should pass to change permissions. Now App tires to
+// insert again - should pass. App tries to update. Should fail. App tries to
+// delete - should pass.
+#[test]
+fn md_created_by_app_4() {
+    let app = create_app();
+    let (tx, rx) = mpsc::channel();
+    let (app_sign_pk_tx, app_sign_pk_rx) = mpsc::channel();
+    let (name_tx, name_rx) = mpsc::channel();
+    unwrap!(app.send(move |client, _app_context| {
+        let sign_pk = unwrap!(client.public_signing_key());
+        unwrap!(app_sign_pk_tx.send(sign_pk));
+        let name: XorName = unwrap!(name_rx.recv());
+        let mut actions = BTreeMap::new();
+        let _ = actions.insert(
+            vec![1, 2, 3, 4],
+            EntryAction::Ins(Value {
+                content: vec![2, 3, 5],
+                entry_version: 1,
+            }),
+        );
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let cl4 = client.clone();
+        let cl5 = client.clone();
+        let cl6 = client.clone();
+        let name2 = name;
+        let name3 = name;
+        let name4 = name;
+        let name5 = name;
+        client.mutate_mdata_entries(name, DIR_TAG, actions)
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(vec![1, 8, 3, 4],
+                                       EntryAction::Update(Value {
+                                           content: vec![2, 8, 5],
+                                           entry_version: 2,
+                                       }));
+                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                let user = User::Key(sign_pk);
+                let permissions = PermissionSet::new().allow(Action::Insert).allow(Action::Delete);
+                cl3.set_mdata_user_permissions(name2, DIR_TAG, user,
+                                               permissions, 1)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(vec![1, 2, 3, 4],
+                                       EntryAction::Ins(Value {
+                                           content: vec![2, 3, 5],
+                                           entry_version: 1,
+                                       }));
+                cl4.mutate_mdata_entries(name3, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(vec![1, 2, 3, 4],
+                                       EntryAction::Update(Value {
+                                           content: vec![2, 8, 5],
+                                           entry_version: 2,
+                                       }));
+                cl5.mutate_mdata_entries(name4, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(vec![1, 2, 3, 4],
+                                       EntryAction::Del(2));
+                cl6.mutate_mdata_entries(name5, DIR_TAG, actions)
+            })
+            .map(move |()| unwrap!(tx.send(())))
+            .map_err(|e| panic!("{:?}", e))
+            .into_box()
+            .into()
+    }));
+    let _joiner = thread::named("Alt client", || {
+        random_client(move |client| {
+            let app_sign_pk = unwrap!(app_sign_pk_rx.recv());
+            let mut rng = unwrap!(OsRng::new());
+
+            let mut permissions = BTreeMap::new();
+            let _ = permissions.insert(
+                User::Key(app_sign_pk),
+                PermissionSet::new().allow(Action::ManagePermissions),
+            );
+
+            let mut data = BTreeMap::new();
+            let _ = data.insert(
+                vec![1, 8, 3, 4],
+                Value {
+                    content: vec![1],
+                    entry_version: 1,
+                },
+            );
+
+            let mut owners = BTreeSet::new();
+            owners.insert(unwrap!(client.owner_key()));
+
+            let name: XorName = rng.gen();
+
+            let mdata = unwrap!(MutableData::new(name, DIR_TAG, permissions, data, owners));
+            let cl2 = client.clone();
+            let cl3 = client.clone();
+
+            client.list_auth_keys_and_version()
+                .then(move |res| {
+                    let (_, version) = unwrap!(res);
+                    cl2.ins_auth_key(app_sign_pk, version + 1)
+                })
+                .then(move |res| {
+                    unwrap!(res);
+                    cl3.put_mdata(mdata)
+                })
+                .map(move |()| unwrap!(name_tx.send(name)))
+                .map_err(|e| panic!("{:?}", e))
+        });
+    });
+    unwrap!(rx.recv());
+}
+
+// MD created by App1, with permission to insert by anyone and permission to
+// manage-permissions only for itself - should pass. App2 created via another
+// random client2 tries to insert (going via client2's MM) into MD of App1 -
+// should Pass. App1 should be able to read the data - should pass. App1 changes
+// permission to remove the anyone access - should pass. App2 tries to insert
+// another data in MD - should fail. App1 tries to get all data from MD - should
+// pass and should have no change (since App2 failed to insert)
+#[test]
+fn multiple_apps() {
+    let app1 = create_app();
+    let app2 = create_app();
+    let (tx, rx) = mpsc::channel();
+    let (name_tx, name_rx) = mpsc::channel();
+    let (entry_tx, entry_rx) = mpsc::channel();
+    let (mutate_again_tx, mutate_again_rx) = mpsc::channel();
+    let (final_check_tx, final_check_rx) = mpsc::channel();
+    unwrap!(app1.send(move |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+        let sign_pk = unwrap!(client.public_signing_key());
+
+        let mut permissions = BTreeMap::new();
+        let _ = permissions.insert(User::Anyone, PermissionSet::new().allow(Action::Insert));
+        let _ = permissions.insert(
+            User::Key(sign_pk),
+            PermissionSet::new().allow(Action::ManagePermissions),
+        );
+
+        let mut owners = BTreeSet::new();
+        owners.insert(unwrap!(client.owner_key()));
+
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(
+            name,
+            DIR_TAG,
+            permissions,
+            BTreeMap::new(),
+            owners,
+        ));
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let cl4 = client.clone();
+        let name2 = name;
+        let name3 = name;
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                unwrap!(res);
+                unwrap!(name_tx.send(name));
+                let entry_key: Vec<u8> = unwrap!(entry_rx.recv());
+                cl2.get_mdata_value(name, DIR_TAG, entry_key.clone()).map(
+                    move |v| (v, entry_key),
+                )
+            })
+            .then(move |res| {
+                let (value, entry_key) = unwrap!(res);
+                assert_eq!(
+                    value,
+                    Value {
+                        content: vec![8],
+                        entry_version: 1,
+                    }
+                );
+                cl3.del_mdata_user_permissions(name2, DIR_TAG, User::Anyone, 1)
+                    .map(move |()| entry_key)
+            })
+            .then(move |res| {
+                let entry_key = unwrap!(res);
+                unwrap!(mutate_again_tx.send(()));
+                unwrap!(final_check_rx.recv());
+                cl4.list_mdata_keys(name3, DIR_TAG).map(
+                    move |x| (x, entry_key),
+                )
+            })
+            .then(move |res| -> Result<_, ()> {
+                let (keys, entry_key) = unwrap!(res);
+                assert_eq!(keys.len(), 1);
+                assert!(keys.contains(&entry_key));
+                unwrap!(tx.send(()));
+                Ok(())
+            })
+            .into_box()
+            .into()
+    }));
+    unwrap!(app2.send(move |client, _app_context| {
+        let name = unwrap!(name_rx.recv());
+        let entry_key = vec![1, 2, 3];
+
+        let mut actions = BTreeMap::new();
+        let _ = actions.insert(
+            entry_key.clone(),
+            EntryAction::Ins(Value {
+                content: vec![8],
+                entry_version: 1,
+            }),
+        );
+
+        let cl2 = client.clone();
+        client
+            .mutate_mdata_entries(name, DIR_TAG, actions)
+            .then(move |res| {
+                unwrap!(res);
+                unwrap!(entry_tx.send(entry_key));
+                unwrap!(mutate_again_rx.recv());
+
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(
+                    vec![2, 2, 2],
+                    EntryAction::Ins(Value {
+                        content: vec![21],
+                        entry_version: 1,
+                    }),
+                );
+
+                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
+            })
+            .then(move |res| -> Result<_, ()> {
+                match res {
+                    Ok(()) => panic!("It should fail"),
+                    Err(CoreError::RoutingClientError(ClientError::AccessDenied)) => (),
+                    Err(x) => panic!("Expected ClientError::AccessDenied. Got {:?}", x),
+                }
+                unwrap!(final_check_tx.send(()));
+                Ok(())
+            })
+            .into_box()
+            .into()
+    }));
+    unwrap!(rx.recv());
+}
+
+// MD created by App with itself allowed to manage-permissions. Insert
+// permission to allow a random-key to perform update operation - should
+// pass. Delete this permission without incrementing version of MD - should fail
+// version check. Querry the permissions list - should continue to have the
+// listed permission for the random-key. Querry the version of the MD in network
+// - should pass. Send request to delete that permission again with propely
+// incremented version from info from the fetched version - should pass. Querry
+// the permissions list - should no longer have the listed permission for the
+// random-key.
+#[test]
+fn permissions_and_version() {
+    let app = create_app();
+    run(&app, |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+        let sign_pk = unwrap!(client.public_signing_key());
+        let (random_key, _) = sign::gen_keypair();
+
+        let mut permissions = BTreeMap::new();
+        let _ = permissions.insert(
+            User::Key(sign_pk),
+            PermissionSet::new().allow(Action::ManagePermissions),
+        );
+
+        let mut owners = BTreeSet::new();
+        owners.insert(unwrap!(client.owner_key()));
+
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(
+            name,
+            DIR_TAG,
+            permissions,
+            BTreeMap::new(),
+            owners,
+        ));
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let cl4 = client.clone();
+        let cl5 = client.clone();
+        let cl6 = client.clone();
+        let cl7 = client.clone();
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                unwrap!(res);
+                let permissions = PermissionSet::new().allow(Action::Update);
+                cl2.set_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), permissions, 1)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl3.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), 1)
+            })
+            .then(move |res| {
+                match res {
+                    Ok(()) => panic!("It should fail with invalid successor"),
+                    Err(CoreError::RoutingClientError(ClientError::InvalidSuccessor(..))) => (),
+                    Err(x) => panic!("Expected ClientError::InvalidSuccessor. Got {:?}", x),
+                }
+                cl4.list_mdata_permissions(name, DIR_TAG)
+            })
+            .then(move |res| {
+                let permissions = unwrap!(res);
+                assert_eq!(permissions.len(), 2);
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                        Action::ManagePermissions,
+                    ),
+                    Some(true)
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Insert),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Update),
+                    Some(true)
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(random_key))).is_allowed(Action::Delete),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(random_key)))
+                        .is_allowed(Action::ManagePermissions),
+                    None
+                );
+                cl5.get_mdata_version(name, DIR_TAG)
+            })
+            .then(move |res| {
+                let v = unwrap!(res);
+                assert_eq!(v, 1);
+                cl6.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key), v + 1)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl7.list_mdata_permissions(name, DIR_TAG)
+            })
+            .map(move |permissions| {
+                assert_eq!(permissions.len(), 1);
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                    None
+                );
+                assert_eq!(
+                    unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                        Action::ManagePermissions,
+                    ),
+                    Some(true)
+                );
+            })
+            .map_err(|e| panic!("{:?}", e))
+    });
+}
+
+// The usual test to insert, update, delete and list all permissions. Put in
+// some permissions, fetch (list) all of them, add some more, list again, delete
+// one or two, list again - all should pass and do the expected (i.e. after list
+// do assert that it contains all the expected stuff, don't just pass test if
+// the list was successful)
+#[test]
+fn permissions_crud() {
+    let app = create_app();
+    run(&app, |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+        let sign_pk = unwrap!(client.public_signing_key());
+        let (random_key_a, _) = sign::gen_keypair();
+        let (random_key_b, _) = sign::gen_keypair();
+
+        let mut permissions = BTreeMap::new();
+        let _ = permissions.insert(
+            User::Key(sign_pk),
+            PermissionSet::new().allow(Action::ManagePermissions),
+        );
+
+        let mut owners = BTreeSet::new();
+        owners.insert(unwrap!(client.owner_key()));
+
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(
+            name,
+            DIR_TAG,
+            permissions,
+            BTreeMap::new(),
+            owners,
+        ));
+
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let cl4 = client.clone();
+        let cl5 = client.clone();
+        let cl6 = client.clone();
+        let cl7 = client.clone();
+        let cl8 = client.clone();
+        let cl9 = client.clone();
+        let cl10 = client.clone();
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                unwrap!(res);
+                let permissions = PermissionSet::new().allow(Action::Insert).allow(
+                    Action::Delete,
+                );
+                cl2.set_mdata_user_permissions(
+                    name,
+                    DIR_TAG,
+                    User::Key(random_key_a),
+                    permissions,
+                    1,
+                )
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl3.list_mdata_permissions(name, DIR_TAG)
+            })
+            .then(move |res| {
+                {
+                    let permissions = unwrap!(res);
+                    assert_eq!(permissions.len(), 2);
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                            Action::ManagePermissions,
+                        ),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Insert),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Delete),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::ManagePermissions),
+                        None
+                    );
+                }
+
+                let permissions = PermissionSet::new().deny(Action::Insert);
+                cl4.set_mdata_user_permissions(
+                    name,
+                    DIR_TAG,
+                    User::Key(random_key_b),
+                    permissions,
+                    2,
+                )
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl5.list_mdata_permissions(name, DIR_TAG)
+            })
+            .then(move |res| {
+                {
+                    let permissions = unwrap!(res);
+                    assert_eq!(permissions.len(), 3);
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                            Action::ManagePermissions,
+                        ),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Insert),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::Delete),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_a)))
+                            .is_allowed(Action::ManagePermissions),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Insert),
+                        Some(false)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::ManagePermissions),
+                        None
+                    );
+                }
+
+                let permissions = PermissionSet::new().deny(Action::Insert);
+                cl6.set_mdata_user_permissions(
+                    name,
+                    DIR_TAG,
+                    User::Key(random_key_b),
+                    permissions,
+                    3,
+                )
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl7.del_mdata_user_permissions(name, DIR_TAG, User::Key(random_key_a), 4)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl8.list_mdata_permissions(name, DIR_TAG)
+            })
+            .then(move |res| {
+                {
+                    let permissions = unwrap!(res);
+                    assert_eq!(permissions.len(), 2);
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                            Action::ManagePermissions,
+                        ),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Insert),
+                        Some(false)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::ManagePermissions),
+                        None
+                    );
+                }
+
+                let permissions = PermissionSet::new().deny(Action::Insert).deny(
+                    Action::Delete,
+                );
+                cl9.set_mdata_user_permissions(
+                    name,
+                    DIR_TAG,
+                    User::Key(random_key_b),
+                    permissions,
+                    5,
+                )
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl10.list_mdata_permissions(name, DIR_TAG)
+            })
+            .then(move |res| -> Result<_, ()> {
+                {
+                    let permissions = unwrap!(res);
+                    assert_eq!(permissions.len(), 2);
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Insert),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(Action::Delete),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(sign_pk))).is_allowed(
+                            Action::ManagePermissions,
+                        ),
+                        Some(true)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Insert),
+                        Some(false)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Update),
+                        None
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::Delete),
+                        Some(false)
+                    );
+                    assert_eq!(
+                        unwrap!(permissions.get(&User::Key(random_key_b)))
+                            .is_allowed(Action::ManagePermissions),
+                        None
+                    );
+                }
+
+                Ok(())
+            })
+            .map_err(|e| panic!("{:?}", e))
+    });
+}
+
+// The usual test to insert, update, delete and list all entry-keys/values. Same
+// thing from `permissions_crud` with entry-key/value - the difference is that
+// after delete you should still get all the keys - delete does not actually
+// delete the entry, only blanks out the entry-value (null vector), the version
+// however should have been bumped - so check for those.
+#[test]
+fn entries_crud() {
+    let app = create_app();
+    run(&app, |client, _app_context| {
+        let mut rng = unwrap!(OsRng::new());
+        let sign_pk = unwrap!(client.public_signing_key());
+
+        let mut permissions = BTreeMap::new();
+        let _ = permissions.insert(
+            User::Key(sign_pk),
+            PermissionSet::new()
+                .allow(Action::Insert)
+                .allow(Action::Update)
+                .allow(Action::Delete),
+        );
+
+        let mut data = BTreeMap::new();
+        let _ = data.insert(
+            vec![0, 0, 1],
+            Value {
+                content: vec![1],
+                entry_version: 1,
+            },
+        );
+        let _ = data.insert(
+            vec![0, 1, 0],
+            Value {
+                content: vec![2, 8],
+                entry_version: 1,
+            },
+        );
+
+        let mut owners = BTreeSet::new();
+        owners.insert(unwrap!(client.owner_key()));
+
+        let name: XorName = rng.gen();
+        let mdata = unwrap!(MutableData::new(name, DIR_TAG, permissions, data, owners));
+
+        let cl2 = client.clone();
+        let cl3 = client.clone();
+        let cl4 = client.clone();
+        let cl5 = client.clone();
+        client
+            .put_mdata(mdata)
+            .then(move |res| {
+                unwrap!(res);
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(
+                    vec![0, 1, 1],
+                    EntryAction::Ins(Value {
+                        content: vec![2, 3, 17],
+                        entry_version: 1,
+                    }),
+                );
+                let _ = actions.insert(
+                    vec![0, 1, 0],
+                    EntryAction::Update(Value {
+                        content: vec![2, 8, 64],
+                        entry_version: 2,
+                    }),
+                );
+                let _ = actions.insert(vec![0, 0, 1], EntryAction::Del(2));
+                cl2.mutate_mdata_entries(name, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl3.list_mdata_entries(name, DIR_TAG)
+            })
+            .then(move |res| {
+                let entries = unwrap!(res);
+                assert_eq!(entries.len(), 3);
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 0, 1])),
+                    Value {
+                        content: vec![],
+                        entry_version: 2,
+                    }
+                );
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 1, 0])),
+                    Value {
+                        content: vec![2, 8, 64],
+                        entry_version: 2,
+                    }
+                );
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 1, 1])),
+                    Value {
+                        content: vec![2, 3, 17],
+                        entry_version: 1,
+                    }
+                );
+                let mut actions = BTreeMap::new();
+                let _ = actions.insert(
+                    vec![1, 0, 0],
+                    EntryAction::Ins(Value {
+                        content: vec![4, 4, 4, 4],
+                        entry_version: 1,
+                    }),
+                );
+                let _ = actions.insert(
+                    vec![0, 1, 0],
+                    EntryAction::Update(Value {
+                        content: vec![64, 8, 1],
+                        entry_version: 3,
+                    }),
+                );
+                let _ = actions.insert(vec![0, 1, 1], EntryAction::Del(2));
+                cl4.mutate_mdata_entries(name, DIR_TAG, actions)
+            })
+            .then(move |res| {
+                unwrap!(res);
+                cl5.list_mdata_entries(name, DIR_TAG)
+            })
+            .then(|res| -> Result<_, ()> {
+                let entries = unwrap!(res);
+                assert_eq!(entries.len(), 4);
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 0, 1])),
+                    Value {
+                        content: vec![],
+                        entry_version: 2,
+                    }
+                );
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 1, 0])),
+                    Value {
+                        content: vec![64, 8, 1],
+                        entry_version: 3,
+                    }
+                );
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![0, 1, 1])),
+                    Value {
+                        content: vec![],
+                        entry_version: 2,
+                    }
+                );
+                assert_eq!(
+                    *unwrap!(entries.get(&vec![1, 0, 0])),
+                    Value {
+                        content: vec![4, 4, 4, 4],
+                        entry_version: 1,
+                    }
+                );
+                Ok(())
+            })
+            .map_err(|e| panic!("{:?}", e))
+    });
+}

--- a/safe_authenticator/src/ffi/logging.rs
+++ b/safe_authenticator/src/ffi/logging.rs
@@ -78,12 +78,27 @@ pub unsafe extern "C" fn auth_output_log_path(
 mod tests {
     use super::*;
     use config_file_handler::current_bin_dir;
-    use ffi_utils::test_utils::call_0;
+    use ffi_utils::test_utils::{call_0, call_1};
     use std::env;
     use std::fs::{self, File};
     use std::io::Read;
     use std::thread;
     use std::time::Duration;
+
+    // Test path where log file is created.
+    #[test]
+    fn output_log_path() {
+        let name = "_test path";
+        let path_str = unwrap!(CString::new(name));
+
+        let path: String = unsafe {
+            unwrap!(call_1(
+                |ud, cb| auth_output_log_path(path_str.as_ptr(), ud, cb),
+            ))
+        };
+
+        assert!(path.contains(name));
+    }
 
     // Test logging errors to file.
     #[test]

--- a/safe_authenticator/src/ffi/logging.rs
+++ b/safe_authenticator/src/ffi/logging.rs
@@ -85,6 +85,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    // Test logging errors to file.
     #[test]
     fn file_logging() {
         setup_log_config();

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -185,6 +185,7 @@ mod tests {
     use std::ffi::CString;
     use std::os::raw::c_void;
 
+    // Test creating an account and logging in.
     #[test]
     fn create_account_and_login() {
         let acc_locator = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
@@ -227,6 +228,7 @@ mod tests {
         }
     }
 
+    // Test disconnection and reconnection with the authenticator.
     #[cfg(all(test, feature = "use-mock-routing"))]
     #[test]
     fn network_status_callback() {
@@ -301,6 +303,7 @@ mod tests {
         }
     }
 
+    // Test account usage statistics before and after a mutation.
     #[test]
     fn account_info() {
         let acc_locator = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));

--- a/safe_authenticator/src/std_dirs.rs
+++ b/safe_authenticator/src/std_dirs.rs
@@ -170,6 +170,7 @@ mod tests {
     use futures::Future;
     use test_utils::{create_account_and_login, run};
 
+    // Test creation of default dirs.
     #[test]
     fn creates_default_dirs() {
         let auth = create_account_and_login();
@@ -199,7 +200,7 @@ mod tests {
                         DEFAULT_PRIVATE_DIRS.iter(),
                     )
                     {
-                        // let's check whether all our entires have been created properly
+                        // let's check whether all our entries have been created properly
                         assert!(mdata_entries.contains_key(*key));
                     }
 

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -20,8 +20,6 @@ mod share_mdata;
 mod utils;
 
 use self::utils::{ChannelType, create_containers_req, decode_ipc_msg, err_cb, unregistered_cb};
-#[cfg(feature = "use-mock-routing")]
-use Authenticator;
 use access_container as access_container_tools;
 use app_container;
 use config::{self, KEY_APPS};
@@ -31,20 +29,10 @@ use ffi_utils::{ReprC, StringError, base64_encode, from_c_str};
 use ffi_utils::test_utils::{call_1, call_vec, sender_as_user_data};
 use futures::{Future, future};
 use ipc::{encode_auth_resp, encode_containers_resp, encode_unregistered_resp};
-#[cfg(feature = "use-mock-routing")]
-use routing::{ClientError, Request, Response, User};
-#[cfg(feature = "use-mock-routing")]
-use safe_core::CoreError;
-#[cfg(feature = "use-mock-routing")]
-use safe_core::MockRouting;
 use safe_core::ipc::{self, AuthReq, BootstrapConfig, ContainersReq, IpcError, IpcMsg, IpcReq,
                      IpcResp, Permission};
 use safe_core::ipc::req::ffi::AppExchangeInfo as FfiAppExchangeInfo;
 use safe_core::mdata_info;
-#[cfg(feature = "use-mock-routing")]
-use safe_core::nfs::NfsError;
-#[cfg(feature = "use-mock-routing")]
-use safe_core::utils::generate_random_string;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::mpsc;
@@ -52,9 +40,394 @@ use std::time::Duration;
 use std_dirs::{DEFAULT_PRIVATE_DIRS, DEFAULT_PUBLIC_DIRS};
 use test_utils::{access_container, compare_access_container_entries, create_account_and_login,
                  rand_app, register_app, revoke, run};
-#[cfg(feature = "use-mock-routing")]
-use test_utils::create_account_and_login_with_hook;
 use tiny_keccak::sha3_256;
+
+#[cfg(feature = "use-mock-routing")]
+mod mock_routing {
+    use super::utils::create_containers_req;
+    use Authenticator;
+    use access_container as access_container_tools;
+    use errors::AuthError;
+    use futures::Future;
+    use routing::{ClientError, Request, Response, User};
+    use safe_core::CoreError;
+    use safe_core::MockRouting;
+    use safe_core::ipc::AuthReq;
+    use safe_core::nfs::NfsError;
+    use safe_core::utils::generate_random_string;
+    use std_dirs::{DEFAULT_PRIVATE_DIRS, DEFAULT_PUBLIC_DIRS};
+    use test_utils::{access_container, create_account_and_login_with_hook, rand_app, register_app,
+                     run};
+
+    // Test operation recovery for std dirs creation.
+    // 1. Try to create a new user's account using `safe_authenticator::Authenticator::create_acc`
+    // 2. Simulate a network disconnection [1] for a randomly selected `PutMData` operation
+    //    with a type_tag == `safe_core::DIR_TAG` (in the range from 3rd request to
+    //    `safe_core::nfs::DEFAULT_PRIVATE_DIRS.len()`). This will meddle with creation of
+    //    default directories.
+    // 3. Try to log in using the same credentials that have been provided for `create_acc`.
+    //    The log in operation should be successful.
+    // 4. Check that after logging in the remaining default directories have been created
+    //    (= operation recovery worked after log in)
+    // 5. Check the access container entry in the user's config root - it must be accessible
+    #[cfg(feature = "use-mock-routing")]
+    #[test]
+    fn std_dirs_recovery() {
+        use safe_core::DIR_TAG;
+
+        // Add a request hook to forbid root dir modification. In this case
+        // account creation operation will be failed, but login still should
+        // be possible afterwards.
+        let locator = unwrap!(generate_random_string(10));
+        let password = unwrap!(generate_random_string(10));
+        let invitation = unwrap!(generate_random_string(10));
+
+        {
+            let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+                let mut put_mdata_counter = 0;
+
+                routing.set_request_hook(move |req| {
+                    match *req {
+                        Request::PutMData { ref data, msg_id, .. } if data.tag() == DIR_TAG => {
+                            put_mdata_counter += 1;
+
+                            if put_mdata_counter > 4 {
+                                Some(Response::PutMData {
+                                    msg_id,
+                                    res: Err(ClientError::LowBalance),
+                                })
+                            } else {
+                                None
+                            }
+                        }
+                        // Pass-through
+                        _ => None,
+                    }
+                });
+                routing
+            };
+
+            let authenticator = Authenticator::create_acc_with_hook(
+                locator.clone(),
+                password.clone(),
+                invitation,
+                |_| (),
+                routing_hook,
+            );
+
+            // This operation should fail
+            match authenticator {
+                Err(AuthError::NfsError(NfsError::CoreError(CoreError::RoutingClientError(
+                    ClientError::LowBalance)))) => (),
+                Err(x) => panic!("Unexpected error {:?}", x),
+                Ok(_) => panic!("Expected an error"),
+            }
+        }
+
+        // Log in using the same credentials
+        let authenticator = unwrap!(Authenticator::login(locator, password, |_| ()));
+
+        // Make sure that all default directories have been created after log in.
+        let std_dir_names: Vec<_> = DEFAULT_PRIVATE_DIRS
+            .iter()
+            .cloned()
+            .chain(DEFAULT_PUBLIC_DIRS.iter().cloned())
+            .collect();
+
+        // Verify that the access container has been created and
+        // fetch the entries of the root authenticator entry.
+        let (_entry_version, entries) = run(&authenticator, |client| {
+            access_container_tools::fetch_authenticator_entry(client).map_err(AuthError::from)
+        });
+
+        // Verify that all the std dirs are there.
+        for name in std_dir_names {
+            assert!(entries.contains_key(name));
+        }
+    }
+
+    // Ensure that users can log in with low account balance.
+    #[cfg(feature = "use-mock-routing")]
+    #[test]
+    fn login_with_low_balance() {
+        // Register a hook prohibiting mutations and login
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            routing.set_request_hook(move |req| {
+                match *req {
+                    Request::PutIData { msg_id, .. } => {
+                        Some(Response::PutIData {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::PutMData { msg_id, .. } => {
+                        Some(Response::PutMData {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::MutateMDataEntries { msg_id, .. } => {
+                        Some(Response::MutateMDataEntries {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::SetMDataUserPermissions { msg_id, .. } => {
+                        Some(Response::SetMDataUserPermissions {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::DelMDataUserPermissions { msg_id, .. } => {
+                        Some(Response::DelMDataUserPermissions {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::ChangeMDataOwner { msg_id, .. } => {
+                        Some(Response::ChangeMDataOwner {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::InsAuthKey { msg_id, .. } => {
+                        Some(Response::InsAuthKey {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    Request::DelAuthKey { msg_id, .. } => {
+                        Some(Response::DelAuthKey {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+
+        // Make sure we can log in
+        let _authenticator = create_account_and_login_with_hook(routing_hook);
+    }
+
+    // Test operation recovery for app authentication.
+    //
+    // 1. Create a test app and try to authenticate it (with `app_container` set to true).
+    //
+    // 2. Simulate a network failure after the `mutate_mdata_entries` operation (relating to the
+    //    addition of the app to the user's config dir) - it should leave the app in the
+    //    `Revoked` state (as it is listen in the config root, but not in the access
+    //    container)
+    // 3. Try to authenticate the app again, it should continue without errors
+    //
+    // 4. Simulate a network failure after the `ins_auth_key` operation.
+    //    The authentication op should fail.
+    // 5. Try to authenticate the app again, it should continue without errors
+    //
+    // 6. Simulate a network failure for the `set_mdata_user_permissions` operation
+    //    (relating to the app's container - so that it will be created successfuly, but fail
+    //    at the permissions set stage).
+    // 7. Try to authenticate the app again, it should continue without errors.
+    //
+    // 8. Simulate a network failure for the `mutate_mdata_entries` operation
+    //    (relating to update of the access container).
+    // 9. Try to authenticate the app again, it should succeed now.
+    //
+    // 10. Check that the app's container has been created.
+    // 11. Check that the app's container has required permissions.
+    // 12. Check that the app's container is listed in the access container entry for
+    //     the app.
+    #[cfg(feature = "use-mock-routing")]
+    #[test]
+    fn app_authentication_recovery() {
+        let locator = unwrap!(generate_random_string(10));
+        let password = unwrap!(generate_random_string(10));
+        let invitation = unwrap!(generate_random_string(10));
+
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            routing.set_request_hook(move |req| {
+                match *req {
+                    // Simulate a network failure after
+                    // the `mutate_mdata_entries` operation (relating to
+                    // the addition of the app to the user's config dir)
+                    Request::InsAuthKey { msg_id, .. } => {
+                        Some(Response::InsAuthKey {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+        let auth = unwrap!(Authenticator::create_acc_with_hook(
+            locator.clone(),
+            password.clone(),
+            invitation,
+            |_| (),
+            routing_hook,
+        ));
+
+        // Create a test app and try to authenticate it (with `app_container` set to true).
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: true,
+            containers: create_containers_req(),
+        };
+        let app_id = auth_req.app.id.clone();
+
+        // App authentication request should fail and leave the app in the
+        // `Revoked` state (as it is listed in the config root, but not in the access
+        // container)
+        match register_app(&auth, &auth_req) {
+            Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Simulate a network failure for the `update_container_perms` step -
+        // it should fail at the second container (`_videos`)
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            let mut reqs_counter = 0;
+
+            routing.set_request_hook(move |req| {
+                match *req {
+                    Request::SetMDataUserPermissions { msg_id, .. } => {
+                        reqs_counter += 1;
+
+                        if reqs_counter == 2 {
+                            Some(Response::SetMDataUserPermissions {
+                                res: Err(ClientError::LowBalance),
+                                msg_id,
+                            })
+                        } else {
+                            None
+                        }
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+        let auth = unwrap!(Authenticator::login_with_hook(
+            locator.clone(),
+            password.clone(),
+            |_| (),
+            routing_hook,
+        ));
+        match register_app(&auth, &auth_req) {
+            Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Simulate a network failure for the `app_container` setup step -
+        // it should fail at the third request for `SetMDataPermissions` (after
+        // setting permissions for 2 requested containers, `_video` and `_documents`)
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            routing.set_request_hook(move |req| {
+                match *req {
+                    Request::PutMData { msg_id, .. } => {
+                        Some(Response::PutMData {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+        let auth = unwrap!(Authenticator::login_with_hook(
+            locator.clone(),
+            password.clone(),
+            |_| (),
+            routing_hook,
+        ));
+        match register_app(&auth, &auth_req) {
+            Err(AuthError::NfsError(NfsError::CoreError(
+                CoreError::RoutingClientError(ClientError::LowBalance)))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Simulate a network failure for the `MutateMDataEntries` request, which
+        // is supposed to setup the access container entry for the app
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            routing.set_request_hook(move |req| {
+                match *req {
+                    Request::MutateMDataEntries { msg_id, .. } => {
+                        // None
+                        Some(Response::SetMDataUserPermissions {
+                            res: Err(ClientError::LowBalance),
+                            msg_id,
+                        })
+
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+        let auth = unwrap!(Authenticator::login_with_hook(
+            locator.clone(),
+            password.clone(),
+            |_| (),
+            routing_hook,
+        ));
+        match register_app(&auth, &auth_req) {
+            Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Now try to authenticate the app without network failure simulation -
+        // it should succeed.
+        let auth = unwrap!(Authenticator::login(
+            locator.clone(),
+            password.clone(),
+            |_| (),
+        ));
+        let auth_granted = match register_app(&auth, &auth_req) {
+            Ok(auth_granted) => auth_granted,
+            x => panic!("Unexpected {:?}", x),
+        };
+
+        // Check that the app's container has been created and that the access container
+        // contains info about all of the requested containers.
+        let mut ac_entries = access_container(&auth, app_id.clone(), auth_granted.clone());
+        let (_videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+        let (_documents_md, _) = unwrap!(ac_entries.remove("_documents"));
+        let (app_container_md, _) = unwrap!(ac_entries.remove(&format!("apps/{}", app_id.clone())));
+
+        let app_pk = auth_granted.app_keys.sign_pk;
+
+        run(&auth, move |client| {
+            let c2 = client.clone();
+
+            client
+                .get_mdata_version(app_container_md.name, app_container_md.type_tag)
+                .then(move |res| {
+                    let version = unwrap!(res);
+                    assert_eq!(version, 0);
+
+                    // Check that the app's container has required permissions.
+                    c2.list_mdata_permissions(app_container_md.name, app_container_md.type_tag)
+                })
+                .then(move |res| {
+                    let perms = unwrap!(res);
+                    assert!(perms.contains_key(&User::Key(app_pk)));
+                    assert_eq!(perms.len(), 1);
+
+                    Ok(())
+                })
+        });
+    }
+}
 
 // Test creation and content of std dirs after account creation.
 #[test]
@@ -117,93 +490,6 @@ fn config_root_dir() {
     // Verify it contains the required entries.
     let config = unwrap!(entries.get(KEY_APPS));
     assert!(config.content.is_empty());
-}
-
-// Test operation recovery for std dirs creation
-// 1. Try to create a new user's account using `safe_authenticator::Authenticator::create_acc`
-// 2. Simulate a network disconnection [1] for a randomly selected `PutMData` operation
-//    with a type_tag == `safe_core::DIR_TAG` (in the range from 3rd request to
-//    `safe_core::nfs::DEFAULT_PRIVATE_DIRS.len()`). This will meddle with creation of
-//    default directories.
-// 3. Try to log in using the same credentials that have been provided for `create_acc`.
-//    The log in operation should be successful.
-// 4. Check that after logging in the remaining default directories have been created
-//    (= operation recovery worked after log in)
-// 5. Check the access container entry in the user's config root - it must be accessible
-#[cfg(feature = "use-mock-routing")]
-#[test]
-fn std_dirs_recovery() {
-    use safe_core::DIR_TAG;
-
-    // Add a request hook to forbid root dir modification. In this case
-    // account creation operation will be failed, but login still should
-    // be possible afterwards.
-    let locator = unwrap!(generate_random_string(10));
-    let password = unwrap!(generate_random_string(10));
-    let invitation = unwrap!(generate_random_string(10));
-
-    {
-        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-            let mut put_mdata_counter = 0;
-
-            routing.set_request_hook(move |req| {
-                match *req {
-                    Request::PutMData { ref data, msg_id, .. } if data.tag() == DIR_TAG => {
-                        put_mdata_counter += 1;
-
-                        if put_mdata_counter > 4 {
-                            Some(Response::PutMData {
-                                msg_id,
-                                res: Err(ClientError::LowBalance),
-                            })
-                        } else {
-                            None
-                        }
-                    }
-                    // Pass-through
-                    _ => None,
-                }
-            });
-            routing
-        };
-
-        let authenticator = Authenticator::create_acc_with_hook(
-            locator.clone(),
-            password.clone(),
-            invitation,
-            |_| (),
-            routing_hook,
-        );
-
-        // This operation should fail
-        match authenticator {
-            Err(AuthError::NfsError(NfsError::CoreError(CoreError::RoutingClientError(
-                ClientError::LowBalance)))) => (),
-            Err(x) => panic!("Unexpected error {:?}", x),
-            Ok(_) => panic!("Expected an error"),
-        }
-    }
-
-    // Log in using the same credentials
-    let authenticator = unwrap!(Authenticator::login(locator, password, |_| ()));
-
-    // Make sure that all default directories have been created after log in.
-    let std_dir_names: Vec<_> = DEFAULT_PRIVATE_DIRS
-        .iter()
-        .cloned()
-        .chain(DEFAULT_PUBLIC_DIRS.iter().cloned())
-        .collect();
-
-    // Verify that the access container has been created and
-    // fetch the entries of the root authenticator entry.
-    let (_entry_version, entries) = run(&authenticator, |client| {
-        access_container_tools::fetch_authenticator_entry(client).map_err(AuthError::from)
-    });
-
-    // Verify that all the std dirs are there.
-    for name in std_dir_names {
-        assert!(entries.contains_key(name));
-    }
 }
 
 // Test app authentication.
@@ -386,9 +672,9 @@ fn unregistered_authentication() {
     let encoded_resp: String = unsafe {
         unwrap!(call_1(|ud, cb| {
             encode_unregistered_resp(req_id,
-                                                    true, // is_granted
-                                                    ud,
-                                                    cb)
+                                     true, // is_granted
+                                     ud,
+                                     cb)
         }))
     };
     let base64_app_id = base64_encode(b"unregistered");
@@ -572,73 +858,6 @@ fn containers_access_request() {
     compare_access_container_entries(&authenticator, app_sign_pk, access_container, expected);
 }
 
-// Ensure that users can log in with low account balance.
-#[cfg(feature = "use-mock-routing")]
-#[test]
-fn login_with_low_balance() {
-    // Register a hook prohibiting mutations and login
-    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        routing.set_request_hook(move |req| {
-            match *req {
-                Request::PutIData { msg_id, .. } => {
-                    Some(Response::PutIData {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::PutMData { msg_id, .. } => {
-                    Some(Response::PutMData {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::MutateMDataEntries { msg_id, .. } => {
-                    Some(Response::MutateMDataEntries {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::SetMDataUserPermissions { msg_id, .. } => {
-                    Some(Response::SetMDataUserPermissions {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::DelMDataUserPermissions { msg_id, .. } => {
-                    Some(Response::DelMDataUserPermissions {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::ChangeMDataOwner { msg_id, .. } => {
-                    Some(Response::ChangeMDataOwner {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::InsAuthKey { msg_id, .. } => {
-                    Some(Response::InsAuthKey {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                Request::DelAuthKey { msg_id, .. } => {
-                    Some(Response::DelAuthKey {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                // Pass-through
-                _ => None,
-            }
-        });
-        routing
-    };
-
-    // Make sure we can log in
-    let _authenticator = create_account_and_login_with_hook(routing_hook);
-}
-
 struct RegisteredAppId(String);
 impl ReprC for RegisteredAppId {
     type C = *const RegisteredApp;
@@ -741,221 +960,6 @@ fn lists_of_registered_and_revoked_apps() {
 
     assert_eq!(registered.len(), 2);
     assert_eq!(revoked.len(), 0);
-}
-
-// Test operation recovery for app authentication
-//
-// 1. Create a test app and try to authenticate it (with `app_container` set to true).
-//
-// 2. Simulate a network failure after the `mutate_mdata_entries` operation (relating to the
-//    addition of the app to the user's config dir) - it should leave the app in the
-//    `Revoked` state (as it is listen in the config root, but not in the access
-//    container)
-// 3. Try to authenticate the app again, it should continue without errors
-//
-// 4. Simulate a network failure after the `ins_auth_key` operation.
-//    The authentication op should fail.
-// 5. Try to authenticate the app again, it should continue without errors
-//
-// 6. Simulate a network failure for the `set_mdata_user_permissions` operation
-//    (relating to the app's container - so that it will be created successfuly, but fail
-//    at the permissions set stage).
-// 7. Try to authenticate the app again, it should continue without errors.
-//
-// 8. Simulate a network failure for the `mutate_mdata_entries` operation
-//    (relating to update of the access container).
-// 9. Try to authenticate the app again, it should succeed now.
-//
-// 10. Check that the app's container has been created.
-// 11. Check that the app's container has required permissions.
-// 12. Check that the app's container is listed in the access container entry for
-//     the app.
-#[cfg(feature = "use-mock-routing")]
-#[test]
-fn app_authentication_recovery() {
-    let locator = unwrap!(generate_random_string(10));
-    let password = unwrap!(generate_random_string(10));
-    let invitation = unwrap!(generate_random_string(10));
-
-    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        routing.set_request_hook(move |req| {
-            match *req {
-                // Simulate a network failure after
-                // the `mutate_mdata_entries` operation (relating to
-                // the addition of the app to the user's config dir)
-                Request::InsAuthKey { msg_id, .. } => {
-                    Some(Response::InsAuthKey {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                // Pass-through
-                _ => None,
-            }
-        });
-        routing
-    };
-    let auth = unwrap!(Authenticator::create_acc_with_hook(
-        locator.clone(),
-        password.clone(),
-        invitation,
-        |_| (),
-        routing_hook,
-    ));
-
-    // Create a test app and try to authenticate it (with `app_container` set to true).
-    let auth_req = AuthReq {
-        app: rand_app(),
-        app_container: true,
-        containers: create_containers_req(),
-    };
-    let app_id = auth_req.app.id.clone();
-
-    // App authentication request should fail and leave the app in the
-    // `Revoked` state (as it is listed in the config root, but not in the access
-    // container)
-    match register_app(&auth, &auth_req) {
-        Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
-        x => panic!("Unexpected {:?}", x),
-    }
-
-    // Simulate a network failure for the `update_container_perms` step -
-    // it should fail at the second container (`_videos`)
-    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        let mut reqs_counter = 0;
-
-        routing.set_request_hook(move |req| {
-            match *req {
-                Request::SetMDataUserPermissions { msg_id, .. } => {
-                    reqs_counter += 1;
-
-                    if reqs_counter == 2 {
-                        Some(Response::SetMDataUserPermissions {
-                            res: Err(ClientError::LowBalance),
-                            msg_id,
-                        })
-                    } else {
-                        None
-                    }
-                }
-                // Pass-through
-                _ => None,
-            }
-        });
-        routing
-    };
-    let auth = unwrap!(Authenticator::login_with_hook(
-        locator.clone(),
-        password.clone(),
-        |_| (),
-        routing_hook,
-    ));
-    match register_app(&auth, &auth_req) {
-        Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
-        x => panic!("Unexpected {:?}", x),
-    }
-
-    // Simulate a network failure for the `app_container` setup step -
-    // it should fail at the third request for `SetMDataPermissions` (after
-    // setting permissions for 2 requested containers, `_video` and `_documents`)
-    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        routing.set_request_hook(move |req| {
-            match *req {
-                Request::PutMData { msg_id, .. } => {
-                    Some(Response::PutMData {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-                }
-                // Pass-through
-                _ => None,
-            }
-        });
-        routing
-    };
-    let auth = unwrap!(Authenticator::login_with_hook(
-        locator.clone(),
-        password.clone(),
-        |_| (),
-        routing_hook,
-    ));
-    match register_app(&auth, &auth_req) {
-        Err(AuthError::NfsError(NfsError::CoreError(
-            CoreError::RoutingClientError(ClientError::LowBalance)))) => (),
-        x => panic!("Unexpected {:?}", x),
-    }
-
-    // Simulate a network failure for the `MutateMDataEntries` request, which
-    // is supposed to setup the access container entry for the app
-    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        routing.set_request_hook(move |req| {
-            match *req {
-                Request::MutateMDataEntries { msg_id, .. } => {
-                    // None
-                    Some(Response::SetMDataUserPermissions {
-                        res: Err(ClientError::LowBalance),
-                        msg_id,
-                    })
-
-                }
-                // Pass-through
-                _ => None,
-            }
-        });
-        routing
-    };
-    let auth = unwrap!(Authenticator::login_with_hook(
-        locator.clone(),
-        password.clone(),
-        |_| (),
-        routing_hook,
-    ));
-    match register_app(&auth, &auth_req) {
-        Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
-        x => panic!("Unexpected {:?}", x),
-    }
-
-    // Now try to authenticate the app without network failure simulation -
-    // it should succeed.
-    let auth = unwrap!(Authenticator::login(
-        locator.clone(),
-        password.clone(),
-        |_| (),
-    ));
-    let auth_granted = match register_app(&auth, &auth_req) {
-        Ok(auth_granted) => auth_granted,
-        x => panic!("Unexpected {:?}", x),
-    };
-
-    // Check that the app's container has been created and that the access container
-    // contains info about all of the requested containers.
-    let mut ac_entries = access_container(&auth, app_id.clone(), auth_granted.clone());
-    let (_videos_md, _) = unwrap!(ac_entries.remove("_videos"));
-    let (_documents_md, _) = unwrap!(ac_entries.remove("_documents"));
-    let (app_container_md, _) = unwrap!(ac_entries.remove(&format!("apps/{}", app_id.clone())));
-
-    let app_pk = auth_granted.app_keys.sign_pk;
-
-    run(&auth, move |client| {
-        let c2 = client.clone();
-
-        client
-            .get_mdata_version(app_container_md.name, app_container_md.type_tag)
-            .then(move |res| {
-                let version = unwrap!(res);
-                assert_eq!(version, 0);
-
-                // Check that the app's container has required permissions.
-                c2.list_mdata_permissions(app_container_md.name, app_container_md.type_tag)
-            })
-            .then(move |res| {
-                let perms = unwrap!(res);
-                assert!(perms.contains_key(&User::Key(app_pk)));
-                assert_eq!(perms.len(), 1);
-
-                Ok(())
-            })
-    });
 }
 
 fn unregistered_decode_ipc_msg(msg: &str) -> ChannelType {

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -475,6 +475,7 @@ fn authenticated_app_can_be_authenticated_again() {
     };
 }
 
+// Create and serialize a containers request for a random app, make sure we get an error.
 #[test]
 fn containers_unknown_app() {
     let authenticator = create_account_and_login();
@@ -503,6 +504,7 @@ fn containers_unknown_app() {
     };
 }
 
+// Test making a containers access request.
 #[test]
 fn containers_access_request() {
     let authenticator = create_account_and_login();
@@ -659,6 +661,11 @@ impl ReprC for RevokedAppId {
     }
 }
 
+// Test app registration and revocation.
+// 1. Initially there should be no registerd or revoked apps.
+// 2. Register two apps. There should be two registered apps, but no revoked apps.
+// 3. Revoke the first app. There should be one registered and one revoked app.
+// 4. Re-register the first app. There should be two registered apps again.
 #[test]
 fn lists_of_registered_and_revoked_apps() {
     let authenticator = create_account_and_login();

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -36,9 +36,10 @@ mod mock_routing {
     use access_container;
     use app_auth::{AppState, app_state};
     use config;
+    use ffi_utils::test_utils::call_0;
     use futures::future;
+    use ipc::auth_flush_app_revocation_queue;
     use rand::{self, Rng};
-    use revocation::flush_app_revocation_queue;
     use routing::{ClientError, Request, Response};
     use safe_core::{Client, FutureExt};
     use safe_core::MockRouting;
@@ -311,19 +312,20 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login(locator, password, |_| ()));
 
         // Flush the revocation queue and verify both apps get revoked.
+        unsafe {
+            unwrap!(call_0(
+                |ud, cb| auth_flush_app_revocation_queue(&auth, ud, cb),
+            ))
+        }
+
         run(&auth, |client| {
             let c2 = client.clone();
-            let c3 = client.clone();
 
-            flush_app_revocation_queue(client)
-                .then(move |res| {
-                    unwrap!(res);
-                    config::list_apps(&c2)
-                })
+            config::list_apps(client)
                 .then(move |res| {
                     let (_, apps) = unwrap!(res);
-                    let f_0 = app_state(&c3, &apps, &app_id_0);
-                    let f_1 = app_state(&c3, &apps, &app_id_1);
+                    let f_0 = app_state(&c2, &apps, &app_id_0);
+                    let f_1 = app_state(&c2, &apps, &app_id_1);
 
                     f_0.join(f_1)
                 })

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -36,6 +36,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use test_utils::{create_account_and_login, rand_app, register_app, run};
 
+// Test making an empty request to share mutable data.
 #[test]
 fn share_zero_mdatas() {
     let authenticator = create_account_and_login();
@@ -60,6 +61,7 @@ fn share_zero_mdatas() {
     };
 }
 
+// Test making a request to share mutable data with barebones mdata.
 #[test]
 fn share_some_mdatas() {
     let authenticator = create_account_and_login();
@@ -119,6 +121,7 @@ fn share_some_mdatas() {
     };
 }
 
+// Test making a request to share mdata with valid metadata.
 #[test]
 fn share_some_mdatas_with_valid_metadata() {
     let authenticator = create_account_and_login();
@@ -227,6 +230,7 @@ fn share_some_mdatas_with_valid_metadata() {
     }
 }
 
+// Test making a request to share mdata with invalid owners.
 #[test]
 fn share_some_mdatas_with_ownership_error() {
     let authenticator = create_account_and_login();

--- a/safe_core/src/client/account.rs
+++ b/safe_core/src/client/account.rs
@@ -171,6 +171,7 @@ mod tests {
     use maidsafe_utilities::serialisation::{deserialise, serialise};
     use std::u32;
 
+    // Test deterministically generating User's Identity for the network using supplied credentials.
     #[test]
     fn generate_network_id() {
         let keyword1 = b"user1";
@@ -209,6 +210,7 @@ mod tests {
         assert_ne!(user1_id, user2_id);
     }
 
+    // Test deterministically generating cryptographic keys.
     #[test]
     fn generate_crypto_keys() {
         let password1 = b"super great password";
@@ -233,6 +235,7 @@ mod tests {
         assert_eq!(keys1, keys2);
     }
 
+    // Test serialising and deserialising accounts.
     #[test]
     fn serialisation() {
         let account = unwrap!(Account::new(ClientKeys::new(None)));
@@ -242,6 +245,7 @@ mod tests {
         assert_eq!(decoded, account);
     }
 
+    // Test encryption and decryption of accounts.
     #[test]
     fn encryption() {
         let account = unwrap!(Account::new(ClientKeys::new(None)));

--- a/safe_core/src/client/mdata_info.rs
+++ b/safe_core/src/client/mdata_info.rs
@@ -87,7 +87,7 @@ impl MDataInfo {
         self.enc_info.as_ref().map(|&(_, ref nonce)| nonce)
     }
 
-    /// encrypt the the key for the mdata entry accordingly
+    /// encrypt the key for the mdata entry accordingly
     pub fn enc_entry_key(&self, plain_text: &[u8]) -> Result<Vec<u8>, CoreError> {
         if let Some((ref key, seed)) = self.new_enc_info {
             enc_entry_key(plain_text, key, seed)

--- a/safe_core/src/client/mdata_info.rs
+++ b/safe_core/src/client/mdata_info.rs
@@ -260,6 +260,7 @@ fn enc_entry_key(
 mod tests {
     use super::*;
 
+    // Ensure that a private mdata info is encrypted.
     #[test]
     fn private_mdata_info_encrypts() {
         let info = unwrap!(MDataInfo::random_private(0));
@@ -273,6 +274,7 @@ mod tests {
         assert_eq!(unwrap!(info.decrypt(&enc_val)), val);
     }
 
+    // Ensure that a public mdata info is not encrypted.
     #[test]
     fn public_mdata_info_doesnt_encrypt() {
         let info = unwrap!(MDataInfo::random_public(0));
@@ -283,6 +285,7 @@ mod tests {
         assert_eq!(unwrap!(info.decrypt(&val)), val);
     }
 
+    // Test creating and committing new encryption info.
     #[test]
     fn decrypt() {
         let mut info = unwrap!(MDataInfo::random_private(0));

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -68,6 +68,7 @@ macro_rules! expect_failure {
     }
 }
 
+// Test the basics idata operations.
 #[test]
 fn immutable_data_basics() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -123,6 +124,7 @@ fn immutable_data_basics() {
     assert_eq!(acct_info.mutations_available, DEFAULT_MAX_MUTATIONS - 2);
 }
 
+// Test the basic mdata operations.
 #[test]
 fn mutable_data_basics() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -354,6 +356,7 @@ fn mutable_data_basics() {
     assert_eq!(entry.entry_version, 0);
 }
 
+// Test valid and invalid mdata entry versioning.
 #[test]
 fn mutable_data_entry_versioning() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -469,6 +472,7 @@ fn mutable_data_entry_versioning() {
     expect_success!(routing_rx, msg_id, Response::MutateMDataEntries);
 }
 
+// Test various operations with and without proper permissions.
 #[test]
 fn mutable_data_permissions() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -486,7 +490,6 @@ fn mutable_data_permissions() {
     let entries = btree_map![
         key0.to_vec() => Value { content: value0_v0, entry_version: 0 }
     ];
-
 
     let data = unwrap!(MutableData::new(name,
                                         tag,
@@ -634,7 +637,7 @@ fn mutable_data_permissions() {
                     Response::SetMDataUserPermissions,
                     ClientError::InvalidSuccessor(_));
 
-    // Modifing permissions with version bump succeeds.
+    // Modifying permissions with version bump succeeds.
     let perms = PermissionSet::new().allow(Action::Insert).allow(
         Action::Update,
     );
@@ -814,6 +817,7 @@ fn mutable_data_permissions() {
                     ClientError::AccessDenied);
 }
 
+// Test mdata operations with valid and invalid owners.
 #[test]
 fn mutable_data_ownership() {
     // Create owner's routing client
@@ -895,6 +899,7 @@ fn mutable_data_ownership() {
     expect_success!(owner_routing_rx, msg_id, Response::ChangeMDataOwner);
 }
 
+// Test auth key operations with valid and invalid version bumps.
 #[test]
 fn auth_keys() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -964,7 +969,7 @@ fn auth_keys() {
     assert_eq!(version, 2);
 }
 
-// Exhaust the account balance and ensure that mutations fail
+// Exhaust the account balance and ensure that mutations fail.
 #[test]
 fn balance_check() {
     let (mut routing, routing_rx, full_id) = setup();
@@ -1018,6 +1023,7 @@ fn balance_check() {
     assert!(mdata.serialised_size() > 0);
 }
 
+// Test routing request hooks.
 #[test]
 fn request_hooks() {
     let (mut routing, routing_rx, full_id) = setup();

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -488,14 +488,14 @@ fn mutable_data_permissions() {
     let value0_v0 = unwrap!(utils::generate_random_vector(10));
 
     let entries = btree_map![
-        key0.to_vec() => Value { content: value0_v0, entry_version: 0 }
-    ];
+          key0.to_vec() => Value { content: value0_v0, entry_version: 0 }
+      ];
 
     let data = unwrap!(MutableData::new(name,
-                                        tag,
-                                        Default::default(),
-                                        entries,
-                                        btree_set!(owner_key)));
+                                          tag,
+                                          Default::default(),
+                                          entries,
+                                          btree_set!(owner_key)));
 
     let nae_mgr = Authority::NaeManager(*data.name());
 
@@ -539,25 +539,25 @@ fn mutable_data_permissions() {
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::MutateMDataEntries,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::MutateMDataEntries,
+                      ClientError::AccessDenied);
 
     // App can't grant itself permission to update.
     let perms = PermissionSet::new().allow(Action::Update);
     let msg_id = MessageId::new();
     unwrap!(app_routing.set_mdata_user_permissions(client_mgr,
-                                                   name,
-                                                   tag,
-                                                   User::Key(app_sign_key),
-                                                   perms,
-                                                   1,
-                                                   msg_id,
-                                                   app_sign_key));
+                                                     name,
+                                                     tag,
+                                                     User::Key(app_sign_key),
+                                                     perms,
+                                                     1,
+                                                     msg_id,
+                                                     app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::SetMDataUserPermissions,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::SetMDataUserPermissions,
+                      ClientError::AccessDenied);
 
     // Verify app still can't update, after the previous attempt to
     // modify its permissions.
@@ -567,21 +567,21 @@ fn mutable_data_permissions() {
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::MutateMDataEntries,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::MutateMDataEntries,
+                      ClientError::AccessDenied);
 
     // Grant insert permission for app.
     let perms = PermissionSet::new().allow(Action::Insert);
     let msg_id = MessageId::new();
     unwrap!(routing.set_mdata_user_permissions(client_mgr,
-                                               name,
-                                               tag,
-                                               User::Key(app_sign_key),
-                                               perms,
-                                               1,
-                                               msg_id,
-                                               owner_key));
+                                                 name,
+                                                 tag,
+                                                 User::Key(app_sign_key),
+                                                 perms,
+                                                 1,
+                                                 msg_id,
+                                                 owner_key));
     expect_success!(routing_rx, msg_id, Response::SetMDataUserPermissions);
 
     // The version is bumped.
@@ -592,28 +592,28 @@ fn mutable_data_permissions() {
 
     // App still can't update entries.
     let actions = btree_map![
-        key0.to_vec() => EntryAction::Update(Value {
-            content: value0_v2.clone(),
-            entry_version: 2,
-        })
-    ];
+          key0.to_vec() => EntryAction::Update(Value {
+              content: value0_v2.clone(),
+              entry_version: 2,
+          })
+      ];
 
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::MutateMDataEntries,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::MutateMDataEntries,
+                      ClientError::AccessDenied);
 
     // But it insert new ones.
     let key1 = b"key1";
     let value1_v0 = unwrap!(utils::generate_random_vector(10));
     let actions = btree_map![
-        key1.to_vec() => EntryAction::Ins(Value {
-            content: value1_v0,
-            entry_version: 0,
-        })
-    ];
+          key1.to_vec() => EntryAction::Ins(Value {
+              content: value1_v0,
+              entry_version: 0,
+          })
+      ];
 
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
@@ -625,17 +625,17 @@ fn mutable_data_permissions() {
     );
     let msg_id = MessageId::new();
     unwrap!(routing.set_mdata_user_permissions(client_mgr,
-                                               name,
-                                               tag,
-                                               User::Key(app_sign_key),
-                                               perms,
-                                               1,
-                                               msg_id,
-                                               owner_key));
+                                                 name,
+                                                 tag,
+                                                 User::Key(app_sign_key),
+                                                 perms,
+                                                 1,
+                                                 msg_id,
+                                                 owner_key));
     expect_failure!(routing_rx,
-                    msg_id,
-                    Response::SetMDataUserPermissions,
-                    ClientError::InvalidSuccessor(_));
+                      msg_id,
+                      Response::SetMDataUserPermissions,
+                      ClientError::InvalidSuccessor(_));
 
     // Modifying permissions with version bump succeeds.
     let perms = PermissionSet::new().allow(Action::Insert).allow(
@@ -643,22 +643,22 @@ fn mutable_data_permissions() {
     );
     let msg_id = MessageId::new();
     unwrap!(routing.set_mdata_user_permissions(client_mgr,
-                                               name,
-                                               tag,
-                                               User::Key(app_sign_key),
-                                               perms,
-                                               2,
-                                               msg_id,
-                                               owner_key));
+                                                 name,
+                                                 tag,
+                                                 User::Key(app_sign_key),
+                                                 perms,
+                                                 2,
+                                                 msg_id,
+                                                 owner_key));
     expect_success!(routing_rx, msg_id, Response::SetMDataUserPermissions);
 
     // App can now update entries.
     let actions = btree_map![
-        key0.to_vec() => EntryAction::Update(Value {
-            content: value0_v2,
-            entry_version: 2,
-        })
-    ];
+          key0.to_vec() => EntryAction::Update(Value {
+              content: value0_v2,
+              entry_version: 2,
+          })
+      ];
 
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
@@ -667,12 +667,12 @@ fn mutable_data_permissions() {
     // Revoke all permissions from app.
     let msg_id = MessageId::new();
     unwrap!(routing.del_mdata_user_permissions(client_mgr,
-                                               name,
-                                               tag,
-                                               User::Key(app_sign_key),
-                                               3,
-                                               msg_id,
-                                               owner_key));
+                                                 name,
+                                                 tag,
+                                                 User::Key(app_sign_key),
+                                                 3,
+                                                 msg_id,
+                                                 owner_key));
     expect_success!(routing_rx, msg_id, Response::DelMDataUserPermissions);
 
     // App can no longer mutate the entries.
@@ -682,21 +682,21 @@ fn mutable_data_permissions() {
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::MutateMDataEntries,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::MutateMDataEntries,
+                      ClientError::AccessDenied);
 
     // Grant the app permission to manage permissions.
     let perms = PermissionSet::new().allow(Action::ManagePermissions);
     let msg_id = MessageId::new();
     unwrap!(routing.set_mdata_user_permissions(client_mgr,
-                                               name,
-                                               tag,
-                                               User::Key(app_sign_key),
-                                               perms,
-                                               4,
-                                               msg_id,
-                                               owner_key));
+                                                 name,
+                                                 tag,
+                                                 User::Key(app_sign_key),
+                                                 perms,
+                                                 4,
+                                                 msg_id,
+                                                 owner_key));
     expect_success!(routing_rx, msg_id, Response::SetMDataUserPermissions);
 
     // The app still can't mutate the entries.
@@ -707,21 +707,21 @@ fn mutable_data_permissions() {
     let msg_id = MessageId::new();
     unwrap!(app_routing.mutate_mdata_entries(client_mgr, name, tag, actions, msg_id, app_sign_key));
     expect_failure!(app_routing_rx,
-                    msg_id,
-                    Response::MutateMDataEntries,
-                    ClientError::AccessDenied);
+                      msg_id,
+                      Response::MutateMDataEntries,
+                      ClientError::AccessDenied);
 
     // App can modify its own permission.
     let perms = PermissionSet::new().allow(Action::Update);
     let msg_id = MessageId::new();
     unwrap!(app_routing.set_mdata_user_permissions(client_mgr,
-                                                   name,
-                                                   tag,
-                                                   User::Key(app_sign_key),
-                                                   perms,
-                                                   5,
-                                                   msg_id,
-                                                   app_sign_key));
+                                                     name,
+                                                     tag,
+                                                     User::Key(app_sign_key),
+                                                     perms,
+                                                     5,
+                                                     msg_id,
+                                                     app_sign_key));
     expect_success!(app_routing_rx, msg_id, Response::SetMDataUserPermissions);
 
     // The app can now mutate the entries.

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -465,12 +465,11 @@ fn mutable_data_reclaim() {
         routing_rx,
         msg_id,
         Response::MutateMDataEntries,
-        ClientError::InvalidSuccessor(2)
+        ClientError::InvalidEntryActions(_)
     );
 
     // Try deleting the entry with an entry_version of 3 and make sure it succeeds
-    let actions =
-        btree_map![
+    let actions = btree_map![
             key0.to_vec() => EntryAction::Del(3),
         ];
 
@@ -514,8 +513,7 @@ fn mutable_data_entry_versioning() {
     // Insert a new entry
     let key = b"key0";
     let value_v0 = unwrap!(utils::generate_random_vector(10));
-    let actions =
-        btree_map![
+    let actions = btree_map![
             key.to_vec() => EntryAction::Ins(Value {
                 content: value_v0,
                 entry_version: 0,
@@ -535,8 +533,7 @@ fn mutable_data_entry_versioning() {
 
     // Attempt to update it without version bump fails.
     let value_v1 = unwrap!(utils::generate_random_vector(10));
-    let actions =
-        btree_map![
+    let actions = btree_map![
             key.to_vec() => EntryAction::Update(Value {
                 content: value_v1.clone(),
                 entry_version: 0,

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -356,6 +356,136 @@ fn mutable_data_basics() {
     assert_eq!(entry.entry_version, 0);
 }
 
+// Test reclamation of deleted mdata.
+#[test]
+fn mutable_data_reclaim() {
+    let (mut routing, routing_rx, full_id) = setup();
+
+    // Create account
+    let owner_key = *full_id.public_id().signing_public_key();
+    let client_mgr = create_account(&mut routing, &routing_rx, owner_key);
+
+    // Construct MutableData
+    let name = rand::random();
+    let tag = 1000u64;
+
+    let data = unwrap!(MutableData::new(
+        name,
+        tag,
+        Default::default(),
+        Default::default(),
+        btree_set!(owner_key),
+    ));
+    let nae_mgr = Authority::NaeManager(*data.name());
+
+    // PutMData
+    let msg_id = MessageId::new();
+    unwrap!(routing.put_mdata(client_mgr, data, msg_id, owner_key));
+    expect_success!(routing_rx, msg_id, Response::PutMData);
+
+    // Mutate the entries: insert, delete and insert again
+    let key0 = b"key0";
+    let value0 = unwrap!(utils::generate_random_vector(10));
+    let actions =
+        btree_map![
+            key0.to_vec() => EntryAction::Ins(Value {
+                content: value0.clone(),
+                entry_version: 0,
+            }),
+        ];
+
+    let msg_id = MessageId::new();
+    unwrap!(routing.mutate_mdata_entries(
+        client_mgr,
+        name,
+        tag,
+        actions,
+        msg_id,
+        owner_key,
+    ));
+    expect_success!(routing_rx, msg_id, Response::MutateMDataEntries);
+
+    let actions =
+        btree_map![
+            key0.to_vec() => EntryAction::Del(1),
+        ];
+
+    let msg_id = MessageId::new();
+    unwrap!(routing.mutate_mdata_entries(
+        client_mgr,
+        name,
+        tag,
+        actions,
+        msg_id,
+        owner_key,
+    ));
+    expect_success!(routing_rx, msg_id, Response::MutateMDataEntries);
+
+    let actions =
+        btree_map![
+            key0.to_vec() => EntryAction::Update(Value {
+                content: value0.clone(),
+                entry_version: 2,
+            })
+        ];
+
+    let msg_id = MessageId::new();
+    unwrap!(routing.mutate_mdata_entries(
+        client_mgr,
+        name,
+        tag,
+        actions,
+        msg_id,
+        owner_key,
+    ));
+    expect_success!(routing_rx, msg_id, Response::MutateMDataEntries);
+
+    // GetMDataVersion should respond with 0 as the mdata itself hasn't changed.
+    let msg_id = MessageId::new();
+    unwrap!(routing.get_mdata_version(nae_mgr, name, tag, msg_id));
+    let version = expect_success!(routing_rx, msg_id, Response::GetMDataVersion);
+    assert_eq!(version, 0);
+
+    // Try deleting the entry with an invalid entry_version and make sure it fails
+    let actions =
+        btree_map![
+            key0.to_vec() => EntryAction::Del(4),
+        ];
+
+    let msg_id = MessageId::new();
+    unwrap!(routing.mutate_mdata_entries(
+        client_mgr,
+        name,
+        tag,
+        actions,
+        msg_id,
+        owner_key,
+    ));
+    expect_failure!(
+        routing_rx,
+        msg_id,
+        Response::MutateMDataEntries,
+        ClientError::InvalidSuccessor(2)
+    );
+
+    // Try deleting the entry with an entry_version of 3 and make sure it succeeds
+    let actions =
+        btree_map![
+            key0.to_vec() => EntryAction::Del(3),
+        ];
+
+    let msg_id = MessageId::new();
+    unwrap!(routing.mutate_mdata_entries(
+        client_mgr,
+        name,
+        tag,
+        actions,
+        msg_id,
+        owner_key,
+    ));
+    expect_success!(routing_rx, msg_id, Response::MutateMDataEntries);
+}
+
 // Test valid and invalid mdata entry versioning.
 #[test]
 fn mutable_data_entry_versioning() {

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -1437,6 +1437,7 @@ mod tests {
     use utils;
     use utils::test_utils::{finish, random_client, setup_client};
 
+    // Test logging in using a seeded account.
     #[test]
     fn seeded_login() {
         let invalid_seed = String::from("123");
@@ -1483,6 +1484,10 @@ mod tests {
                      |_| finish());
     }
 
+    // Tests for unregistered clients.
+    // 1. Have a registered client PUT something on the network.
+    // 2. Try to set the access container as unregistered - this should fail.
+    // 3. Try to set the config root directory as unregistered - this should fail.
     #[test]
     fn unregistered_client() {
         let orig_data = ImmutableData::new(unwrap!(utils::generate_random_vector(30)));
@@ -1539,6 +1544,8 @@ mod tests {
         });
     }
 
+    // Test account creation.
+    // It should succeed the first time and fail the second time with the same secrets.
     #[test]
     fn registered_client() {
         let el = unwrap!(Core::new());
@@ -1567,6 +1574,7 @@ mod tests {
         }
     }
 
+    // Test creating and logging in to an account on the network.
     #[test]
     fn login() {
         let sec_0 = unwrap!(utils::generate_random_string(10));
@@ -1594,6 +1602,7 @@ mod tests {
                      |_| finish());
     }
 
+    // Test creation of an access container.
     #[test]
     fn access_container_creation() {
         let sec_0 = unwrap!(utils::generate_random_string(10));
@@ -1620,6 +1629,7 @@ mod tests {
                      });
     }
 
+    // Test setting the configuration root directory.
     #[test]
     fn config_root_dir_creation() {
         let sec_0 = unwrap!(utils::generate_random_string(10));
@@ -1646,6 +1656,7 @@ mod tests {
                      });
     }
 
+    // Test restarting routing after a network disconnect.
     #[cfg(feature = "use-mock-routing")]
     #[test]
     fn restart_routing() {
@@ -1680,6 +1691,7 @@ mod tests {
         );
     }
 
+    // Test that a `RequestTimeout` error is returned on network timeout.
     #[cfg(feature = "use-mock-routing")]
     #[test]
     fn timeout() {

--- a/safe_core/src/client/recovery.rs
+++ b/safe_core/src/client/recovery.rs
@@ -281,7 +281,7 @@ fn fix_entry_action(action: EntryAction, error: &EntryError) -> Option<EntryActi
     }
 }
 
-// Create union of the two permission sets, preffering allows to deny's.
+// Create union of the two permission sets, preferring allows to deny's.
 fn union_permission_sets(a: &PermissionSet, b: &PermissionSet) -> PermissionSet {
     let actions = [
         Action::Insert,
@@ -345,6 +345,7 @@ pub fn ins_auth_key<T: 'static>(
 mod tests {
     use super::*;
 
+    // Test modifying given entry actions to fix entry errors
     #[test]
     fn test_fix_entry_actions() {
         let mut actions = BTreeMap::new();
@@ -451,6 +452,7 @@ mod tests {
         assert_eq!(*unwrap!(actions.get([7].as_ref())), EntryAction::Del(3));
     }
 
+    // Test creating a union of two permission sets
     #[test]
     fn test_union_permission_sets() {
         let a = PermissionSet::new()
@@ -477,6 +479,7 @@ mod tests_with_mock_routing {
     use rust_sodium::crypto::sign;
     use utils::test_utils::random_client;
 
+    // Test putting mdata and recovering from errors
     #[test]
     fn put_mdata_with_recovery() {
         random_client(|client| {
@@ -589,6 +592,7 @@ mod tests_with_mock_routing {
         })
     }
 
+    // Test mutating mdata entries and recovering from errors
     #[test]
     fn mutate_mdata_entries_with_recovery() {
         random_client(|client| {
@@ -711,6 +715,7 @@ mod tests_with_mock_routing {
         })
     }
 
+    // Test setting and deleting user permissions and recovering from errors
     #[test]
     fn set_and_del_mdata_user_permissions_with_recovery() {
         random_client(|client| {

--- a/safe_core/src/immutable_data.rs
+++ b/safe_core/src/immutable_data.rs
@@ -159,21 +159,25 @@ mod tests {
     use utils;
     use utils::test_utils::{finish, random_client};
 
+    // Test creating and retrieving a 1kb idata.
     #[test]
     fn create_and_retrieve_1kb() {
         create_and_retrieve(1024)
     }
 
+    // Test creating and retrieving a 1mb idata.
     #[test]
     fn create_and_retrieve_1mb() {
         create_and_retrieve(1024 * 1024)
     }
 
+    // Test creating and retrieving a 2mb idata.
     #[test]
     fn create_and_retrieve_2mb() {
         create_and_retrieve(2 * 1024 * 1024)
     }
 
+    // Test creating and retrieving a 10mb idata.
     #[cfg(not(debug_assertions))]
     #[test]
     fn create_and_retrieve_10mb() {

--- a/safe_core/src/ipc/req/mod.rs
+++ b/safe_core/src/ipc/req/mod.rs
@@ -297,6 +297,7 @@ mod tests {
     use std::collections::HashMap;
     use std::ffi::CStr;
 
+    // Test converting `ContainerPermissions` to its FFI representation and back again.
     #[test]
     fn container_permissions() {
         let mut cp = HashMap::new();
@@ -311,6 +312,7 @@ mod tests {
         assert_eq!(unwrap!(cp.get("foobar")), &btree_set![Permission::Insert]);
     }
 
+    // Test that cloning an empty `ContainerPermissions` from FFI produces an error.
     #[test]
     fn empty_container_permissions() {
         // Expect an error for an empty permission set
@@ -324,6 +326,9 @@ mod tests {
         assert!(cp.is_err());
     }
 
+    // Test cloning a permission set for the following two cases:
+    // 1. If only the `read` perm is set - return an error.
+    // 2. The `read` perm should be ignored in all other cases.
     #[test]
     fn permissions_set_conversion() {
         // It should return an error in case if we have set only the `read` perm
@@ -338,7 +343,7 @@ mod tests {
         let res = permission_set_clone_from_repr_c(&ps);
         assert!(res.is_err());
 
-        // It should ignore read perms in all other cases
+        // It should ignore `read` perms in all other cases
         let ps = FfiPermissionSet {
             read: true,
             insert: false,
@@ -354,6 +359,7 @@ mod tests {
         assert!(res.is_allowed(Action::ManagePermissions).is_none());
     }
 
+    // Testing converting an `AppExchangeInfo` object to its FFI representation and back again.
     #[test]
     fn app_exchange_info() {
         let a = AppExchangeInfo {
@@ -391,6 +397,7 @@ mod tests {
         }
     }
 
+    // Test converting an `AuthReq` object to its FFI representation and back again.
     #[test]
     fn auth_request() {
         let app = AppExchangeInfo {
@@ -421,6 +428,7 @@ mod tests {
         assert_eq!(a.containers.len(), 0);
     }
 
+    // Test converting a `ContainersReq` object to its FFI representation and back again.
     #[test]
     fn containers_req() {
         let app = AppExchangeInfo {

--- a/safe_core/src/ipc/resp/mod.rs
+++ b/safe_core/src/ipc/resp/mod.rs
@@ -380,6 +380,7 @@ mod tests {
     use routing::{XOR_NAME_LEN, XorName};
     use rust_sodium::crypto::{box_, secretbox, sign};
 
+    // Test converting an `AuthGranted` object to its FFI representation and then back again.
     #[test]
     fn auth_granted() {
         let (ok, _) = sign::gen_keypair();
@@ -414,6 +415,7 @@ mod tests {
         assert_eq!(ag.access_container.tag, 681);
     }
 
+    // Testing converting an `AppKeys` object to its FFI representation and back again.
     #[test]
     fn app_keys() {
         let (ok, _) = sign::gen_keypair();
@@ -466,6 +468,7 @@ mod tests {
         assert_eq!(ak.enc_sk, oursk);
     }
 
+    // Test converting an `AccessContInfo` struct to its FFI representation and back again.
     #[test]
     fn access_container() {
         let nonce = secretbox::gen_nonce();

--- a/safe_core/src/nfs/file.rs
+++ b/safe_core/src/nfs/file.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
     use maidsafe_utilities::serialisation::{deserialise, serialise};
 
+    // Test that serialising and deserialising a file restores the original file.
     #[test]
     fn serialise_deserialise() {
         let obj_before = File::new("{mime:\"application/json\"}".to_string().into_bytes());

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -343,6 +343,8 @@ mod tests {
         });
     }
 
+    // Test appending to a file.
+    // Read the file afterwards and test that it has both the original and the new contnet.
     #[test]
     fn file_update_append() {
         random_client(|client| {
@@ -382,6 +384,8 @@ mod tests {
         });
     }
 
+    // Test updating file metadata.
+    // Fetch the file afterwards and test that it has the new metadata.
     #[test]
     fn file_update_metadata() {
         random_client(|client| {
@@ -406,6 +410,8 @@ mod tests {
                 })
         });
     }
+
+    // Test deleting a file entry, and that fetching it after is an error.
     #[test]
     fn file_delete() {
         random_client(|client| {

--- a/safe_core/src/nfs/file_metadata.rs
+++ b/safe_core/src/nfs/file_metadata.rs
@@ -162,6 +162,7 @@ mod tests {
     use maidsafe_utilities::serialisation::{deserialise, serialise};
     use self_encryption::DataMap;
 
+    // Test that serialising and deserialising file metadata restores the original contents.
     #[test]
     fn serialise_and_deserialise_file_metadata() {
         let obj_before = FileMetadata::new("hello.txt".to_string(),

--- a/safe_core/src/utils/mod.rs
+++ b/safe_core/src/utils/mod.rs
@@ -145,6 +145,7 @@ mod tests {
 
     const SIZE: usize = 10;
 
+    // Test `generate_random_string` and that the results are not repeated.
     #[test]
     fn random_string() {
         let str0 = unwrap!(generate_random_string(SIZE));
@@ -154,8 +155,13 @@ mod tests {
         assert_ne!(str0, str1);
         assert_ne!(str0, str2);
         assert_ne!(str1, str2);
+
+        assert_eq!(str0.chars().collect::<Vec<char>>().len(), SIZE);
+        assert_eq!(str1.chars().collect::<Vec<char>>().len(), SIZE);
+        assert_eq!(str2.chars().collect::<Vec<char>>().len(), SIZE);
     }
 
+    // Test `generate_random_vector` and that the results are not repeated.
     #[test]
     fn random_vector() {
         let vec0 = unwrap!(generate_random_vector::<u8>(SIZE));
@@ -165,8 +171,13 @@ mod tests {
         assert_ne!(vec0, vec1);
         assert_ne!(vec0, vec2);
         assert_ne!(vec1, vec2);
+
+        assert_eq!(vec0.len(), SIZE);
+        assert_eq!(vec1.len(), SIZE);
+        assert_eq!(vec2.len(), SIZE);
     }
 
+    // Test derivation of distinct password, keyword, and pin secrets.
     #[test]
     fn secrets_derivation() {
         // Random pass-phrase

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -74,6 +74,7 @@ use std::sync::mpsc;
 struct SendWrapper<T>(T);
 unsafe impl<T> Send for SendWrapper<T> {}
 
+// Main integration test for safe_client_libs.
 #[test]
 fn test() {
     let app_id = unwrap!(utils::generate_random_string(10));


### PR DESCRIPTION
- add missing high-level descriptions for all tests
- split mock-routing-only tests into a separate module (completing https://maidsafe.atlassian.net/browse/MAID-2278)
- add missing test cases