### PR TITLE
 refactor/ffi: refactor `mdata_entries_for_each` to `mdata_list_entries`

### DIFF
--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -35,8 +35,7 @@ use routing::MutableData;
 use safe_core::{CoreError, FutureExt, MDataInfo};
 use safe_core::ffi::MDataInfo as FfiMDataInfo;
 use safe_core::ffi::ipc::req::PermissionSet as FfiPermissionSet;
-use safe_core::ffi::ipc::resp::MDataKey as FfiMDataKey;
-use safe_core::ffi::ipc::resp::MDataValue as FfiMDataValue;
+use safe_core::ffi::ipc::resp::{MDataKey as FfiMDataKey, MDataValue as FfiMDataValue};
 use safe_core::ipc::req::{permission_set_clone_from_repr_c, permission_set_into_repr_c};
 use safe_core::ipc::resp::{MDataKey, MDataValue};
 use std::os::raw::c_void;
@@ -216,11 +215,11 @@ pub unsafe extern "C" fn mdata_get_value(
     })
 }
 
-/// Get complete list of entries in the mutable data.
+/// Get a handle to the complete list of entries in the mutable data.
 ///
 /// Callback parameters: user data, error code, entries handle
 #[no_mangle]
-pub unsafe extern "C" fn mdata_list_entries(
+pub unsafe extern "C" fn mdata_entries(
     app: *const App,
     info: *const FfiMDataInfo,
     user_data: *mut c_void,

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -422,13 +422,10 @@ fn entries_crud_ffi() {
         assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
     }
 
-    // Check mdata_list_entries
+    // Check mdata_entries
     {
-        let entries_list_h = unsafe {
-            unwrap!(call_1(
-                |ud, cb| mdata_list_entries(&app, &md_info_priv, ud, cb),
-            ))
-        };
+        let entries_h =
+            unsafe { unwrap!(call_1(|ud, cb| mdata_entries(&app, &md_info_priv, ud, cb))) };
 
         // Try with a fake entry key, expect error.
         let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
@@ -438,7 +435,7 @@ fn entries_crud_ffi() {
         unsafe {
             mdata_entries_get(
                 &app,
-                entries_list_h,
+                entries_h,
                 fake_key.as_ptr(),
                 fake_key.len(),
                 sender_as_user_data(&tx, &mut ud),
@@ -459,7 +456,7 @@ fn entries_crud_ffi() {
         unsafe {
             mdata_entries_get(
                 &app,
-                entries_list_h,
+                entries_h,
                 key_enc.as_ptr(),
                 key_enc.len(),
                 sender_as_user_data(&tx, &mut ud),
@@ -484,11 +481,7 @@ fn entries_crud_ffi() {
         };
         assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
 
-        unsafe {
-            unwrap!(call_0(
-                |ud, cb| mdata_entries_free(&app, entries_list_h, ud, cb),
-            ))
-        }
+        unsafe { unwrap!(call_0(|ud, cb| mdata_entries_free(&app, entries_h, ud, cb))) }
     }
 
     // Check mdata_list_keys

--- a/safe_authenticator/src/ffi/ipc.rs
+++ b/safe_authenticator/src/ffi/ipc.rs
@@ -409,7 +409,8 @@ pub unsafe extern "C" fn encode_auth_resp(
                             resp: IpcResp::Auth(Ok(auth_granted)),
                         })?;
 
-                        Ok(o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr()))
+                        o_cb(user_data.0, FFI_RESULT_OK, resp.as_ptr());
+                        Ok(())
                     })
                     .or_else(move |e| -> Result<(), AuthError> {
                         let (error_code, description) = ffi_error!(e);
@@ -421,7 +422,8 @@ pub unsafe extern "C" fn encode_auth_resp(
                             error_code,
                             description: description.as_ptr(),
                         };
-                        Ok(o_cb(user_data.0, &res, resp.as_ptr()))
+                        o_cb(user_data.0, &res, resp.as_ptr());
+                        Ok(())
                     })
                     .map_err(move |e| {
                         call_result_cb!(Err::<(), _>(e), user_data, o_cb);
@@ -527,7 +529,8 @@ pub unsafe extern "C" fn encode_containers_resp(
                             error_code,
                             description: description.as_ptr(),
                         };
-                        Ok(o_cb(user_data.0, &res, resp.as_ptr()))
+                        o_cb(user_data.0, &res, resp.as_ptr());
+                        Ok(())
                     })
                     .map_err(move |e| debug!("Unexpected error: {:?}", e))
                     .into_box()

--- a/safe_core/src/ffi/ipc/resp.rs
+++ b/safe_core/src/ffi/ipc/resp.rs
@@ -205,6 +205,16 @@ impl Drop for MetadataResponse {
     }
 }
 
+/// Represents an FFI-safe mutable data key.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct MDataKey {
+    /// Key value pointer.
+    pub val: *const u8,
+    /// Key length.
+    pub val_len: usize,
+}
+
 /// Represents the FFI-safe mutable data value.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -217,12 +227,12 @@ pub struct MDataValue {
     pub entry_version: u64,
 }
 
-/// Represents an FFI-safe mutable data key.
+/// Represents an FFI-safe mutable data (key, value) entry.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct MDataKey {
-    /// Key value pointer.
-    pub val: *const u8,
-    /// Key length.
-    pub val_len: usize,
+pub struct MDataEntry {
+    /// Mutable data key.
+    pub key: MDataKey,
+    /// Mutable data value.
+    pub value: MDataValue,
 }

--- a/safe_core/src/ipc/resp.rs
+++ b/safe_core/src/ipc/resp.rs
@@ -507,6 +507,39 @@ impl ReprC for MDataKey {
     }
 }
 
+/// Mutable data entry.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub struct MDataEntry {
+    /// Key.
+    pub key: MDataKey,
+    /// Value.
+    pub value: MDataValue,
+}
+
+impl MDataEntry {
+    /// Returns FFI counterpart without consuming the object.
+    pub fn as_repr_c(&self) -> ffi::MDataEntry {
+        ffi::MDataEntry {
+            key: self.key.as_repr_c(),
+            value: self.value.as_repr_c(),
+        }
+    }
+}
+
+impl ReprC for MDataEntry {
+    type C = *const ffi::MDataEntry;
+    type Error = ();
+
+    unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
+        let ffi::MDataEntry { key, value } = *c_repr;
+
+        Ok(MDataEntry {
+            key: MDataKey::clone_from_repr_c(&key)?,
+            value: MDataValue::clone_from_repr_c(&value)?,
+        })
+    }
+}
+
 #[cfg(test)]
 #[allow(unsafe_code)]
 mod tests {

--- a/safe_core/src/utils/test_utils/mod.rs
+++ b/safe_core/src/utils/test_utils/mod.rs
@@ -137,11 +137,12 @@ where
     let (net_tx, net_rx) = mpsc::unbounded();
     let client = unwrap!(c(el_h.clone(), core_tx.clone(), net_tx));
 
-    let net_fut = net_rx.for_each(move |net_event| Ok(n(net_event))).map_err(
-        |e| {
-            panic!("Network event stream error: {:?}", e)
-        },
-    );
+    let net_fut = net_rx
+        .for_each(move |net_event| {
+            n(net_event);
+            Ok(())
+        })
+        .map_err(|e| panic!("Network event stream error: {:?}", e));
     el_h.spawn(net_fut);
 
     let core_tx_clone = core_tx.clone();


### PR DESCRIPTION
API changes:
- `mdata_list_entries` => `mdata_entries`
- `mdata_entries_for_each` => `mdata_list_entries`
-  new`MDataEntry` struct, returned by `mdata_list_entries`