### PR TITLE
MAID-1612: Do not clone secret keys

### DIFF
--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -22,6 +22,7 @@ use ffi_utils::{FFI_RESULT_OK, FfiResult, OpaqueCtx, catch_unwind_cb, vec_clone_
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use object_cache::{EncryptPubKeyHandle, EncryptSecKeyHandle, SignKeyHandle};
 use rust_sodium::crypto::{box_, sealedbox, sign};
+use safe_core::crypto::shared_box;
 use safe_core::ffi::{AsymNonce, AsymPublicKey, AsymSecretKey};
 use std::os::raw::c_void;
 use std::slice;
@@ -116,7 +117,7 @@ pub unsafe extern "C" fn enc_generate_key_pair(
                         EncryptSecKeyHandle),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
-        let (ourpk, oursk) = box_::gen_keypair();
+        let (ourpk, oursk) = shared_box::gen_keypair();
         let user_data = OpaqueCtx(user_data);
 
         (*app).send(move |_, context| {
@@ -187,7 +188,7 @@ pub unsafe extern "C" fn enc_secret_key_new(
     o_cb: extern "C" fn(*mut c_void, FfiResult, EncryptSecKeyHandle),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
-        let key = box_::SecretKey(*data);
+        let key = shared_box::SecretKey::from_raw(&*data);
         send_sync(app, user_data, o_cb, move |_, context| {
             Ok(context.object_cache().insert_secret_key(key))
         })

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -239,7 +239,8 @@ mod tests {
     use ffi_utils::test_utils::call_2;
     use rand;
     use routing::{Action, PermissionSet};
-    use rust_sodium::crypto::{box_, secretbox, sign};
+    use rust_sodium::crypto::secretbox;
+    use safe_core::crypto::{shared_box, shared_secretbox, shared_sign};
     use safe_core::ipc::{self, AccessContInfo, AppKeys, AuthGranted, AuthReq, BootstrapConfig,
                          ContainersReq, IpcMsg, IpcReq, IpcResp, ShareMData, ShareMDataReq};
     use safe_core::ipc::req::Permission;
@@ -643,10 +644,10 @@ mod tests {
     }
 
     fn gen_app_keys() -> AppKeys {
-        let (owner_key, _) = sign::gen_keypair();
-        let enc_key = secretbox::gen_key();
-        let (sign_pk, sign_sk) = sign::gen_keypair();
-        let (enc_pk, enc_sk) = box_::gen_keypair();
+        let (owner_key, _) = shared_sign::gen_keypair();
+        let enc_key = shared_secretbox::gen_key();
+        let (sign_pk, sign_sk) = shared_sign::gen_keypair();
+        let (enc_pk, enc_sk) = shared_box::gen_keypair();
 
         AppKeys {
             owner_key: owner_key,

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -25,6 +25,7 @@ use object_cache::MDataInfoHandle;
 use routing::XorName;
 use rust_sodium::crypto::secretbox;
 use safe_core::MDataInfo;
+use safe_core::crypto::shared_secretbox;
 use safe_core::ffi::{SymNonce, SymSecretKey, XorNameArray};
 use std::os::raw::c_void;
 
@@ -62,7 +63,7 @@ pub unsafe extern "C" fn mdata_info_new_private(
     catch_unwind_cb(user_data, o_cb, || {
         let name = XorName(*name);
 
-        let sk = secretbox::Key(*secret_key);
+        let sk = shared_secretbox::Key::from_raw(&*secret_key);
         let nonce = secretbox::Nonce(*nonce);
 
         send_sync(app, user_data, o_cb, move |_, context| {
@@ -329,7 +330,7 @@ mod tests {
             ))
         };
 
-        let key = secretbox::gen_key();
+        let key = shared_secretbox::gen_key();
         let nonce = secretbox::gen_nonce();
         let new_info_h = unsafe {
             unwrap!(call_1(|ud, cb| {

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -76,11 +76,11 @@ use futures::stream::Stream;
 use futures::sync::mpsc as futures_mpsc;
 use maidsafe_utilities::serialisation::deserialise;
 use maidsafe_utilities::thread::{self, Joiner};
-use rust_sodium::crypto::secretbox;
 use safe_core::{Client, ClientKeys, CoreMsg, CoreMsgTx, FutureExt, MDataInfo, NetworkEvent,
                 NetworkTx, event_loop, utils};
 #[cfg(feature = "use-mock-routing")]
 use safe_core::MockRouting as Routing;
+use safe_core::crypto::shared_secretbox;
 use safe_core::ipc::{AccessContInfo, AppKeys, AuthGranted, BootstrapConfig, Permission};
 use safe_core::ipc::resp::access_container_enc_key;
 use std::cell::RefCell;
@@ -319,7 +319,7 @@ pub struct Unregistered {
 pub struct Registered {
     object_cache: ObjectCache,
     app_id: String,
-    sym_enc_key: secretbox::Key,
+    sym_enc_key: shared_secretbox::Key,
     access_container_info: AccessContInfo,
     access_info: RefCell<AccessContainerEntry>,
 }
@@ -331,7 +331,7 @@ impl AppContext {
 
     fn registered(
         app_id: String,
-        sym_enc_key: secretbox::Key,
+        sym_enc_key: shared_secretbox::Key,
         access_container_info: AccessContInfo,
     ) -> Self {
         AppContext::Registered(Rc::new(Registered {
@@ -352,7 +352,7 @@ impl AppContext {
     }
 
     /// Symmetric encryption/decryption key.
-    pub fn sym_enc_key(&self) -> Result<&secretbox::Key, AppError> {
+    pub fn sym_enc_key(&self) -> Result<&shared_secretbox::Key, AppError> {
         Ok(&self.as_registered()?.sym_enc_key)
     }
 

--- a/safe_app/src/object_cache.rs
+++ b/safe_app/src/object_cache.rs
@@ -26,6 +26,7 @@ use lru_cache::LruCache;
 use routing::{EntryAction, PermissionSet, User, Value};
 use rust_sodium::crypto::{box_, sign};
 use safe_core::{MDataInfo, SelfEncryptionStorage};
+use safe_core::crypto::shared_box;
 use self_encryption::{SelfEncryptor, SequentialEncryptor};
 use std::cell::{Cell, RefCell, RefMut};
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,7 +81,7 @@ pub struct ObjectCache {
     handle_gen: HandleGenerator,
     cipher_opt: Store<CipherOpt>,
     encrypt_key: Store<box_::PublicKey>,
-    secret_key: Store<box_::SecretKey>,
+    secret_key: Store<shared_box::SecretKey>,
     mdata_info: Store<MDataInfo>,
     mdata_entries: Store<BTreeMap<Vec<u8>, Value>>,
     mdata_keys: Store<BTreeSet<Vec<u8>>>,
@@ -185,7 +186,7 @@ impl_cache!(
 );
 impl_cache!(
     secret_key,
-    box_::SecretKey,
+    shared_box::SecretKey,
     EncryptSecKeyHandle,
     InvalidEncryptSecKeyHandle,
     get_secret_key,

--- a/safe_core/src/client/account.rs
+++ b/safe_core/src/client/account.rs
@@ -17,6 +17,7 @@
 
 use DIR_TAG;
 use client::MDataInfo;
+use crypto::{shared_box, shared_secretbox, shared_sign};
 use errors::CoreError;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::{FullId, XOR_NAME_LEN, XorName};
@@ -124,24 +125,24 @@ pub struct ClientKeys {
     /// Signing public key
     pub sign_pk: sign::PublicKey,
     /// Signing secret key
-    pub sign_sk: sign::SecretKey,
+    pub sign_sk: shared_sign::SecretKey,
     /// Encryption public key
     pub enc_pk: box_::PublicKey,
     /// Encryption private key
-    pub enc_sk: box_::SecretKey,
+    pub enc_sk: shared_box::SecretKey,
     /// Symmetric encryption key
-    pub enc_key: secretbox::Key,
+    pub enc_key: shared_secretbox::Key,
 }
 
 impl ClientKeys {
     /// Construct new `ClientKeys`
     pub fn new(seed: Option<&Seed>) -> Self {
         let sign = match seed {
-            Some(s) => sign::keypair_from_seed(s),
-            None => sign::gen_keypair(),
+            Some(s) => shared_sign::keypair_from_seed(s),
+            None => shared_sign::gen_keypair(),
         };
-        let enc = box_::gen_keypair();
-        let enc_key = secretbox::gen_key();
+        let enc = shared_box::gen_keypair();
+        let enc_key = shared_secretbox::gen_key();
 
         ClientKeys {
             sign_pk: sign.0,
@@ -161,7 +162,10 @@ impl Default for ClientKeys {
 
 impl Into<FullId> for ClientKeys {
     fn into(self) -> FullId {
-        FullId::with_keys((self.enc_pk, self.enc_sk), (self.sign_pk, self.sign_sk))
+        let enc_sk = (*self.enc_sk).clone();
+        let sign_sk = (*self.sign_sk).clone();
+
+        FullId::with_keys((self.enc_pk, enc_sk), (self.sign_pk, sign_sk))
     }
 }
 

--- a/safe_core/src/crypto.rs
+++ b/safe_core/src/crypto.rs
@@ -1,0 +1,218 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+//! Secret encryption and signing keys with more secure cloning semantics. These
+//! keys implement implicit sharing of the underlying sensitive data to avoid
+//! multiple copies of it stored in the memory, preventing certain class of attacks.
+
+/// Symmetric encryption utilities.
+pub mod shared_secretbox {
+    use rust_sodium::crypto::secretbox;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt::{self, Debug};
+    use std::ops::Deref;
+    use std::sync::Arc;
+
+    /// Shared symmetric encryption key.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct Key(Arc<secretbox::Key>);
+
+    impl Key {
+        /// Create new safe-to-share key from the given regular key.
+        pub fn new(inner: secretbox::Key) -> Self {
+            // NOTE: make sure we move the inner array, not the whole key, because
+            // moving the key would leave the `inner` variable in the "moved-from"
+            // state which means it's destructor wouldn't be called and the old
+            // memory location wouldn't be zeroed - leaving the sensitive data
+            // dangling in the memory.
+            Key(Arc::new(secretbox::Key(inner.0)))
+        }
+
+        /// Create new key from the given raw key data.
+        pub fn from_raw(data: &[u8; secretbox::KEYBYTES]) -> Self {
+            // FIXME: this function subverts the purpose of this module - it
+            // copies the sensitive data. Possible fix might be to take the input by
+            // mutable reference and zero it afterwards.
+            Key(Arc::new(secretbox::Key(*data)))
+        }
+
+        /// Create new key from the data in the given slice.
+        pub fn from_slice(data: &[u8]) -> Option<Self> {
+            secretbox::Key::from_slice(data).map(Self::new)
+        }
+    }
+
+    /// Generate new random shared symmetric encryption key.
+    pub fn gen_key() -> Key {
+        Key::new(secretbox::gen_key())
+    }
+
+    impl Deref for Key {
+        type Target = secretbox::Key;
+
+        fn deref(&self) -> &Self::Target {
+            &*self.0
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Key {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let inner = secretbox::Key::deserialize(deserializer)?;
+            Ok(Key::new(inner))
+        }
+    }
+
+    impl Serialize for Key {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl Debug for Key {
+        fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+}
+
+/// Asymmetric encryption utilities.
+pub mod shared_box {
+    use rust_sodium::crypto::box_;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt::{self, Debug};
+    use std::ops::Deref;
+    use std::sync::Arc;
+
+    /// Shared secret encryption key.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct SecretKey(Arc<box_::SecretKey>);
+
+    impl SecretKey {
+        /// Create new safe-to-share key from the given regular key.
+        pub fn new(inner: box_::SecretKey) -> Self {
+            SecretKey(Arc::new(box_::SecretKey(inner.0)))
+        }
+
+        /// Create new key from the given raw key data.
+        pub fn from_raw(data: &[u8; box_::SECRETKEYBYTES]) -> Self {
+            // FIXME: this function subverts the purpose of this module - it
+            // copies the sensitive data. Possible fix might be to take the input by
+            // mutable reference and zero it afterwards.
+            SecretKey(Arc::new(box_::SecretKey(*data)))
+        }
+    }
+
+    /// Generate new random public/secret keypair.
+    pub fn gen_keypair() -> (box_::PublicKey, SecretKey) {
+        let (pk, sk) = box_::gen_keypair();
+        (pk, SecretKey::new(sk))
+    }
+
+    impl Deref for SecretKey {
+        type Target = box_::SecretKey;
+
+        fn deref(&self) -> &Self::Target {
+            &*self.0
+        }
+    }
+
+    impl<'de> Deserialize<'de> for SecretKey {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let inner = box_::SecretKey::deserialize(deserializer)?;
+            Ok(SecretKey::new(inner))
+        }
+    }
+
+    impl Serialize for SecretKey {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl Debug for SecretKey {
+        fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+}
+
+/// Signing utilities.
+pub mod shared_sign {
+    use rust_sodium::crypto::sign;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt::{self, Debug};
+    use std::ops::Deref;
+    use std::sync::Arc;
+
+    /// Shared secret signing key.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct SecretKey(Arc<sign::SecretKey>);
+
+    impl SecretKey {
+        /// Create new safe-to-share key from the given regular key.
+        pub fn new(inner: sign::SecretKey) -> Self {
+            SecretKey(Arc::new(sign::SecretKey(inner.0)))
+        }
+
+        /// Create new key from the given raw key data.
+        pub fn from_raw(data: &[u8; sign::SECRETKEYBYTES]) -> Self {
+            // FIXME: this function subverts the purpose of this module - it
+            // copies the sensitive data. Possible fix might be to take the input by
+            // mutable reference and zero it afterwards.
+            SecretKey(Arc::new(sign::SecretKey(*data)))
+        }
+    }
+
+    /// Generate new random public/secret keypair.
+    pub fn gen_keypair() -> (sign::PublicKey, SecretKey) {
+        let (pk, sk) = sign::gen_keypair();
+        (pk, SecretKey::new(sk))
+    }
+
+    /// Generate new random public/secret keypair using the given seed.
+    pub fn keypair_from_seed(seed: &sign::Seed) -> (sign::PublicKey, SecretKey) {
+        let (pk, sk) = sign::keypair_from_seed(seed);
+        (pk, SecretKey::new(sk))
+    }
+
+    impl Deref for SecretKey {
+        type Target = sign::SecretKey;
+
+        fn deref(&self) -> &Self::Target {
+            &*self.0
+        }
+    }
+
+    impl<'de> Deserialize<'de> for SecretKey {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let inner = sign::SecretKey::deserialize(deserializer)?;
+            Ok(SecretKey::new(inner))
+        }
+    }
+
+    impl Serialize for SecretKey {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl Debug for SecretKey {
+        fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+}

--- a/safe_core/src/immutable_data.rs
+++ b/safe_core/src/immutable_data.rs
@@ -16,11 +16,11 @@
 // relating to use of the SAFE Network Software.
 
 use client::Client;
+use crypto::shared_secretbox;
 use event_loop::CoreFuture;
 use futures::Future;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::{ImmutableData, XorName};
-use rust_sodium::crypto::secretbox;
 use self_encryption::{DataMap, SelfEncryptor};
 use self_encryption_storage::SelfEncryptionStorage;
 use utils::{self, FutureExt};
@@ -37,7 +37,7 @@ enum DataTypeEncoding {
 pub fn create<T: 'static>(
     client: &Client<T>,
     value: &[u8],
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<CoreFuture<ImmutableData>> {
     trace!("Creating conformant ImmutableData.");
 
@@ -71,7 +71,7 @@ pub fn create<T: 'static>(
 pub fn extract_value<T: 'static>(
     client: &Client<T>,
     data: &ImmutableData,
-    decryption_key: Option<secretbox::Key>,
+    decryption_key: Option<shared_secretbox::Key>,
 ) -> Box<CoreFuture<Vec<u8>>> {
     let client = client.clone();
 
@@ -100,7 +100,7 @@ pub fn extract_value<T: 'static>(
 pub fn get_value<T: 'static>(
     client: &Client<T>,
     name: &XorName,
-    decryption_key: Option<secretbox::Key>,
+    decryption_key: Option<shared_secretbox::Key>,
 ) -> Box<CoreFuture<Vec<u8>>> {
     let client2 = client.clone();
     client
@@ -155,7 +155,6 @@ fn unpack<T: 'static>(client: Client<T>, data: &ImmutableData) -> Box<CoreFuture
 mod tests {
     use super::*;
     use futures::Future;
-    use rust_sodium::crypto::secretbox;
     use utils;
     use utils::test_utils::{finish, random_client};
 
@@ -212,7 +211,7 @@ mod tests {
         // Encrypted
         {
             let value_before = value.clone();
-            let key = secretbox::gen_key();
+            let key = shared_secretbox::gen_key();
 
             random_client(move |client| {
                 let client2 = client.clone();
@@ -239,7 +238,7 @@ mod tests {
         // Put unencrypted Retrieve encrypted - Should fail
         {
             let value = value.clone();
-            let key = secretbox::gen_key();
+            let key = shared_secretbox::gen_key();
 
             random_client(move |client| {
                 let client2 = client.clone();
@@ -265,7 +264,7 @@ mod tests {
         // Put encrypted Retrieve unencrypted - Should fail
         {
             let value = value.clone();
-            let key = secretbox::gen_key();
+            let key = shared_secretbox::gen_key();
 
             random_client(move |client| {
                 let client2 = client.clone();

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -57,6 +57,7 @@ extern crate lru_cache;
 extern crate maidsafe_utilities;
 extern crate rand;
 extern crate routing;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate rust_sodium;
@@ -79,6 +80,8 @@ pub mod ipc;
 pub mod nfs;
 /// Implements the Self Encryption storage trait
 pub mod self_encryption_storage;
+/// Cryptographic utilities
+pub mod crypto;
 
 mod client;
 mod errors;

--- a/safe_core/src/nfs/data_map.rs
+++ b/safe_core/src/nfs/data_map.rs
@@ -18,12 +18,12 @@
 //! `DataMap` utilities
 
 use client::Client;
+use crypto::shared_secretbox;
 use futures::{Future, future};
 use immutable_data;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use nfs::NfsFuture;
 use routing::XorName;
-use rust_sodium::crypto::secretbox;
 use self_encryption::DataMap;
 use utils::FutureExt;
 
@@ -32,7 +32,7 @@ use utils::FutureExt;
 pub fn get<T: 'static>(
     client: &Client<T>,
     name: &XorName,
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<NfsFuture<DataMap>> {
     immutable_data::get_value(client, name, encryption_key)
         .map_err(From::from)
@@ -45,7 +45,7 @@ pub fn get<T: 'static>(
 pub fn put<T: 'static>(
     client: &Client<T>,
     data_map: &DataMap,
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<NfsFuture<XorName>> {
     let client = client.clone();
     let client2 = client.clone();

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -16,12 +16,12 @@
 // relating to use of the SAFE Network Software.
 
 use client::{Client, MDataInfo};
+use crypto::shared_secretbox;
 use errors::CoreError;
 use futures::{Future, IntoFuture};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use nfs::{File, Mode, NfsError, NfsFuture, Reader, Writer};
 use routing::{ClientError, EntryActions};
-use rust_sodium::crypto::secretbox;
 use self_encryption_storage::SelfEncryptionStorage;
 use utils::FutureExt;
 
@@ -86,7 +86,7 @@ where
 pub fn read<T: 'static>(
     client: Client<T>,
     file: &File,
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<NfsFuture<Reader<T>>> {
     trace!("Reading file {:?}", file);
     Reader::new(
@@ -178,7 +178,7 @@ pub fn write<T>(
     client: Client<T>,
     file: File,
     mode: Mode,
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<NfsFuture<Writer<T>>>
 where
     T: 'static,
@@ -208,11 +208,11 @@ fn convert_error(err: CoreError) -> NfsError {
 mod tests {
     use DIR_TAG;
     use client::{Client, MDataInfo};
+    use crypto::shared_secretbox;
     use errors::CoreError;
     use futures::Future;
     use nfs::{File, Mode, NfsError, NfsFuture, create_dir, file_helper};
     use rand::{self, Rng};
-    use rust_sodium::crypto::secretbox;
     use utils::FutureExt;
     use utils::test_utils::random_client;
 
@@ -555,8 +555,8 @@ mod tests {
             let content: Vec<u8> = rng.gen_iter().take(ORIG_SIZE).collect();
             let content2 = content.clone();
 
-            let key = secretbox::gen_key();
-            let wrong_key = secretbox::gen_key();
+            let key = shared_secretbox::gen_key();
+            let wrong_key = shared_secretbox::gen_key();
 
             file_helper::write(
                 client.clone(),

--- a/safe_core/src/nfs/reader.rs
+++ b/safe_core/src/nfs/reader.rs
@@ -16,9 +16,9 @@
 // relating to use of the SAFE Network Software.
 
 use client::Client;
+use crypto::shared_secretbox;
 use futures::Future;
 use nfs::{File, NfsError, NfsFuture, data_map};
-use rust_sodium::crypto::secretbox;
 use self_encryption::SelfEncryptor;
 use self_encryption_storage::SelfEncryptionStorage;
 use utils::FutureExt;
@@ -37,7 +37,7 @@ impl<T: 'static> Reader<T> {
         client: Client<T>,
         storage: SelfEncryptionStorage<T>,
         file: &File,
-        encryption_key: Option<secretbox::Key>,
+        encryption_key: Option<shared_secretbox::Key>,
     ) -> Box<NfsFuture<Reader<T>>> {
         data_map::get(&client, file.data_map_name(), encryption_key)
             .and_then(move |data_map| {

--- a/safe_core/src/nfs/writer.rs
+++ b/safe_core/src/nfs/writer.rs
@@ -17,9 +17,9 @@
 
 use chrono::Utc;
 use client::Client;
+use crypto::shared_secretbox;
 use futures::Future;
 use nfs::{File, NfsFuture, data_map};
-use rust_sodium::crypto::secretbox;
 use self_encryption::SequentialEncryptor;
 use self_encryption_storage::SelfEncryptionStorage;
 use utils::FutureExt;
@@ -38,7 +38,7 @@ pub struct Writer<T> {
     client: Client<T>,
     file: File,
     self_encryptor: SequentialEncryptor<SelfEncryptionStorage<T>>,
-    encryption_key: Option<secretbox::Key>,
+    encryption_key: Option<shared_secretbox::Key>,
 }
 
 impl<T: 'static> Writer<T> {
@@ -48,7 +48,7 @@ impl<T: 'static> Writer<T> {
         storage: SelfEncryptionStorage<T>,
         file: File,
         mode: Mode,
-        encryption_key: Option<secretbox::Key>,
+        encryption_key: Option<shared_secretbox::Key>,
     ) -> Box<NfsFuture<Writer<T>>> {
         let fut = match mode {
             Mode::Append => {

--- a/safe_core/src/utils/mod.rs
+++ b/safe_core/src/utils/mod.rs
@@ -17,6 +17,7 @@
 
 #[macro_use]
 mod futures;
+
 /// Common utility functions for writing test cases
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;


### PR DESCRIPTION
Rebase of #572 on the latest master branch.

Replace all secret keys (`rust_sodium::crypto::box_::SecretKey`, `rust_sodium::crypto::secretbox::Key` and `rust_sodium::crypto::sign::SecretKey`) with drop-in equivalents that implement "secure cloning" - they don't actually clone the underlying data but instead implicitly share it. This is supposed to prevent some attack vectors.