### PR TITLE
chore/ci: remove fixed Rust version from deploy script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,4 +99,3 @@ deploy:
   artifact: /.*\.zip/
   on:
     branch: master
-    RUST_TOOLCHAIN: 1.19.0


### PR DESCRIPTION
This hardcoded toolchain version is easy to overlook and it can prevent the CI from deploying the release artifacts. It also serves no purpose because the correct toolchain version (stable) is already selected by filtering out by the branch in the deploy script. Thus it's been removed.