### PR TITLE
chore/rust: upgrade to Rust 1.22.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
 env:
   global:
     - RUST_BACKTRACE=1
+    - RUST_STABLE=1.22.1
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust
 matrix:
   include:
     - os: linux
-      rust: 1.19.0
+      rust: 1.22.1
     - os: linux
-      rust: 1.19.0-i686-unknown-linux-gnu
+      rust: 1.22.1-i686-unknown-linux-gnu
       addons:
         apt:
           packages:
             - gcc-multilib
     - os: linux
-      rust: nightly-2017-07-20
+      rust: nightly-2018-01-10
     - os: osx
-      rust: 1.19.0
+      rust: 1.22.1
 sudo: false
 cache: cargo
 before_script:
@@ -42,17 +43,17 @@ before_script:
     fi
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - if [[ "$TRAVIS_RUST_VERSION" == 1.19.0 && $TRAVIS_EVENT_TYPE = pull_request ]]; then
+  - if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" && $TRAVIS_EVENT_TYPE = pull_request ]]; then
       bash cargo_install.sh rustfmt 0.9.0;
     elif [[ "$TRAVIS_RUST_VERSION" =~ nightly && $TRAVIS_EVENT_TYPE = pull_request ]]; then
-      bash cargo_install.sh clippy 0.0.144;
+      bash cargo_install.sh clippy 0.0.179;
     fi
 script:
   - export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
-  - if [[ "$TRAVIS_RUST_VERSION" =~ 1.19.0 && $TRAVIS_EVENT_TYPE = pull_request ]]; then
+  - if [[ "$TRAVIS_RUST_VERSION" =~ "$RUST_STABLE" && $TRAVIS_EVENT_TYPE = pull_request ]]; then
       (
         set -x;
-        if [[ "$TRAVIS_RUST_VERSION" == 1.19.0 ]]; then
+        if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
           echo "--- Check format ---" &&
           cargo fmt --all -- --write-mode=diff;
         fi &&
@@ -73,7 +74,7 @@ script:
         cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml &&
         cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml &&
 
-        if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == 1.19.0 ]]; then
+        if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
           (
             echo "--- Test binary compatibility ---" &&
 
@@ -161,5 +162,5 @@ deploy:
   on:
     branch: master
     tags: false
-    condition: $TRAVIS_RUST_VERSION =~ 1.19.0 && $TRAVIS_EVENT_TYPE = push
+    condition: $TRAVIS_RUST_VERSION =~ $RUST_STABLE && $TRAVIS_EVENT_TYPE = push
 after_deploy: rm -rf target/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,47 @@ env:
   global:
     - RUST_BACKTRACE=1
     - RUST_STABLE=1.22.1
+    - RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust
-matrix:
+stages:
+  - stable
+  - nightly-warmup
+  - nightly-tests
+jobs:
   include:
-    - os: linux
+    # Stable
+    - stage: stable
+      script: scripts/stable
+      os: linux
       rust: 1.22.1
     - os: linux
+      script: scripts/stable
       rust: 1.22.1-i686-unknown-linux-gnu
       addons:
         apt:
           packages:
             - gcc-multilib
-    - os: linux
-      rust: nightly-2018-01-10
     - os: osx
+      script: scripts/stable
       rust: 1.22.1
+    # Nightly compiler warm-up
+    - stage: nightly-warmup
+      script: set -x; scripts/build-all
+      os: linux
+      rust: nightly-2018-01-10
+    # Nightly clippy + tests
+    - stage: nightly-tests
+      script: set -x; scripts/clippy-all
+      os: linux
+      rust: nightly-2018-01-10
+    - stage: nightly-tests
+      script: set -x; scripts/test-all
+      os: linux
+      rust: nightly-2018-01-10
 sudo: false
-cache: cargo
+cache:
+  cargo: true
 before_script:
   # Expected version change PR title format:
   # Version change: safe_app to 0.2.2; safe_authenticator to 0.2.3; safe_core to 0.26.0;
@@ -47,74 +70,6 @@ before_script:
       bash cargo_install.sh rustfmt 0.9.0;
     elif [[ "$TRAVIS_RUST_VERSION" =~ nightly && $TRAVIS_EVENT_TYPE = pull_request ]]; then
       bash cargo_install.sh clippy 0.0.179;
-    fi
-script:
-  - export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
-  - if [[ "$TRAVIS_RUST_VERSION" =~ "$RUST_STABLE" && $TRAVIS_EVENT_TYPE = pull_request ]]; then
-      (
-        set -x;
-        if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
-          echo "--- Check format ---" &&
-          cargo fmt --all -- --write-mode=diff;
-        fi &&
-        echo "--- Test ffi_utils ---" &&
-        cargo test --verbose --release --manifest-path=ffi_utils/Cargo.toml &&
-
-        echo "--- Check compilation against actual routing ---" &&
-        cargo check --verbose --release --manifest-path=safe_core/Cargo.toml &&
-        cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
-        cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-        cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
-        cargo check --verbose --release --lib --tests --manifest-path=tests/Cargo.toml &&
-
-        echo "--- Test against mock ---" &&
-        cargo test config_mock_vault_path --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
-        export SAFE_MOCK_IN_MEMORY_STORAGE=1 &&
-        cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
-        cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml &&
-        cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml &&
-
-        if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
-          (
-            echo "--- Test binary compatibility ---" &&
-
-            unset SAFE_MOCK_IN_MEMORY_STORAGE &&
-            export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
-            mkdir -p $SAFE_MOCK_VAULT_PATH &&
-
-            export BASE_BRANCH_DIR=${TRAVIS_BUILD_DIR%/}-$TRAVIS_BRANCH &&
-            cp -r $TRAVIS_BUILD_DIR $BASE_BRANCH_DIR &&
-            cd $BASE_BRANCH_DIR &&
-            git checkout -qf $TRAVIS_BRANCH &&
-
-            cd $TRAVIS_BUILD_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
-
-            cd $BASE_BRANCH_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
-
-            cd $TRAVIS_BUILD_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored
-          );
-        fi
-      );
-    elif [[ $TRAVIS_EVENT_TYPE = pull_request ]]; then
-      (
-        set -x;
-        cd ffi_utils && cargo clippy --profile=test &&
-
-        echo "--- Test build for real network ---" &&
-        cd ../safe_core && cargo clippy --profile=test --features=testing &&
-        cd ../safe_authenticator && cargo clippy --profile=test --features=testing &&
-        cd ../safe_app && cargo clippy --profile=test --features=testing &&
-        cd ../tests && cargo clippy --profile=test &&
-
-        echo "--- Test build for mock-routing ---" &&
-        cd ../safe_core && cargo clippy --profile=test --features=use-mock-routing &&
-        cd ../safe_authenticator && cargo clippy --profile=test --features=use-mock-routing &&
-        cd ../safe_app && cargo clippy --profile=test --features=use-mock-routing;
-      )
     fi
 after_script:
   - if [[ $TRAVIS_EVENT_TYPE = pull_request && -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -50,8 +50,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,6 +67,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -98,7 +103,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,22 +111,27 @@ name = "bzip2"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bzip2-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "c_linked_list"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -134,7 +144,7 @@ name = "chrono"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -143,8 +153,8 @@ name = "chrono"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -157,7 +167,7 @@ dependencies = [
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,17 +182,9 @@ dependencies = [
  "fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "conv"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,24 +202,19 @@ dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "igd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "custom_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "docopt"
@@ -225,7 +222,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -237,7 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "either"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -251,21 +248,23 @@ version = "0.4.0"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "moz-cheddar 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "moz-cheddar 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.1.10"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -274,12 +273,12 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fnv"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -301,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,8 +317,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -364,9 +377,9 @@ dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,15 +403,15 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "iovec"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,10 +420,10 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -438,6 +451,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazycell"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,18 +467,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "linked-hash-map"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "log"
-version = "0.3.8"
+name = "linked-hash-map"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log-mdc"
@@ -476,17 +505,17 @@ dependencies = [
  "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -506,23 +535,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "magenta"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "magenta-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "maidsafe_utilities"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +542,12 @@ dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -549,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "1.0.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -571,30 +583,30 @@ name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miniz-sys"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mio"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -614,13 +626,13 @@ dependencies = [
 
 [[package]]
 name = "moz-cheddar"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -647,22 +659,22 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -671,7 +683,7 @@ name = "num-integer"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -680,17 +692,17 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -701,13 +713,13 @@ name = "ordered-float"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -727,27 +739,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -762,7 +774,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -776,17 +788,17 @@ dependencies = [
  "crust 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource_proof 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,9 +810,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -813,8 +825,8 @@ dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -830,19 +842,19 @@ version = "0.5.0"
 dependencies = [
  "config_file_handler 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.4.0",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.5.0",
  "safe_core 0.28.0",
  "self_encryption 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -852,17 +864,17 @@ version = "0.5.0"
 dependencies = [
  "config_file_handler 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.4.0",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.28.0",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -876,21 +888,21 @@ dependencies = [
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.4.0",
  "fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_encryption 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -911,24 +923,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "brotli-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -937,22 +944,22 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -961,24 +968,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -989,6 +996,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "slab"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1040,7 +1052,7 @@ version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1049,11 +1061,12 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1068,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "term_size"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1092,9 +1105,9 @@ dependencies = [
  "safe_app 0.5.0",
  "safe_authenticator 0.5.0",
  "safe_core 0.28.0",
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1103,16 +1116,16 @@ name = "textwrap"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1123,7 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1134,35 +1147,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tokio-core"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1170,7 +1175,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1263,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1304,9 +1309,9 @@ dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1347,10 +1352,10 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1366,7 +1371,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
@@ -1376,33 +1381,35 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum brotli-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f08f1ec7187669af59bb4acd62f27471f0a2a9f20b3809ab2db210fffe2f6b38"
 "checksum brotli2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e31d102deacace1dfc91b23ca3adb02c15262f7a1db83c8ef9f57a5d51fb678"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 "checksum bzip2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3eafc42c44e0d827de6b1c131175098fe7fb53b8ce8a47e65cb3ea94688be24"
-"checksum bzip2-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "98ce3fff84d4e90011f464bbdf48e3428f04270439f703868fd489d2aaedfc30"
+"checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
 "checksum c_linked_list 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48754957a925b4554473af6c83fe05c2fdc9319f7636f6fc29b6969c73eb8fc0"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7f1aabf260a8f3fefa8871f16b531038c98dd9eab1cfa2c575e78c459abfa3a0"
 "checksum config_file_handler 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eacf66b01d0c37025db8a8b3a10f973a3e0da7eace0a23da8f96ab184e2f183c"
-"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum crust 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006a6c49ef502a2f9b17f01e177c5907bf9de36bc21b78e06edf6bf955455725"
-"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d8098c37c3aa33404700f9097733de3bf28b0393aab28af03b5b179a230b81c"
-"checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
+"checksum filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "aa75ec8f7927063335a9583e7fa87b0110bb888cf766dc01b54c0ff70d760c8e"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
-"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
+"checksum fuchsia-zircon 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd510087c325af53ba24f3be8f1c081b0982319adcb8b03cad764512923ccc19"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
-"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
+"checksum fuchsia-zircon-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "08b3a6f13ad6b96572b53ce7af74543132f1a7055ccceb6d073dd36c54481859"
+"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum get_if_addrs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da2383c2f4e45082129ad20f4a309aaa1f26c9ed4045082902bc2951ec9c6a3c"
 "checksum get_if_addrs-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf68ed691805f2dfe4e83cf85e3d373e704c3654c454dbb3280a15e2ea8d509"
@@ -1412,48 +1419,48 @@ dependencies = [
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum igd 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "356a0dc23a4fa0f8ce4777258085d00a01ea4923b2efd93538fc44bf5e1bda76"
-"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
-"checksum itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22c285d60139cf413244894189ca52debcfd70b57966feed060da76802e415a0"
+"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
+"checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 "checksum libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "36fbc8a8929c632868295d0178dd8f63fc423fd7537ad0738372bd010b3ac9b0"
-"checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2aab0478615bb586559b0114d94dd8eca4fdbb73b443adcb0d00b61692b4bf"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+"checksum log 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a89a0c46ba789b8a247d4c567aed4d7c68e624672d238b45cc3ec20dc9f940"
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 "checksum log4rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9beb5748c7d304a7c07e74ff2f0e642146a1191f8e9d9fb398e46ccb128364d"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum lru_time_cache 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30f38a48ad40936ca7c69db730dad50cf003d9655b2b1419b238ea225c9ca1d6"
-"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
-"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum maidsafe_utilities 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5acab44b1e0b79745359da196003b37f29f7e9acbf25e5847a7b17a6651023a"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46f3c7359028b31999287dae4e5047ddfe90a23b7dca2282ce759b491080c99b"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
-"checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
+"checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
+"checksum mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0e8411968194c7b139e9105bc4ae7db0bae232af087147e72f0616ebf5fdb9cb"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum moz-cheddar 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ea88fbe82964741aa3b57ec5c34d8808aa5c7e058bb9781add200d391063ab"
+"checksum moz-cheddar 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43b29fdad80b06f38d959105a138ab8ca8c5a57c3435f5bfbd770fa73e625015"
 "checksum msdos_time 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65ba9d75bcea84e07812618fedf284a64776c2f2ea0cad6bca7f69739695a958"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
-"checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
-"checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
+"checksum num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4083e14b542ea3eb9b5f33ff48bd373a92d78687e74f4cc0a30caeb754f0ca"
+"checksum num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "bdc1494b5912f088f260b775799468d9b9209ac60885d8186a547a0476289e23"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
-"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
-"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cacfcab5eb48250ee7d0c7896b51a2c5eec99c1feea5f32025635f5ae4b00070"
+"checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58d25b6c0e47b20d05226d288ff434940296e7e2f8b877975da32f862152241f"
-"checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum podio 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e5422a1ee1bc57cc47ae717b0137314258138f38fd5f3cea083f43a9725383a0"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
-"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
-"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7944d95d25ace8f377da3ac7068ce517e4c646754c43a1b1849177bbf72e59"
+"checksum redox_syscall 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "07b8f011e3254d5a9b318fde596d409a0001c9ae4c6e7907520c2eaa4d988c99"
+"checksum regex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6ab4e9218ade5b423358bbd2567d1617418403c7a512603630181813316322"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum resource_proof 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9eaa71a03a0cd0d41a32dfb3c5234c66658e6fa41d53785c5290d86465328215"
 "checksum routing 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9422f90f90dfb5f93320d63e0bdbe9a86e1bcbbbebe48cc25e0360e28449f061"
@@ -1463,32 +1470,31 @@ dependencies = [
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum self_encryption 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7218cc3dd020e4a8f43d166fbcacce42a4b7bfc68ec61e82caa2e83763c77575"
-"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
-"checksum serde 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "1c57ab4ec5fa85d08aaf8ed9245899d9bbdd66768945b21113b84d5f595cb6a1"
+"checksum serde 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "d1d6af49db29f2f2678e442f4eb82e7d78f59dbbd3e373ccffc17fe70c1b94f8"
 "checksum serde-value 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71187cf90819445c78d64f749d16499ba210d7724f16a95754dd03e0f207356d"
-"checksum serde_derive 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "02c92ea07b6e49b959c1481804ebc9bfd92d3c459f1274c9a9546829e42a66ce"
-"checksum serde_derive_internals 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75c6aac7b99801a16db5b40b7bf0d7e4ba16e76fbf231e32a4677f271cac0603"
-"checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
-"checksum serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49d983aa39d2884a4b422bb11bb38f4f48fa05186e17469bc31e47d01e381111"
+"checksum serde_derive 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "95b4ea937d8dff4c94d1a6fdd710eade6aedaa17c4049da29bb97a4f8a4f4bc1"
+"checksum serde_derive_internals 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "730fe9f29fe8db69a601837f416e46cba07792031ed6b27557a43e49d62d89ae"
+"checksum serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf5b0b5b4bd22eeecb7e01ac2e1225c7ef5e4272b79ee28a8392a8c8489c839"
+"checksum serde_yaml 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f868d400d9d13d00988da49f7f02aeac6ef00f11901a8c535bd59d777b9e19"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
+"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "867cc5c2d7140ae7eaad2ae9e8bf39cb18a67ca651b7834f88d46ca98faadb9c"
 "checksum syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13ad4762fe52abc9f4008e85c4fb1b1fe3aa91ccb99ff4826a439c7c598e1047"
 "checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
-"checksum tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "281285b717926caa919ad905ef89c63d75805c7d89437fb873100925a53f2b1b"
+"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
+"checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termion 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9105678ba52491a8e38e67be7842435ac44d7797b9b05bcdad370b0c84559615"
 "checksum textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f86300c3e7416ee233abd7cda890c492007a3980f941f79185c753a701257167"
-"checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52d12ad79e4063e0cb0ca5efa202ed7244b6ce4d25f4d3abe410b2a66128292"
-"checksum tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e85d419699ec4b71bfe35bbc25bb8771e52eff0471a7f75c853ad06e200b4f86"
-"checksum tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ab83e7adb5677e42e405fa4ceff75659d93c4d7d7dd22f52fcec59ee9f02af"
-"checksum toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd86ad9ebee246fdedd610e0f6d0587b754a3d81438db930a244d0480ed7878f"
+"checksum tokio-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c87c27560184212c9dc45cd8f38623f37918248aad5b58fb65303b5d07a98c6e"
+"checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
@@ -1515,5 +1521,5 @@ dependencies = [
 "checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"
 "checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"
 "checksum xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "472a9d37c7c53ab2391161df5b89b1f3bf76dab6ab150d7941ecbdd832282082"
-"checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
 "checksum zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "21c4067ff2f91926cb9aef8a8a55f8568b0f2631bb6b827d0fb9770ff5894e43"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.19.0
+    - RUST_TOOLCHAIN: 1.22.1
 
 cache:
   - '%USERPROFILE%\.cargo'

--- a/ffi_utils/src/catch_unwind.rs
+++ b/ffi_utils/src/catch_unwind.rs
@@ -32,15 +32,6 @@ where
     }
 }
 
-/// Catch panics. On error return the error code.
-pub fn catch_unwind_error_code<'a, F, E>(f: F) -> i32
-where
-    F: FnOnce() -> Result<(), E>,
-    E: Debug + ErrorCode + From<&'a str>,
-{
-    ffi_result_code!(catch_unwind_result(f))
-}
-
 /// Catch panics. On error call the callback.
 pub fn catch_unwind_cb<'a, U, C, F, E>(user_data: U, cb: C, f: F)
 where
@@ -74,19 +65,6 @@ mod tests {
         });
 
         assert!(res.is_err());
-        assert!(did_unwind);
-    }
-
-    #[test]
-    fn panic_inside_catch_unwind_error_code() {
-        let mut did_unwind = false;
-
-        let res = catch_unwind_error_code(|| -> Result<(), TestError> {
-            let _probe = DropProbe::new(|| did_unwind = true);
-            panic!("simulated panic");
-        });
-
-        assert!(res < 0);
         assert!(did_unwind);
     }
 

--- a/ffi_utils/src/lib.rs
+++ b/ffi_utils/src/lib.rs
@@ -39,7 +39,7 @@
 
 #![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
                                          option_unwrap_used))]
-#![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments))]
+#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher, too_many_arguments, use_debug))]
 
 extern crate base64;
 #[macro_use]
@@ -96,7 +96,7 @@ pub struct FfiResult {
 }
 
 /// Constant value to be used for OK result
-pub const FFI_RESULT_OK: &'static FfiResult = &FfiResult {
+pub const FFI_RESULT_OK: &FfiResult = &FfiResult {
     error_code: 0,
     description: 0 as *const c_char,
 };

--- a/ffi_utils/src/lib.rs
+++ b/ffi_utils/src/lib.rs
@@ -62,7 +62,7 @@ pub mod string;
 pub mod header_gen;
 
 pub use self::b64::{base64_decode, base64_encode};
-pub use self::catch_unwind::{catch_unwind_cb, catch_unwind_error_code};
+pub use self::catch_unwind::catch_unwind_cb;
 pub use self::repr_c::ReprC;
 pub use self::string::{StringError, from_c_str};
 pub use self::vec::{SafePtr, vec_clone_from_raw_parts, vec_into_raw_parts};

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::collections::HashMap;
     use std::ffi::CString;
     use std::rc::Rc;
-    use test_utils::{create_app_with_access, run};
+    use test_utils::{create_app_by_req, create_auth_req_with_access, run};
 
     // Test refreshing access info by fetching it from the network.
     #[test]
@@ -149,7 +149,7 @@ mod tests {
             btree_set![Permission::Read, Permission::Insert],
         );
 
-        let app = create_app_with_access(container_permissions.clone());
+        let app = create_app_by_req(&create_auth_req_with_access(container_permissions.clone()));
 
         run(&app, move |_client, context| {
             let reg = Rc::clone(unwrap!(context.as_registered()));
@@ -182,7 +182,7 @@ mod tests {
     fn get_access_info() {
         let mut container_permissions = HashMap::new();
         let _ = container_permissions.insert("_videos".to_string(), btree_set![Permission::Read]);
-        let app = create_app_with_access(container_permissions);
+        let app = create_app_by_req(&create_auth_req_with_access(container_permissions));
 
         // Get access container info
         let perms: Vec<PermSet> =

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -19,24 +19,26 @@
 
 #![allow(unsafe_code)]
 
-/// Access container
+/// Access container.
 pub mod access_container;
-/// Cipher Options
+/// Cipher Options.
 pub mod cipher_opt;
-/// Low level manipulation of `ImmutableData`
+/// Low level manipulation of `ImmutableData`.
 pub mod immutable_data;
-/// IPC utilities
+/// IPC utilities.
 pub mod ipc;
-/// Logging operations
+/// Logging operations.
 pub mod logging;
-/// `MDataInfo` operations
+/// `MDataInfo` operations.
 pub mod mdata_info;
-/// Crypto-related routines
+/// Crypto-related routines.
 pub mod crypto;
-/// Low level manipulation of `MutableData`
+/// Low level manipulation of `MutableData`.
 pub mod mutable_data;
-/// NFS API
+/// NFS API.
 pub mod nfs;
+/// Testing utilities.
+pub mod test_utils;
 
 mod helper;
 #[cfg(test)]

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -38,6 +38,7 @@ pub mod mutable_data;
 /// NFS API.
 pub mod nfs;
 /// Testing utilities.
+#[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
 mod helper;

--- a/safe_app/src/ffi/test_utils.rs
+++ b/safe_app/src/ffi/test_utils.rs
@@ -1,0 +1,63 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+#![allow(unsafe_code)]
+
+use App;
+use errors::AppError;
+use ffi_utils::{FFI_RESULT_OK, FfiResult, ReprC, catch_unwind_cb, from_c_str};
+use safe_core::ffi::ipc::req::AuthReq;
+use safe_core::ipc::req::AuthReq as NativeAuthReq;
+use std::os::raw::{c_char, c_void};
+use test_utils::{create_app_by_req, create_auth_req};
+
+/// Creates a random app instance for testing.
+#[no_mangle]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn test_create_app(
+    app_id: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void,
+                        result: *const FfiResult,
+                        app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let app_id = from_c_str(app_id)?;
+        let auth_req = create_auth_req(Some(app_id), None);
+        let app = create_app_by_req(&auth_req);
+        o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
+        Ok(())
+    })
+}
+
+/// Create a random app instance for testing, with access to containers.
+#[no_mangle]
+#[allow(unsafe_code)]
+pub unsafe extern "C" fn test_create_app_with_access(
+    auth_req: *const AuthReq,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void,
+                        result: *const FfiResult,
+                        o_app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let auth_req = NativeAuthReq::clone_from_repr_c(auth_req)?;
+        let app = create_app_by_req(&auth_req);
+        o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
+        Ok(())
+    })
+}

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -30,7 +30,7 @@ use safe_core::nfs::NfsError;
 use std;
 use std::collections::HashMap;
 use std::ffi::CString;
-use test_utils::{create_app_with_access, run};
+use test_utils::{create_app_by_req, create_auth_req_with_access, run};
 
 fn setup() -> (App, MDataInfo) {
     let mut container_permissions = HashMap::new();
@@ -44,7 +44,7 @@ fn setup() -> (App, MDataInfo) {
         ],
     );
 
-    let app = create_app_with_access(container_permissions);
+    let app = create_app_by_req(&create_auth_req_with_access(container_permissions));
 
     let container_info = run(&app, move |client, context| {
         context.get_access_info(client).then(move |res| {

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -89,7 +89,10 @@ mod tests;
 pub mod test_utils;
 
 pub use self::errors::*;
+
 use self::object_cache::ObjectCache;
+#[cfg(feature = "testing")]
+pub use ffi::test_utils::{test_create_app, test_create_app_with_access};
 use futures::{Future, future};
 use futures::stream::Stream;
 use futures::sync::mpsc as futures_mpsc;
@@ -107,8 +110,6 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Mutex;
 use std::sync::mpsc as std_mpsc;
-#[cfg(feature = "testing")]
-pub use test_utils::{test_create_app, test_create_app_with_access};
 use tokio_core::reactor::{Core, Handle};
 
 macro_rules! try_tx {

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -33,9 +33,10 @@ maidsafe_logo.png",
        unused_qualifications, unused_results)]
 #![allow(box_pointers, missing_copy_implementations, missing_debug_implementations,
          variant_size_differences)]
-#![cfg_attr(feature = "cargo-clippy",
-           deny(clippy, unicode_not_nfc, wrong_pub_self_convention, option_unwrap_used))]
-#![cfg_attr(feature = "cargo-clippy", allow(use_debug, too_many_arguments))]
+
+#![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
+                                           option_unwrap_used))]
+#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher, too_many_arguments, use_debug))]
 
 extern crate config_file_handler;
 #[macro_use]
@@ -91,7 +92,7 @@ pub mod test_utils;
 pub use self::errors::*;
 
 use self::object_cache::ObjectCache;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub use ffi::test_utils::{test_create_app, test_create_app_with_access};
 use futures::{Future, future};
 use futures::stream::Stream;

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -106,7 +106,7 @@ pub fn create_auth_req(
 
     let (app_container, containers) = match access_info {
         Some(access_info) => (true, access_info),
-        None => (false, HashMap::new()),
+        None => (false, HashMap::default()),
     };
 
     NativeAuthReq {

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -17,7 +17,7 @@
 
 use super::{App, AppContext};
 use super::errors::AppError;
-use ffi_utils::catch_unwind_error_code;
+use ffi_utils::{FFI_RESULT_OK, FfiResult, catch_unwind_cb, from_c_str};
 use futures::{Future, IntoFuture};
 use safe_authenticator::test_utils as authenticator;
 use safe_core::{Client, FutureExt, utils};
@@ -25,6 +25,7 @@ use safe_core::ffi::ipc::req::ContainerPermissions as FfiContainerPermissions;
 use safe_core::ipc::AppExchangeInfo;
 use safe_core::ipc::req::{AuthReq, ContainerPermissions, containers_from_repr_c};
 use std::collections::HashMap;
+use std::os::raw::{c_char, c_void};
 use std::sync::mpsc;
 
 /// Generates an `AppExchangeInfo` structure for a mock application.
@@ -80,54 +81,60 @@ where
     unwrap!(unwrap!(rx.recv()))
 }
 
-/// Create registered app.
-pub fn create_app() -> App {
+// Create registered app with optional app id and access info.
+fn create_app_with_id_or_access(
+    app_id: Option<String>,
+    access_info: Option<HashMap<String, ContainerPermissions>>,
+) -> App {
     let auth = authenticator::create_account_and_login();
 
-    let app_info = gen_app_exchange_info();
+    let mut app_info = gen_app_exchange_info();
+    if let Some(app_id) = app_id {
+        app_info.id = app_id;
+    }
     let app_id = app_info.id.clone();
+
+    let (app_container, containers) = match access_info {
+        Some(access_info) => (true, access_info),
+        None => (false, HashMap::new()),
+    };
 
     let auth_granted = unwrap!(authenticator::register_app(
         &auth,
         &AuthReq {
             app: app_info,
-            app_container: false,
-            containers: HashMap::new(),
+            app_container,
+            containers,
         },
     ));
 
     unwrap!(App::registered(app_id, auth_granted, || ()))
 }
 
-/// Create app and grant it access to the specified containers.
+/// Create registered app with a random id.
+pub fn create_app() -> App {
+    create_app_with_id_or_access(None, None)
+}
+
+/// Create registered app with a random id and grant it access to the specified containers.
 pub fn create_app_with_access(access_info: HashMap<String, ContainerPermissions>) -> App {
-    let auth = authenticator::create_account_and_login();
-
-    let app_info = gen_app_exchange_info();
-    let app_id = app_info.id.clone();
-
-    let auth_granted = unwrap!(authenticator::register_app(
-        &auth,
-        &AuthReq {
-            app: app_info,
-            app_container: true,
-            containers: access_info,
-        },
-    ));
-
-    unwrap!(App::registered(app_id, auth_granted, || ()))
+    create_app_with_id_or_access(None, Some(access_info))
 }
 
 /// Creates a random app instance for testing.
 #[no_mangle]
 #[allow(unsafe_code)]
-#[cfg_attr(feature = "cargo-clippy", allow(not_unsafe_ptr_arg_deref))]
-pub extern "C" fn test_create_app(o_app: *mut *mut App) -> i32 {
-    catch_unwind_error_code(|| -> Result<(), AppError> {
-        let app = create_app();
-        unsafe {
-            *o_app = Box::into_raw(Box::new(app));
-        }
+pub unsafe extern "C" fn test_create_app(
+    app_id: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void,
+                        result: *const FfiResult,
+                        app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let app_id = from_c_str(app_id)?;
+        let app = create_app_with_id_or_access(Some(app_id), None);
+        o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
         Ok(())
     })
 }
@@ -135,18 +142,20 @@ pub extern "C" fn test_create_app(o_app: *mut *mut App) -> i32 {
 /// Create a random app instance for testing, with access to containers.
 #[no_mangle]
 #[allow(unsafe_code)]
-#[cfg_attr(feature = "cargo-clippy", allow(not_unsafe_ptr_arg_deref))]
-pub extern "C" fn test_create_app_with_access(
+pub unsafe extern "C" fn test_create_app_with_access(
+    app_id: *const c_char,
     access_info: *const FfiContainerPermissions,
     access_info_len: usize,
-    o_app: *mut *mut App,
-) -> i32 {
-    catch_unwind_error_code(|| -> Result<(), AppError> {
-        let containers = unsafe { containers_from_repr_c(access_info, access_info_len)? };
-        let app = create_app_with_access(containers);
-        unsafe {
-            *o_app = Box::into_raw(Box::new(app));
-        }
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void,
+                        result: *const FfiResult,
+                        o_app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let app_id = from_c_str(app_id)?;
+        let containers = containers_from_repr_c(access_info, access_info_len)?;
+        let app = create_app_with_id_or_access(Some(app_id), Some(containers));
+        o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
         Ok(())
     })
 }

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -18,6 +18,7 @@
 mod mutable_data;
 
 use App;
+use ffi::test_utils::test_create_app_with_access;
 use ffi_utils::test_utils::call_1;
 use futures::Future;
 #[cfg(feature = "use-mock-routing")]
@@ -32,8 +33,7 @@ use safe_core::ipc::Permission;
 use safe_core::ipc::req::{AppExchangeInfo, AuthReq};
 use std::collections::HashMap;
 use std::rc::Rc;
-use test_utils::{create_app_by_req, create_auth_req, create_auth_req_with_access, run,
-                 test_create_app_with_access};
+use test_utils::{create_app_by_req, create_auth_req, create_auth_req_with_access, run};
 use test_utils::gen_app_exchange_info;
 
 // Test refreshing access info by fetching it from the network.

--- a/safe_app/src/tests/mutable_data.rs
+++ b/safe_app/src/tests/mutable_data.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use ffi::test_utils::test_create_app;
 use ffi_utils::test_utils::call_1;
 use futures::Future;
 use maidsafe_utilities::thread;
@@ -26,7 +27,7 @@ use safe_core::utils::test_utils::random_client;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::CString;
 use std::sync::mpsc;
-use test_utils::{create_app, run, test_create_app};
+use test_utils::{create_app, run};
 
 // MD created by App. App lists its own sign_pk in owners field: Put should
 // fail - Rejected by MaidManagers. Should pass when it lists the owner's

--- a/safe_authenticator/src/app_auth.rs
+++ b/safe_authenticator/src/app_auth.rs
@@ -243,7 +243,7 @@ fn authenticated_app(
         })
         .and_then(move |perms| {
             let access_container_info = c3.access_container()?;
-            let access_container_info = AccessContInfo::from_mdata_info(access_container_info)?;
+            let access_container_info = AccessContInfo::from_mdata_info(&access_container_info)?;
 
             Ok(AuthGranted {
                 app_keys,
@@ -307,7 +307,7 @@ fn authenticate_new_app(
         })
         .and_then(move |access_container_entry| {
             let access_container_info = c6.access_container()?;
-            let access_container_info = AccessContInfo::from_mdata_info(access_container_info)?;
+            let access_container_info = AccessContInfo::from_mdata_info(&access_container_info)?;
 
             Ok(AuthGranted {
                 app_keys: app_keys_auth,

--- a/safe_authenticator/src/config.rs
+++ b/safe_authenticator/src/config.rs
@@ -45,10 +45,10 @@ pub struct AppInfo {
 }
 
 /// Config file key under which the list of registered apps is stored.
-pub const KEY_APPS: &'static [u8] = b"apps";
+pub const KEY_APPS: &[u8] = b"apps";
 
 /// Config file key under which the revocation queue is stored.
-pub const KEY_APP_REVOCATION_QUEUE: &'static [u8] = b"revocation-queue";
+pub const KEY_APP_REVOCATION_QUEUE: &[u8] = b"revocation-queue";
 
 /// Maps from a SHA-3 hash of an app ID to app info
 pub type Apps = HashMap<[u8; 32], AppInfo>;

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -112,7 +112,7 @@ pub fn decode_ipc_msg(
         IpcMsg::Resp { .. } |
         IpcMsg::Revoked { .. } |
         IpcMsg::Err(..) => {
-            return err!(AuthError::IpcError(IpcError::InvalidMsg.into()));
+            return err!(AuthError::IpcError(IpcError::InvalidMsg));
         }
     }
 }

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -39,8 +39,7 @@
 
 #![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
                                    option_unwrap_used))]
-// Allow `panic_params` until https://github.com/Manishearth/rust-clippy/issues/768 is resolved.
-#![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments, panic_params))]
+#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher, too_many_arguments, use_debug))]
 
 extern crate config_file_handler;
 #[macro_use]
@@ -278,7 +277,7 @@ impl Authenticator {
                             unwrap!(tx.send(Ok(core_tx2)));
                         })
                         .map_err(move |e| {
-                            unwrap!(tx2.send(Err((Some(core_tx3), AuthError::from(e)))));
+                            unwrap!(tx2.send(Err((Some(core_tx3), e))));
                         })
                         .into_box()
                         .into()

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -15,6 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+#![cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
+
 use super::DataId;
 use super::vault::{self, Data, Vault, VaultGuard};
 use config_handler::{Config, get_config};
@@ -40,8 +42,8 @@ pub type RequestHookFn = FnMut(&Request) -> Option<Response> + 'static;
 /// Function that is used to modify responses before they are sent.
 pub type ResponseHookFn = FnMut(Response) -> Response + 'static;
 
-const CONNECT_THREAD_NAME: &'static str = "Mock routing connect";
-const DELAY_THREAD_NAME: &'static str = "Mock routing delay";
+const CONNECT_THREAD_NAME: &str = "Mock routing connect";
+const DELAY_THREAD_NAME: &str = "Mock routing delay";
 
 const DEFAULT_DELAY_MS: u64 = 0;
 const CONNECT_DELAY_MS: u64 = DEFAULT_DELAY_MS;
@@ -133,8 +135,8 @@ impl Routing {
     }
 
     /// Sets the vault for this routing instance.
-    pub fn set_vault(&mut self, vault: Arc<Mutex<Vault>>) {
-        self.vault = vault.clone();
+    pub fn set_vault(&mut self, vault: &Arc<Mutex<Vault>>) {
+        self.vault = Arc::clone(vault);
     }
 
     /// Gets MAID account information.

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -1365,7 +1365,7 @@ fn setup() -> (Routing, Receiver<Event>, FullId) {
 fn setup_with_config(config: Config) -> (Routing, Receiver<Event>, FullId) {
     let (mut routing, routing_rx, full_id) = setup_impl();
 
-    routing.set_vault(Arc::new(Mutex::new(Vault::new(config))));
+    routing.set_vault(&Arc::new(Mutex::new(Vault::new(config))));
 
     (routing, routing_rx, full_id)
 }

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 use tiny_keccak::sha3_256;
 
-const FILE_NAME: &'static str = "MockVault";
+const FILE_NAME: &str = "MockVault";
 
 pub struct Vault {
     cache: Cache,
@@ -77,11 +77,11 @@ fn init_vault_store(config: &Config) -> Box<Store> {
                 }
                 Some(ref dev) => {
                     trace!("Mock vault: using file store");
-                    Box::new(FileStore::new(init_vault_path(Some(dev))))
+                    Box::new(FileStore::new(&init_vault_path(Some(dev))))
                 }
                 None => {
                     trace!("Mock vault: using file store");
-                    Box::new(FileStore::new(init_vault_path(None)))
+                    Box::new(FileStore::new(&init_vault_path(None)))
                 }
             }
         }
@@ -268,7 +268,7 @@ struct FileStore {
 }
 
 impl FileStore {
-    fn new(path: PathBuf) -> Self {
+    fn new(path: &PathBuf) -> Self {
         FileStore {
             file: None,
             sync_time: None,

--- a/safe_core/src/crypto.rs
+++ b/safe_core/src/crypto.rs
@@ -33,7 +33,7 @@ pub mod shared_secretbox {
 
     impl Key {
         /// Create new safe-to-share key from the given regular key.
-        pub fn new(inner: secretbox::Key) -> Self {
+        pub fn new(inner: &secretbox::Key) -> Self {
             // NOTE: make sure we move the inner array, not the whole key, because
             // moving the key would leave the `inner` variable in the "moved-from"
             // state which means it's destructor wouldn't be called and the old
@@ -52,13 +52,13 @@ pub mod shared_secretbox {
 
         /// Create new key from the data in the given slice.
         pub fn from_slice(data: &[u8]) -> Option<Self> {
-            secretbox::Key::from_slice(data).map(Self::new)
+            secretbox::Key::from_slice(data).map(|key| Self::new(&key))
         }
     }
 
     /// Generate new random shared symmetric encryption key.
     pub fn gen_key() -> Key {
-        Key::new(secretbox::gen_key())
+        Key::new(&secretbox::gen_key())
     }
 
     impl Deref for Key {
@@ -72,7 +72,7 @@ pub mod shared_secretbox {
     impl<'de> Deserialize<'de> for Key {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             let inner = secretbox::Key::deserialize(deserializer)?;
-            Ok(Key::new(inner))
+            Ok(Key::new(&inner))
         }
     }
 
@@ -103,7 +103,7 @@ pub mod shared_box {
 
     impl SecretKey {
         /// Create new safe-to-share key from the given regular key.
-        pub fn new(inner: box_::SecretKey) -> Self {
+        pub fn new(inner: &box_::SecretKey) -> Self {
             SecretKey(Arc::new(box_::SecretKey(inner.0)))
         }
 
@@ -119,7 +119,7 @@ pub mod shared_box {
     /// Generate new random public/secret keypair.
     pub fn gen_keypair() -> (box_::PublicKey, SecretKey) {
         let (pk, sk) = box_::gen_keypair();
-        (pk, SecretKey::new(sk))
+        (pk, SecretKey::new(&sk))
     }
 
     impl Deref for SecretKey {
@@ -133,7 +133,7 @@ pub mod shared_box {
     impl<'de> Deserialize<'de> for SecretKey {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             let inner = box_::SecretKey::deserialize(deserializer)?;
-            Ok(SecretKey::new(inner))
+            Ok(SecretKey::new(&inner))
         }
     }
 
@@ -164,7 +164,7 @@ pub mod shared_sign {
 
     impl SecretKey {
         /// Create new safe-to-share key from the given regular key.
-        pub fn new(inner: sign::SecretKey) -> Self {
+        pub fn new(inner: &sign::SecretKey) -> Self {
             SecretKey(Arc::new(sign::SecretKey(inner.0)))
         }
 
@@ -180,13 +180,13 @@ pub mod shared_sign {
     /// Generate new random public/secret keypair.
     pub fn gen_keypair() -> (sign::PublicKey, SecretKey) {
         let (pk, sk) = sign::gen_keypair();
-        (pk, SecretKey::new(sk))
+        (pk, SecretKey::new(&sk))
     }
 
     /// Generate new random public/secret keypair using the given seed.
     pub fn keypair_from_seed(seed: &sign::Seed) -> (sign::PublicKey, SecretKey) {
         let (pk, sk) = sign::keypair_from_seed(seed);
-        (pk, SecretKey::new(sk))
+        (pk, SecretKey::new(&sk))
     }
 
     impl Deref for SecretKey {
@@ -200,7 +200,7 @@ pub mod shared_sign {
     impl<'de> Deserialize<'de> for SecretKey {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             let inner = sign::SecretKey::deserialize(deserializer)?;
-            Ok(SecretKey::new(inner))
+            Ok(SecretKey::new(&inner))
         }
     }
 

--- a/safe_core/src/ffi/ipc/resp.rs
+++ b/safe_core/src/ffi/ipc/resp.rs
@@ -115,17 +115,21 @@ pub struct AccessContInfo {
 #[repr(C)]
 pub struct AccessContainerEntry {
     /// Pointer to the array of `ContainerInfo`.
-    pub ptr: *const ContainerInfo,
+    pub containers_ptr: *const ContainerInfo,
     /// Size of the array.
-    pub len: usize,
+    pub containers_len: usize,
     /// Internal field used by rust memory allocator.
-    pub cap: usize,
+    pub containers_cap: usize,
 }
 
 impl Drop for AccessContainerEntry {
     fn drop(&mut self) {
         unsafe {
-            let _ = Vec::from_raw_parts(self.ptr as *mut ContainerInfo, self.len, self.cap);
+            let _ = Vec::from_raw_parts(
+                self.containers_ptr as *mut ContainerInfo,
+                self.containers_len,
+                self.containers_cap,
+            );
         }
     }
 }

--- a/safe_core/src/ffi/ipc/resp.rs
+++ b/safe_core/src/ffi/ipc/resp.rs
@@ -36,7 +36,7 @@ pub struct AuthGranted {
     pub access_container_entry: AccessContainerEntry,
 
     /// Crust's bootstrap config
-    pub bootstrap_config_ptr: *mut u8,
+    pub bootstrap_config: *mut u8,
     /// `bootstrap_config`'s length
     pub bootstrap_config_len: usize,
     /// Used by Rust memory allocator
@@ -47,7 +47,7 @@ impl Drop for AuthGranted {
     fn drop(&mut self) {
         unsafe {
             let _ = Vec::from_raw_parts(
-                self.bootstrap_config_ptr,
+                self.bootstrap_config,
                 self.bootstrap_config_len,
                 self.bootstrap_config_cap,
             );
@@ -115,7 +115,7 @@ pub struct AccessContInfo {
 #[repr(C)]
 pub struct AccessContainerEntry {
     /// Pointer to the array of `ContainerInfo`.
-    pub containers_ptr: *const ContainerInfo,
+    pub containers: *const ContainerInfo,
     /// Size of the array.
     pub containers_len: usize,
     /// Internal field used by rust memory allocator.
@@ -126,7 +126,7 @@ impl Drop for AccessContainerEntry {
     fn drop(&mut self) {
         unsafe {
             let _ = Vec::from_raw_parts(
-                self.containers_ptr as *mut ContainerInfo,
+                self.containers as *mut ContainerInfo,
                 self.containers_len,
                 self.containers_cap,
             );
@@ -210,7 +210,7 @@ impl Drop for MetadataResponse {
 #[derive(Clone, Copy, Debug)]
 pub struct MDataValue {
     /// Content pointer.
-    pub content_ptr: *const u8,
+    pub content: *const u8,
     /// Content length.
     pub content_len: usize,
     /// Entry version.
@@ -222,7 +222,7 @@ pub struct MDataValue {
 #[derive(Clone, Copy, Debug)]
 pub struct MDataKey {
     /// Key value pointer.
-    pub val_ptr: *const u8,
+    pub val: *const u8,
     /// Key length.
     pub val_len: usize,
 }

--- a/safe_core/src/ipc/mod.rs
+++ b/safe_core/src/ipc/mod.rs
@@ -27,6 +27,7 @@ pub use self::req::{AppExchangeInfo, AuthReq, ContainersReq, IpcReq, Permission,
                     ShareMDataReq};
 pub use self::resp::{AccessContInfo, AccessContainerEntry, AppKeys, AuthGranted, IpcResp,
                      access_container_enc_key};
+
 use ffi_utils::{base64_decode, base64_encode};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use rand::{self, Rng};

--- a/safe_core/src/ipc/req/mod.rs
+++ b/safe_core/src/ipc/req/mod.rs
@@ -24,6 +24,7 @@ mod share_mdata;
 pub use self::auth::AuthReq;
 pub use self::containers::ContainersReq;
 pub use self::share_mdata::{ShareMData, ShareMDataReq};
+
 use ffi::ipc::req::{AppExchangeInfo as FfiAppExchangeInfo,
                     ContainerPermissions as FfiContainerPermissions,
                     PermissionSet as FfiPermissionSet};

--- a/safe_core/src/ipc/resp.rs
+++ b/safe_core/src/ipc/resp.rs
@@ -217,15 +217,19 @@ pub fn access_container_entry_into_repr_c(
         })
     }
 
-    let (ptr, len, cap) = vec_into_raw_parts(vec);
-    Ok(ffi::AccessContainerEntry { ptr, len, cap })
+    let (containers_ptr, containers_len, containers_cap) = vec_into_raw_parts(vec);
+    Ok(ffi::AccessContainerEntry {
+        containers_ptr,
+        containers_len,
+        containers_cap,
+    })
 }
 
 /// Convert FFI representation of `AccessContainerEntry` to native rust representation by cloning.
 pub unsafe fn access_container_entry_clone_from_repr_c(
     entry: *const ffi::AccessContainerEntry,
 ) -> Result<AccessContainerEntry, IpcError> {
-    let input = slice::from_raw_parts((*entry).ptr, (*entry).len);
+    let input = slice::from_raw_parts((*entry).containers_ptr, (*entry).containers_len);
     let mut output = AccessContainerEntry::with_capacity(input.len());
 
     for container in input {

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -99,7 +99,7 @@
 
 #![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
                                          option_unwrap_used))]
-#![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments))]
+#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher, too_many_arguments, use_debug))]
 
 extern crate base64;
 extern crate chrono;

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -186,7 +186,7 @@ where
     trace!("Creating a writer for a file");
 
     Writer::new(
-        client.clone(),
+        &client.clone(),
         SelfEncryptionStorage::new(client),
         file,
         mode,

--- a/safe_core/src/nfs/writer.rs
+++ b/safe_core/src/nfs/writer.rs
@@ -25,6 +25,7 @@ use self_encryption_storage::SelfEncryptionStorage;
 use utils::FutureExt;
 
 /// Mode of the writer
+#[derive(Clone, Copy, Debug)]
 pub enum Mode {
     /// Will create new data
     Overwrite,
@@ -44,7 +45,7 @@ pub struct Writer<T> {
 impl<T: 'static> Writer<T> {
     /// Create new instance of Writer
     pub fn new(
-        client: Client<T>,
+        client: &Client<T>,
         storage: SelfEncryptionStorage<T>,
         file: File,
         mode: Mode,
@@ -52,7 +53,7 @@ impl<T: 'static> Writer<T> {
     ) -> Box<NfsFuture<Writer<T>>> {
         let fut = match mode {
             Mode::Append => {
-                data_map::get(&client, file.data_map_name(), encryption_key.clone())
+                data_map::get(client, file.data_map_name(), encryption_key.clone())
                     .map(Some)
                     .into_box()
             }

--- a/scripts/build-all
+++ b/scripts/build-all
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scripts/build-ffi-utils && scripts/build-real && scripts/build-mock

--- a/scripts/build-ffi-utils
+++ b/scripts/build-ffi-utils
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo build --verbose --release --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/build-mock
+++ b/scripts/build-mock
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cargo build --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
+cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
+cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
+cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
+cargo build --verbose --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/build-real
+++ b/scripts/build-real
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cargo build --verbose --release --manifest-path=safe_core/Cargo.toml &&
+cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
+cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
+cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
+cargo build --verbose --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-all
+++ b/scripts/check-all
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scripts/check-ffi-utils && scripts/check-real && scripts/check-mock

--- a/scripts/check-ffi-utils
+++ b/scripts/check-ffi-utils
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo check --verbose --release --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/check-mock
+++ b/scripts/check-mock
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cargo check --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
+cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
+cargo check --verbose --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-real
+++ b/scripts/check-real
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cargo check --verbose --release --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
+cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
+cargo check --verbose --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/clippy-all
+++ b/scripts/clippy-all
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scripts/clippy-ffi-utils && scripts/clippy-real && scripts/clippy-mock

--- a/scripts/clippy-ffi-utils
+++ b/scripts/clippy-ffi-utils
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd ffi_utils && cargo clippy --profile=test && cd ..

--- a/scripts/clippy-mock
+++ b/scripts/clippy-mock
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd safe_core && cargo clippy --profile=test --features=use-mock-routing && cd .. &&
+cd safe_authenticator && cargo clippy --profile=test --features=use-mock-routing && cd .. &&
+cd safe_app && cargo clippy --profile=test --features=use-mock-routing && cd ..

--- a/scripts/clippy-real
+++ b/scripts/clippy-real
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd safe_core && cargo clippy --profile=test --features=testing && cd .. &&
+cd safe_authenticator && cargo clippy --profile=test --features=testing && cd .. &&
+cd safe_app && cargo clippy --profile=test --features=testing && cd .. &&
+cd tests && cargo clippy --profile=test && cd ..

--- a/scripts/stable
+++ b/scripts/stable
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [[ $TRAVIS_EVENT_TYPE = pull_request ]]; then
+  (
+    set -x;
+    if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
+      echo "--- Check format ---" &&
+        cargo fmt --all -- --write-mode=diff;
+    fi &&
+
+      echo "--- Test ffi_utils ---" &&
+      scripts/test-ffi-utils &&
+
+      echo "--- Check compilation against actual routing ---" &&
+      scripts/check-real &&
+
+      echo "--- Test against mock ---" &&
+      scripts/test-mock &&
+
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        (
+          echo "--- Test binary compatibility ---" &&
+
+            unset SAFE_MOCK_IN_MEMORY_STORAGE &&
+            export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
+            mkdir -p $SAFE_MOCK_VAULT_PATH &&
+
+            export BASE_BRANCH_DIR=${TRAVIS_BUILD_DIR%/}-$TRAVIS_BRANCH &&
+            cp -r $TRAVIS_BUILD_DIR $BASE_BRANCH_DIR &&
+            cd $BASE_BRANCH_DIR &&
+            git checkout -qf $TRAVIS_BRANCH &&
+
+            cd $TRAVIS_BUILD_DIR &&
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
+
+            cd $BASE_BRANCH_DIR &&
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored &&
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
+
+            cd $TRAVIS_BUILD_DIR &&
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored
+        );
+      fi
+  )
+fi

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scripts/test-ffi-utils && scripts/test-mock

--- a/scripts/test-ffi-utils
+++ b/scripts/test-ffi-utils
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo test --verbose --release --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/test-mock
+++ b/scripts/test-mock
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cargo test config_mock_vault_path --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
+export SAFE_MOCK_IN_MEMORY_STORAGE=1 &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -37,7 +37,7 @@
 
 #![cfg_attr(feature="cargo-clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention,
                                          option_unwrap_used))]
-#![cfg_attr(feature="cargo-clippy", allow(use_debug, too_many_arguments))]
+#![cfg_attr(feature="cargo-clippy", allow(implicit_hasher, too_many_arguments, use_debug))]
 
 extern crate ffi_utils;
 extern crate safe_app;


### PR DESCRIPTION
- Upgrade nightly to `2018-01-10`
- Upgrade clippy to `0.0.179`
- Fix various clippy errors

Also:
- fix naming conventions
- improve test app creation APIs
- move FFI test_utils functions to an FFI module