### PR TITLE
fix/safe_app: fix clap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ name = "ffi_utils"
 version = "0.4.0"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "moz-cheddar 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ffi_utils/Cargo.toml
+++ b/ffi_utils/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.4.0"
 
 [dependencies]
+clap = "=2.25.1"
 base64 = "~0.7.0"
 log = "~0.3.7"
 moz-cheddar = "~0.4.0"


### PR DESCRIPTION
It is required because newer version of clap depend on crates that are incompatible with Rust 1.19 (which is currently the only version that we support). This fix needs to be reverted as soon as we'll upgrade to the newer Rust compiler.