### PR TITLE
refactor/app: optimise the network events callback

### DIFF
--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -59,7 +59,7 @@ use std::slice;
 /// Create unregistered app.
 /// The `user_data` parameter corresponds to the first parameter of the
 /// `o_cb` callback, while `disconnect_cb_user_data` corresponds to the
-/// first parameter of `o_disconnect_notifier_cb`.
+/// parameter of `o_disconnect_notifier_cb`.
 ///
 /// Callback parameters: user data, error code, app
 #[no_mangle]
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn app_unregistered(
     bootstrap_config_len: usize,
     disconnect_cb_user_data: *mut c_void,
     user_data: *mut c_void,
-    o_disconnect_notifier_cb: extern "C" fn(user_data: *mut c_void, result: FfiResult),
+    o_disconnect_notifier_cb: extern "C" fn(user_data: *mut c_void),
     o_cb: extern "C" fn(user_data: *mut c_void, result: FfiResult, app: *mut App),
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn app_unregistered(
         };
 
         let app = App::unregistered(
-            move || o_disconnect_notifier_cb(disconnect_cb_user_data.0, FFI_RESULT_OK),
+            move || o_disconnect_notifier_cb(disconnect_cb_user_data.0),
             config,
         )?;
 
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn app_unregistered(
 /// Create a registered app.
 /// The `user_data` parameter corresponds to the first parameter of the
 /// `o_cb` callback, while `disconnect_cb_user_data` corresponds to the
-/// first parameter of `o_disconnect_notifier_cb`.
+/// parameter of `o_disconnect_notifier_cb`.
 ///
 /// Callback parameters: user data, error code, app
 #[no_mangle]
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn app_registered(
     auth_granted: *const FfiAuthGranted,
     disconnect_cb_user_data: *mut c_void,
     user_data: *mut c_void,
-    o_disconnect_notifier_cb: extern "C" fn(user_data: *mut c_void, result: FfiResult),
+    o_disconnect_notifier_cb: extern "C" fn(user_data: *mut c_void),
     o_cb: extern "C" fn(user_data: *mut c_void, result: FfiResult, app: *mut App),
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn app_registered(
         let auth_granted = AuthGranted::clone_from_repr_c(auth_granted)?;
 
         let app = App::registered(app_id, auth_granted, move || {
-            o_disconnect_notifier_cb(disconnect_cb_user_data.0, FFI_RESULT_OK)
+            o_disconnect_notifier_cb(disconnect_cb_user_data.0)
         })?;
 
         o_cb(user_data.0, FFI_RESULT_OK, Box::into_raw(Box::new(app)));

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -322,6 +322,8 @@ mod tests {
             }
         }
 
+        let mut ud = Default::default();
+
         // Key 0
         unsafe {
             mdata_entries_get(
@@ -329,7 +331,7 @@ mod tests {
                 handle0,
                 key0.as_ptr(),
                 key0.len(),
-                sender_as_user_data(&tx),
+                sender_as_user_data(&tx, &mut ud),
                 get_cb,
             );
         };
@@ -343,7 +345,7 @@ mod tests {
                 handle0,
                 key1.as_ptr(),
                 key1.len(),
-                sender_as_user_data(&tx),
+                sender_as_user_data(&tx, &mut ud),
                 get_cb,
             );
         };

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -283,7 +283,7 @@ fn entries_crud_ffi() {
     // Retrieve added entry
     {
         let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
-        let ud = sender_as_user_data(&tx);
+        let mut ud = Default::default();
 
         unsafe {
             mdata_get_value(
@@ -291,7 +291,7 @@ fn entries_crud_ffi() {
                 &md_info_pub,
                 KEY.as_ptr(),
                 KEY.len(),
-                ud,
+                sender_as_user_data(&tx, &mut ud),
                 get_value_cb,
             )
         };
@@ -394,7 +394,7 @@ fn entries_crud_ffi() {
     // Retrieve added entry from private MD
     {
         let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
-        let ud = sender_as_user_data(&tx);
+        let mut ud = Default::default();
 
         unsafe {
             mdata_get_value(
@@ -402,7 +402,7 @@ fn entries_crud_ffi() {
                 &md_info_priv,
                 key_enc.as_ptr(),
                 key_enc.len(),
-                ud,
+                sender_as_user_data(&tx, &mut ud),
                 get_value_cb,
             )
         };
@@ -435,7 +435,7 @@ fn entries_crud_ffi() {
 
         // Try with a fake entry key, expect error.
         let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
-        let ud = sender_as_user_data(&tx);
+        let mut ud = Default::default();
 
         let fake_key = vec![0];
         unsafe {
@@ -444,7 +444,7 @@ fn entries_crud_ffi() {
                 entries_list_h,
                 fake_key.as_ptr(),
                 fake_key.len(),
-                ud,
+                sender_as_user_data(&tx, &mut ud),
                 get_value_cb,
             )
         };
@@ -457,7 +457,7 @@ fn entries_crud_ffi() {
 
         // Try with the real encrypted entry key.
         let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
-        let ud = sender_as_user_data(&tx);
+        let mut ud = Default::default();
 
         unsafe {
             mdata_entries_get(
@@ -465,7 +465,7 @@ fn entries_crud_ffi() {
                 entries_list_h,
                 key_enc.as_ptr(),
                 key_enc.len(),
-                ud,
+                sender_as_user_data(&tx, &mut ud),
                 get_value_cb,
             )
         };

--- a/safe_app/src/ffi/tests/mod.rs
+++ b/safe_app/src/ffi/tests/mod.rs
@@ -58,11 +58,12 @@ fn account_info() {
 #[test]
 fn network_status_callback() {
     use App;
-    use ffi_utils::test_utils::{call_0, send_via_user_data, sender_as_user_data};
+    use ffi_utils::test_utils::{call_0, sender_as_user_data};
     use maidsafe_utilities::serialisation::serialise;
     use safe_core::ipc::BootstrapConfig;
     use std::os::raw::c_void;
     use std::sync::mpsc;
+    use std::sync::mpsc::Sender;
     use std::time::Duration;
 
     {
@@ -121,9 +122,10 @@ fn network_status_callback() {
         unsafe { app_free(app) };
     }
 
-    extern "C" fn disconnect_cb(user_data: *mut c_void, res: FfiResult) {
+    extern "C" fn disconnect_cb(user_data: *mut c_void) {
         unsafe {
-            send_via_user_data(user_data, res.error_code);
+            let tx = user_data as *mut Sender<()>;
+            unwrap!((*tx).send(()));
         }
     }
 }

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -96,7 +96,7 @@ pub fn create_app() -> App {
         },
     ));
 
-    unwrap!(App::registered(app_id, auth_granted, |_network_event| ()))
+    unwrap!(App::registered(app_id, auth_granted, || ()))
 }
 
 /// Create app and grant it access to the specified containers.
@@ -115,7 +115,7 @@ pub fn create_app_with_access(access_info: HashMap<String, ContainerPermissions>
         },
     ));
 
-    unwrap!(App::registered(app_id, auth_granted, |_network_event| ()))
+    unwrap!(App::registered(app_id, auth_granted, || ()))
 }
 
 /// Creates a random app instance for testing.

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -162,7 +162,7 @@ pub fn login_registered_with_low_balance() {
     let _app = unwrap!(App::registered_with_hook(
         app_id,
         auth_granted,
-        |_network_event| (),
+        || (),
         routing_hook,
     ));
 }
@@ -183,11 +183,7 @@ fn authorise_app(
         },
     ));
 
-    unwrap!(App::registered(
-        String::from(app_id),
-        auth_granted,
-        |_network_event| (),
-    ))
+    unwrap!(App::registered(String::from(app_id), auth_granted, || ()))
 }
 
 // Get the number of containers for `app`

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -35,8 +35,7 @@ use std::os::raw::{c_char, c_void};
 /// Create a registered client. This or any one of the other companion
 /// functions to get an authenticator instance must be called before initiating any
 /// operation allowed by this module. The `user_data` parameter corresponds to the
-/// first parameter of the `o_cb` callback, while `network_cb_user_data` corresponds
-/// to the first parameter of the network events observer callback (`o_network_obs_cb`).
+/// first parameter of the `o_cb` and `o_disconnect_notifier_cb` callbacks.
 ///
 /// Callback parameters: user data, error code, authenticator
 #[no_mangle]
@@ -44,15 +43,13 @@ pub unsafe extern "C" fn create_acc(
     account_locator: *const c_char,
     account_password: *const c_char,
     invitation: *const c_char,
-    network_cb_user_data: *mut c_void,
     user_data: *mut c_void,
-    o_network_obs_cb: extern "C" fn(user_data: *mut c_void, err_code: i32, event: i32),
+    o_disconnect_notifier_cb: extern "C" fn(user_data: *mut c_void),
     o_cb: extern "C" fn(user_data: *mut c_void,
                         result: FfiResult,
                         authenticator: *mut Authenticator),
 ) {
     let user_data = OpaqueCtx(user_data);
-    let network_cb_user_data = OpaqueCtx(network_cb_user_data);
 
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
         trace!("Authenticator - create a client account.");
@@ -62,12 +59,8 @@ pub unsafe extern "C" fn create_acc(
         let invitation = from_c_str(invitation)?;
 
         let authenticator =
-            Authenticator::create_acc(acc_locator, acc_password, invitation, move |net_event| {
-                let ud = network_cb_user_data.0;
-                match net_event {
-                    Ok(event) => o_network_obs_cb(ud, 0, event.into()),
-                    Err(()) => o_network_obs_cb(ud, -1, 0),
-                }
+            Authenticator::create_acc(acc_locator, acc_password, invitation, move || {
+                o_disconnect_notifier_cb(user_data.0)
             })?;
 
         o_cb(
@@ -83,8 +76,7 @@ pub unsafe extern "C" fn create_acc(
 /// Log into a registered account. This or any one of the other companion
 /// functions to get an authenticator instance must be called before initiating
 /// any operation allowed for authenticator. The `user_data` parameter corresponds to the
-/// first parameter of the `o_cb` callback, while `network_cb_user_data` corresponds
-/// to the first parameter of the network events observer callback (`o_network_obs_cb`).
+/// first parameter of the `o_cb` and `o_disconnect_notifier_cb` callbacks.
 ///
 /// Callback parameters: user data, error code, authenticator
 #[no_mangle]
@@ -92,14 +84,12 @@ pub unsafe extern "C" fn login(
     account_locator: *const c_char,
     account_password: *const c_char,
     user_data: *mut c_void,
-    network_cb_user_data: *mut c_void,
-    o_network_obs_cb: unsafe extern "C" fn(user_data: *mut c_void, err_code: i32, event: i32),
+    o_disconnect_notifier_cb: unsafe extern "C" fn(user_data: *mut c_void),
     o_cb: extern "C" fn(user_data: *mut c_void,
                         result: FfiResult,
                         authenticaor: *mut Authenticator),
 ) {
     let user_data = OpaqueCtx(user_data);
-    let network_cb_user_data = OpaqueCtx(network_cb_user_data);
 
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
         trace!("Authenticator - log in a registered client.");
@@ -107,14 +97,9 @@ pub unsafe extern "C" fn login(
         let acc_locator = from_c_str(account_locator)?;
         let acc_password = from_c_str(account_password)?;
 
-        let authenticator = Authenticator::login(
-            acc_locator,
-            acc_password,
-            move |net_event| match net_event {
-                Ok(event) => o_network_obs_cb(network_cb_user_data.0, 0, event.into()),
-                Err(()) => o_network_obs_cb(network_cb_user_data.0, -1, 0),
-            },
-        )?;
+        let authenticator = Authenticator::login(acc_locator, acc_password, move || {
+            o_disconnect_notifier_cb(user_data.0)
+        })?;
 
         o_cb(
             user_data.0,
@@ -257,8 +242,7 @@ mod tests {
                         acc_password.as_ptr(),
                         invitation.as_ptr(),
                         ud,
-                        ud,
-                        net_event_cb,
+                        || (),
                         cb,
                     )
                 }))
@@ -270,14 +254,7 @@ mod tests {
         {
             let auth_h: *mut Authenticator = unsafe {
                 unwrap!(call_1(|ud, cb| {
-                    login(
-                        acc_locator.as_ptr(),
-                        acc_password.as_ptr(),
-                        ud,
-                        ud,
-                        net_event_cb,
-                        cb,
-                    )
+                    login(acc_locator.as_ptr(), acc_password.as_ptr(), ud, || (), cb)
                 }))
             };
             assert!(!auth_h.is_null());
@@ -290,17 +267,17 @@ mod tests {
     #[test]
     fn network_status_callback() {
         use ffi_utils::test_utils::call_0;
-        use ffi_utils::test_utils::{send_via_user_data, sender_as_user_data};
-        use safe_core::NetworkEvent;
+        use ffi_utils::test_utils::sender_as_user_data;
         use std::time::Duration;
         use std::sync::mpsc;
+        use std::sync::mpsc::{Receiver, Sender};
 
         let acc_locator = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
         let acc_password = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
         let invitation = unwrap!(CString::new(unwrap!(utils::generate_random_string(10))));
 
         {
-            let (tx, rx) = mpsc::channel();
+            let (tx, rx): (Sender<()>, Receiver<()>) = mpsc::channel();
 
             let auth: *mut Authenticator = unsafe {
                 unwrap!(call_1(|ud, cb| {
@@ -308,9 +285,10 @@ mod tests {
                         acc_locator.as_ptr(),
                         acc_password.as_ptr(),
                         invitation.as_ptr(),
-                        sender_as_user_data(&tx),
                         ud,
-                        net_event_cb,
+                        || {
+                            unwrap!(tx.send(()));
+                        },
                         cb,
                     )
                 }))
@@ -323,40 +301,34 @@ mod tests {
                 }));
             }
 
-            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
-            assert_eq!(err_code, 0);
-
-            let disconnected: i32 = NetworkEvent::Disconnected.into();
-            assert_eq!(event, disconnected);
+            // disconnect_cb should be called.
+            unwrap!(rx.recv_timeout(Duration::from_secs(10)));
 
             // Reconnect with the network
             unsafe { unwrap!(call_0(|ud, cb| auth_reconnect(auth, ud, cb))) };
 
-            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
-            assert_eq!(err_code, 0);
-
-            let connected: i32 = NetworkEvent::Connected.into();
-            assert_eq!(event, connected);
+            // This should time out.
+            let result = rx.recv_timeout(Duration::from_secs(1));
+            match result {
+                Err(_) => (),
+                _ => panic!("Disconnect callback was called"),
+            }
 
             // The reconnection should be fine if we're already connected.
             unsafe { unwrap!(call_0(|ud, cb| auth_reconnect(auth, ud, cb))) };
 
-            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
-            assert_eq!(err_code, 0);
-            assert_eq!(event, disconnected);
+            // disconnect_cb should be called.
+            unwrap!(rx.recv_timeout(Duration::from_secs(10)));
 
-            let (err_code, event): (i32, i32) = unwrap!(rx.recv_timeout(Duration::from_secs(10)));
-            assert_eq!(err_code, 0);
-            assert_eq!(event, connected);
-
+            // This should time out.
+            unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+            let result = rx.recv_timeout(Duration::from_secs(1));
+            match result {
+                Err(_) => (),
+                _ => panic!("Disconnect callback was called"),
+            }
 
             unsafe { auth_free(auth) };
-        }
-
-        extern "C" fn net_event_cb(user_data: *mut c_void, err_code: i32, event: i32) {
-            unsafe {
-                send_via_user_data(user_data, (err_code, event));
-            }
         }
     }
 
@@ -374,8 +346,7 @@ mod tests {
                     acc_password.as_ptr(),
                     invitation.as_ptr(),
                     ud,
-                    ud,
-                    net_event_cb,
+                    || (),
                     cb,
                 )
             }))
@@ -404,9 +375,5 @@ mod tests {
         );
 
         unsafe { auth_free(auth) };
-    }
-
-    extern "C" fn net_event_cb(_user_data: *mut c_void, err_code: i32, _event: i32) {
-        assert_eq!(err_code, 0);
     }
 }

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -60,7 +60,7 @@ pub fn create_authenticator() -> (Authenticator, String, String) {
         locator.clone(),
         password.clone(),
         invitation,
-        |_| (),
+        || (),
     ));
 
     (auth, locator, password)
@@ -69,7 +69,7 @@ pub fn create_authenticator() -> (Authenticator, String, String) {
 /// Create a random authenticator and login using the same credentials.
 pub fn create_account_and_login() -> Authenticator {
     let (_, locator, password) = create_authenticator();
-    unwrap!(Authenticator::login(locator, password, |_| ()))
+    unwrap!(Authenticator::login(locator, password, || ()))
 }
 
 /// Revoke an app, returning an error on failure
@@ -100,7 +100,7 @@ where
     unwrap!(Authenticator::login_with_hook(
         locator,
         password,
-        |_| (),
+        || (),
         hook,
     ))
 }

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -953,12 +953,13 @@ fn unregistered_decode_ipc_msg(msg: &str) -> ChannelType {
     let (tx, rx) = mpsc::channel::<ChannelType>();
 
     let ffi_msg = unwrap!(CString::new(msg));
+    let mut ud = Default::default();
 
     unsafe {
         use ffi::ipc::auth_unregistered_decode_ipc_msg;
         auth_unregistered_decode_ipc_msg(
             ffi_msg.as_ptr(),
-            sender_as_user_data(&tx),
+            sender_as_user_data(&tx, &mut ud),
             unregistered_cb,
             err_cb,
         );

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -110,7 +110,7 @@ mod mock_routing {
                 locator.clone(),
                 password.clone(),
                 invitation,
-                |_| (),
+                || (),
                 routing_hook,
             );
 
@@ -123,7 +123,7 @@ mod mock_routing {
         }
 
         // Log in using the same credentials
-        let authenticator = unwrap!(Authenticator::login(locator, password, |_| ()));
+        let authenticator = unwrap!(Authenticator::login(locator, password, || ()));
 
         // Make sure that all default directories have been created after log in.
         let std_dir_names: Vec<_> = DEFAULT_PRIVATE_DIRS
@@ -265,7 +265,7 @@ mod mock_routing {
             locator.clone(),
             password.clone(),
             invitation,
-            |_| (),
+            || (),
             routing_hook,
         ));
 
@@ -313,7 +313,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login_with_hook(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
             routing_hook,
         ));
         match register_app(&auth, &auth_req) {
@@ -342,7 +342,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login_with_hook(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
             routing_hook,
         ));
         match register_app(&auth, &auth_req) {
@@ -373,7 +373,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login_with_hook(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
             routing_hook,
         ));
         match register_app(&auth, &auth_req) {
@@ -386,7 +386,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
         ));
         let auth_granted = match register_app(&auth, &auth_req) {
             Ok(auth_granted) => auth_granted,

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -123,7 +123,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login_with_hook(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
             routing_hook,
         ));
 
@@ -165,7 +165,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login(
             locator.clone(),
             password.clone(),
-            |_| (),
+            || (),
         ));
 
         // App revocation should succeed
@@ -296,7 +296,7 @@ mod mock_routing {
         }
 
         // Login again without simulated failures.
-        let auth = unwrap!(Authenticator::login(locator, password, |_| ()));
+        let auth = unwrap!(Authenticator::login(locator, password, || ()));
 
         // Flush the revocation queue and verify both apps get revoked.
         unsafe {
@@ -388,7 +388,7 @@ mod mock_routing {
                     let auth = unwrap!(Authenticator::login_with_hook(
                         locator,
                         password,
-                        |_| (),
+                        || (),
                         move |routing| sync.hook(routing),
                     ));
 
@@ -491,7 +491,7 @@ mod mock_routing {
                     let auth = unwrap!(Authenticator::login_with_hook(
                         locator,
                         password,
-                        |_| (),
+                        || (),
                         move |routing| sync.hook(routing),
                     ));
 
@@ -536,7 +536,7 @@ mod mock_routing {
         S: AsRef<str>,
     {
         // First, log in normally to obtain the access contained info.
-        let auth = unwrap!(Authenticator::login(locator, password, |_| ()));
+        let auth = unwrap!(Authenticator::login(locator, password, || ()));
         let ac_info = run(&auth, |client| Ok(unwrap!(client.access_container())));
 
         // Then, log in with a request hook that makes mutation of the access container
@@ -544,7 +544,7 @@ mod mock_routing {
         let auth = unwrap!(Authenticator::login_with_hook(
             locator,
             password,
-            |_| (),
+            || (),
             move |mut routing| {
                 let ac_info = ac_info.clone();
 

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -204,13 +204,15 @@ fn share_some_mdatas_with_valid_metadata() {
 
     let (tx, rx) = mpsc::channel::<Result<(), (i32, String)>>();
     let req_c = unwrap!(req.into_repr_c());
+    let mut ud = Default::default();
+
     unsafe {
         encode_share_mdata_resp(
             &authenticator,
             &req_c,
             req_id,
             true,
-            sender_as_user_data::<Result<(), (i32, String)>>(&tx),
+            sender_as_user_data::<Result<(), (i32, String)>>(&tx, &mut ud),
             encode_share_mdata_cb,
         );
     }
@@ -292,13 +294,15 @@ fn share_some_mdatas_with_ownership_error() {
 
     let (tx, rx) = mpsc::channel::<Result<(), (i32, String)>>();
     let req_c = unwrap!(req.into_repr_c());
+    let mut ud = Default::default();
+
     unsafe {
         encode_share_mdata_resp(
             &authenticator,
             &req_c,
             req_id,
             false,
-            sender_as_user_data::<Result<(), (i32, String)>>(&tx),
+            sender_as_user_data::<Result<(), (i32, String)>>(&tx, &mut ud),
             encode_share_mdata_cb,
         );
     }
@@ -433,13 +437,15 @@ fn auth_apps_accessing_mdatas() {
 
         let (tx, rx) = mpsc::channel::<Result<(), (i32, String)>>();
         let req_c = unwrap!(req.into_repr_c());
+        let mut ud = Default::default();
+
         unsafe {
             encode_share_mdata_resp(
                 &authenticator,
                 &req_c,
                 req_id,
                 true,
-                sender_as_user_data::<Result<(), (i32, String)>>(&tx),
+                sender_as_user_data::<Result<(), (i32, String)>>(&tx, &mut ud),
                 encode_share_mdata_cb,
             );
         }

--- a/safe_authenticator/src/tests/utils.rs
+++ b/safe_authenticator/src/tests/utils.rs
@@ -135,13 +135,14 @@ pub fn decode_ipc_msg(authenticator: &Authenticator, msg: &str) -> ChannelType {
     }
 
     let ffi_msg = unwrap!(CString::new(msg));
+    let mut ud = Default::default();
 
     unsafe {
         use ffi::ipc::auth_decode_ipc_msg;
         auth_decode_ipc_msg(
             authenticator,
             ffi_msg.as_ptr(),
-            sender_as_user_data(&tx),
+            sender_as_user_data(&tx, &mut ud),
             auth_cb,
             containers_cb,
             unregistered_cb,


### PR DESCRIPTION
Instead of a network-events callback, have a simpler callback whose call alone indicates that a disconnect occurred.