### PR TITLE
[MAID-2650] address long Travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ stages:
   - tests-stable
   - tests-nightly
 jobs:
+  fast_finish: true
   allow_failures:
     - rust: *stable-i686
   include:
@@ -73,7 +74,7 @@ jobs:
       if: type = pull_request
       os: linux
       rust: *stable
-    - script: set -x; scripts/stable && scripts/test-binary
+    - script: set -x; scripts/stable
       if: type = pull_request
       os: linux
       rust: *stable-i686

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,21 @@ env:
     - RUST_BACKTRACE=1
     - RUST_STABLE=1.26.1
     - RUST_NIGHTLY=nightly-2018-05-29
+    - RUST_RUSTFMT=0.8.2
+    - RUST_CLIPPY=0.0.206
     - RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust
 stages:
   - warmup-real
   - warmup-mock
-  - tests
-  - clippy
+  - tests-stable
+  - tests-nightly
 jobs:
   allow_failures:
     - rust: *stable-i686
   include:
-    # Cache warm-ups
+    # Warm up the cache for a real build
     - stage: warmup-real
       script: set -x; scripts/build-ffi-utils && scripts/build-real
       if: type = pull_request
@@ -33,10 +35,10 @@ jobs:
         apt:
           packages:
             - gcc-multilib
-    - script: set -x; scripts/build-ffi-utils && scripts/build-real
+    - script: set -x; scripts/rustfmt && scripts/build-ffi-utils && scripts/build-real
       os: linux
       rust: *nightly
-    # Cache warm-ups
+    # Warm up the cache for a mock build
     - stage: warmup-mock
       script: set -x; scripts/build-mock
       if: type = pull_request
@@ -65,8 +67,8 @@ jobs:
         apt:
           packages:
             - gcc-multilib
-    # Stable + nightly tests
-    - stage: tests
+    # Stable + nightly clippy
+    - stage: tests-stable
       script: set -x; scripts/stable && scripts/test-binary
       if: type = pull_request
       os: linux
@@ -83,17 +85,17 @@ jobs:
       if: type = pull_request
       os: osx
       rust: *stable
-    - script: set -x; scripts/test-all
+    - script: set -x; scripts/check-debug-all; scripts/clippy-all
       os: linux
       rust: *nightly
-      # Clippy
-    - stage: clippy
-      script: set -x; scripts/clippy-all
+    # Nightly tests
+    - stage: tests-nightly
+      script: set -x; scripts/test-all
       os: linux
       rust: *nightly
 sudo: false
 cache:
-  # Double the default timeout. We cache a lot!
+  # Double the default timeout.
   timeout: 360
   cargo: true
   directories:
@@ -122,8 +124,8 @@ before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
   - if [ "$TRAVIS_RUST_VERSION" = $RUST_NIGHTLY ] && [ "$TRAVIS_OS_NAME" = linux ]; then
-      bash cargo_install.sh rustfmt-nightly 0.8.2;
-      bash cargo_install.sh clippy 0.0.206;
+      bash cargo_install.sh rustfmt-nightly "$RUST_RUSTFMT";
+      bash cargo_install.sh clippy "$RUST_CLIPPY";
     fi
 after_script:
   - if [[ $TRAVIS_EVENT_TYPE = pull_request && -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,49 +11,73 @@ env:
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust
 stages:
-  - stable
-  - nightly-warmup
-  - nightly-tests
+  - warmup-real
+  - warmup-mock
+  - tests
 jobs:
   allow_failures:
     - rust: *stable-i686
   include:
-    # Stable
-    - stage: stable
-      script: set -x; scripts/stable
+    # Cache warm-ups
+    - stage: warmup-real
+      script: set -x; scripts/build-ffi-utils && scripts/build-real
+      if: type = pull_request
       os: linux
       rust: *stable
-    - os: linux
-      script: set -x; scripts/stable
+    - script: set -x; scripts/build-ffi-utils && scripts/build-real
+      if: type = pull_request
+      os: linux
       rust: *stable-i686
       addons:
         apt:
           packages:
             - gcc-multilib
-    - os: osx
-      script: set -x; scripts/stable
+    - script: set -x; scripts/build-ffi-utils && scripts/build-real
+      os: linux
+      rust: *nightly
+    # Cache warm-ups
+    - stage: warmup-mock
+      script: set -x; scripts/build-mock && scripts/build-binary
+      if: type = pull_request
+      os: linux
       rust: *stable
-    # Nightly compiler warm-up + clippy
-    - stage: nightly-warmup
-      script: set -x; scripts/build-all
-      os: linux
-      rust: *nightly
-    - script: set -x; scripts/check-debug-ffi-utils && scripts/clippy-ffi-utils && scripts/check-debug-real && scripts/clippy-real
+    - script: set -x; scripts/build-mock && scripts/build-binary
       if: type = pull_request
       os: linux
-      rust: *nightly
-    # Nightly tests + clippy
-    - stage: nightly-tests
-      script: set -x; scripts/test-all
+      rust: *stable-i686
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - script: set -x; scripts/build-mock
       os: linux
       rust: *nightly
-    - script: set -x; scripts/check-debug-mock && scripts/clippy-mock
+    # Stable + nightly tests
+    - stage: tests
+      script: set -x; scripts/stable && scripts/test-binary
       if: type = pull_request
+      os: linux
+      rust: *stable
+    - script: set -x; scripts/stable && scripts/test-binary
+      if: type = pull_request
+      os: linux
+      rust: *stable-i686
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - script: set -x; scripts/stable
+      if: type = pull_request
+      os: osx
+      rust: *stable
+    - script: set -x; scripts/test-all && scripts/clippy-all
       os: linux
       rust: *nightly
 sudo: false
 cache:
   cargo: true
+  directories:
+    - "${TRAVIS_BUILD_DIR%/}-$TRAVIS_BRANCH/target"
 before_script:
   # Expected version change PR title format:
   # Version change: safe_app to 0.2.2; safe_authenticator to 0.2.3; safe_core to 0.26.0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ stages:
   - warmup-real
   - warmup-mock
   - tests
+  - clippy
 jobs:
   allow_failures:
     - rust: *stable-i686
@@ -37,7 +38,7 @@ jobs:
       rust: *nightly
     # Cache warm-ups
     - stage: warmup-mock
-      script: set -x; scripts/build-mock && scripts/build-binary
+      script: set -x; scripts/build-mock
       if: type = pull_request
       os: linux
       rust: *stable
@@ -52,6 +53,18 @@ jobs:
     - script: set -x; scripts/build-mock
       os: linux
       rust: *nightly
+    - script: set -x; scripts/build-binary
+      if: type = push
+      os: linux
+      rust: *stable
+    - script: set -x; scripts/build-binary
+      if: type = push
+      os: linux
+      rust: *stable-i686
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
     # Stable + nightly tests
     - stage: tests
       script: set -x; scripts/stable && scripts/test-binary
@@ -70,14 +83,21 @@ jobs:
       if: type = pull_request
       os: osx
       rust: *stable
-    - script: set -x; scripts/test-all && scripts/clippy-all
+    - script: set -x; scripts/test-all
+      os: linux
+      rust: *nightly
+      # Clippy
+    - stage: clippy
+      script: set -x; scripts/clippy-all
       os: linux
       rust: *nightly
 sudo: false
 cache:
+  # Double the default timeout. We cache a lot!
+  timeout: 360
   cargo: true
   directories:
-    - "${TRAVIS_BUILD_DIR%/}-$TRAVIS_BRANCH/target"
+    - "${HOME}/.cache/master"
 before_script:
   # Expected version change PR title format:
   # Version change: safe_app to 0.2.2; safe_authenticator to 0.2.3; safe_core to 0.26.0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
       if: type = pull_request
       os: osx
       rust: *stable
-    - script: set -x; scripts/check-debug-all; scripts/clippy-all
+    - script: set -x; scripts/clippy-all
       os: linux
       rust: *nightly
     # Nightly tests

--- a/scripts/build-all
+++ b/scripts/build-all
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 scripts/build-ffi-utils && scripts/build-real && scripts/build-mock

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x;
+
+echo "--- Building the binary compatibility test ---" &&
+
+export BASE_BRANCH_DIR="${TRAVIS_BUILD_DIR}-$TRAVIS_BRANCH" &&
+rsync -av --exclude="target" "${TRAVIS_BUILD_DIR}/" "$BASE_BRANCH_DIR" &&
+cp -r "$TRAVIS_BUILD_DIR" "$BASE_BRANCH_DIR" &&
+
+cd "$BASE_BRANCH_DIR" &&
+git checkout -qf "$TRAVIS_BRANCH" &&
+
+cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -4,11 +4,9 @@ set -x;
 
 echo "--- Building the binary compatibility test ---" &&
 
-export BASE_BRANCH_DIR="${TRAVIS_BUILD_DIR}-$TRAVIS_BRANCH" &&
-rsync -av --exclude="target" "${TRAVIS_BUILD_DIR}/" "$BASE_BRANCH_DIR" &&
-cp -r "$TRAVIS_BUILD_DIR" "$BASE_BRANCH_DIR" &&
+    cargo test --verbose --release --no-run --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml &&
 
-cd "$BASE_BRANCH_DIR" &&
-git checkout -qf "$TRAVIS_BRANCH" &&
-
-cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+    # Find the file to run.
+    TEST_FILE=$(find target/release -maxdepth 1 -type f -perm -111 -name "safe_authenticator-*" | head -1) &&
+    COMPAT_TESTS="${HOME}/.cache/master/tests" &&
+    cp "$TEST_FILE" "$COMPAT_TESTS"

--- a/scripts/build-ffi-utils
+++ b/scripts/build-ffi-utils
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 cargo build --verbose --release --tests --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/build-mock
+++ b/scripts/build-mock
@@ -3,5 +3,4 @@
 cargo build --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
-cargo build --verbose --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml

--- a/scripts/build-mock
+++ b/scripts/build-mock
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cargo build --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&

--- a/scripts/build-real
+++ b/scripts/build-real
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cargo build --verbose --release --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&

--- a/scripts/check-all
+++ b/scripts/check-all
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 scripts/check-ffi-utils && scripts/check-real && scripts/check-mock

--- a/scripts/check-debug-all
+++ b/scripts/check-debug-all
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-scripts/check-debug-ffi-utils && scripts/check-debug-real && scripts/check-debug-mock

--- a/scripts/check-debug-ffi-utils
+++ b/scripts/check-debug-ffi-utils
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-cargo check --verbose --tests --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/check-debug-mock
+++ b/scripts/check-debug-mock
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-cargo check --verbose --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --lib --tests --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --lib --tests --manifest-path=safe_app/Cargo.toml &&
-cargo check --verbose --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-debug-real
+++ b/scripts/check-debug-real
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-cargo check --verbose --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features=testing --lib --tests --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features=testing --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-cargo check --verbose --features=testing --lib --tests --manifest-path=safe_app/Cargo.toml &&
-cargo check --verbose --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-ffi-utils
+++ b/scripts/check-ffi-utils
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 cargo check --verbose --release --tests --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/check-mock
+++ b/scripts/check-mock
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cargo check --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&

--- a/scripts/check-mock
+++ b/scripts/check-mock
@@ -3,5 +3,4 @@
 cargo check --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml &&
-cargo check --verbose --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml

--- a/scripts/check-real
+++ b/scripts/check-real
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cargo check --verbose --release --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
 cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&

--- a/scripts/clippy-all
+++ b/scripts/clippy-all
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-scripts/clippy-ffi-utils && scripts/clippy-real && scripts/clippy-mock
+set -x;
+
+# TODO: remove `check-all` line below.
+# This fixes a Clippy issue when compiling JNI dependency by running `cargo check` first.
+# See https://github.com/rust-lang-nursery/rust-clippy/issues/2831
+scripts/check-all &&
+  scripts/clippy-ffi-utils &&
+  scripts/clippy-real &&
+  scripts/clippy-mock

--- a/scripts/clippy-ffi-utils
+++ b/scripts/clippy-ffi-utils
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 cd ffi_utils && cargo clippy --verbose --release --profile=test && cd ..

--- a/scripts/clippy-ffi-utils
+++ b/scripts/clippy-ffi-utils
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cd ffi_utils && cargo clippy --profile=test && cd ..
+cd ffi_utils && cargo clippy --verbose --release --profile=test && cd ..

--- a/scripts/clippy-mock
+++ b/scripts/clippy-mock
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cd safe_core && cargo clippy --profile=test --features=use-mock-routing && cd .. &&
-cd safe_authenticator && cargo clippy --profile=test --features=use-mock-routing && cd .. &&
-cd safe_app && cargo clippy --profile=test --features=use-mock-routing && cd ..
+cd safe_core && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
+cd safe_authenticator && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
+cd safe_app && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd ..

--- a/scripts/clippy-mock
+++ b/scripts/clippy-mock
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cd safe_core && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
 cd safe_authenticator && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
 cd safe_app && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd ..

--- a/scripts/clippy-real
+++ b/scripts/clippy-real
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cd safe_core && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&
 cd safe_authenticator && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&
 cd safe_app && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&

--- a/scripts/clippy-real
+++ b/scripts/clippy-real
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd safe_core && cargo clippy --profile=test --features=testing && cd .. &&
-cd safe_authenticator && cargo clippy --profile=test --features=testing && cd .. &&
-cd safe_app && cargo clippy --profile=test --features=testing && cd .. &&
-cd tests && cargo clippy --profile=test && cd ..
+cd safe_core && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&
+cd safe_authenticator && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&
+cd safe_app && cargo clippy --verbose --features=testing --release --profile=test && cd .. &&
+cd tests && cargo clippy --verbose --release --profile=test && cd ..

--- a/scripts/rustfmt
+++ b/scripts/rustfmt
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo fmt --all -- --check

--- a/scripts/rustfmt
+++ b/scripts/rustfmt
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 cargo fmt --all -- --check

--- a/scripts/stable
+++ b/scripts/stable
@@ -1,41 +1,17 @@
 #!/bin/bash
 
-if [[ $TRAVIS_EVENT_TYPE = pull_request ]]; then
-  (
-    set -x;
+set -x;
 
-      echo "--- Test ffi_utils ---" &&
-      scripts/test-ffi-utils &&
+if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
+  echo "--- Check format ---" &&
+    cargo fmt --all -- --write-mode=diff;
+fi &&
 
-      echo "--- Check compilation against actual routing ---" &&
-      scripts/check-real &&
+  echo "--- Test ffi_utils ---" &&
+  scripts/test-ffi-utils &&
 
-      echo "--- Test against mock ---" &&
-      scripts/test-mock &&
+  echo "--- Check compilation against actual routing ---" &&
+  scripts/check-real &&
 
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        (
-          echo "--- Test binary compatibility ---" &&
-
-            unset SAFE_MOCK_IN_MEMORY_STORAGE &&
-            export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
-            mkdir -p $SAFE_MOCK_VAULT_PATH &&
-
-            export BASE_BRANCH_DIR=${TRAVIS_BUILD_DIR%/}-$TRAVIS_BRANCH &&
-            cp -r $TRAVIS_BUILD_DIR $BASE_BRANCH_DIR &&
-            cd $BASE_BRANCH_DIR &&
-            git checkout -qf $TRAVIS_BRANCH &&
-
-            cd $TRAVIS_BUILD_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
-
-            cd $BASE_BRANCH_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
-
-            cd $TRAVIS_BUILD_DIR &&
-            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored
-        );
-      fi
-  )
-fi
+  echo "--- Test against mock ---" &&
+  scripts/test-mock

--- a/scripts/stable
+++ b/scripts/stable
@@ -2,16 +2,11 @@
 
 set -x;
 
-if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
-    echo "--- Check format ---" &&
-        cargo fmt --all -- --write-mode=diff;
-fi &&
+echo "--- Test ffi_utils ---" &&
+  scripts/test-ffi-utils &&
 
-    echo "--- Test ffi_utils ---" &&
-    scripts/test-ffi-utils &&
+  echo "--- Check compilation against actual routing ---" &&
+  scripts/check-real &&
 
-    echo "--- Check compilation against actual routing ---" &&
-    scripts/check-real &&
-
-    echo "--- Test against mock ---" &&
-    scripts/test-mock
+  echo "--- Test against mock ---" &&
+  scripts/test-mock

--- a/scripts/stable
+++ b/scripts/stable
@@ -3,15 +3,15 @@
 set -x;
 
 if [[ "$TRAVIS_RUST_VERSION" == "$RUST_STABLE" ]]; then
-  echo "--- Check format ---" &&
-    cargo fmt --all -- --write-mode=diff;
+    echo "--- Check format ---" &&
+        cargo fmt --all -- --write-mode=diff;
 fi &&
 
-  echo "--- Test ffi_utils ---" &&
-  scripts/test-ffi-utils &&
+    echo "--- Test ffi_utils ---" &&
+    scripts/test-ffi-utils &&
 
-  echo "--- Check compilation against actual routing ---" &&
-  scripts/check-real &&
+    echo "--- Check compilation against actual routing ---" &&
+    scripts/check-real &&
 
-  echo "--- Test against mock ---" &&
-  scripts/test-mock
+    echo "--- Test against mock ---" &&
+    scripts/test-mock

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 scripts/test-ffi-utils && scripts/test-mock

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_RUST_VERSION" == "$RUST_NIGHTLY" ]]; then
-  echo "--- Check format ---" &&
-    cargo fmt --all -- --check;
-fi &&
-
-  scripts/test-ffi-utils && scripts/test-mock
+scripts/test-ffi-utils && scripts/test-mock

--- a/scripts/test-binary
+++ b/scripts/test-binary
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x;
+
+echo "--- Test binary compatibility ---" &&
+
+# Use mock vault file.
+unset SAFE_MOCK_IN_MEMORY_STORAGE &&
+export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
+mkdir -p "$SAFE_MOCK_VAULT_PATH" &&
+
+export BASE_BRANCH_DIR="${TRAVIS_BUILD_DIR}-$TRAVIS_BRANCH" &&
+rsync -av --exclude="target" "${TRAVIS_BUILD_DIR}/" "$BASE_BRANCH_DIR" &&
+cp -r "$TRAVIS_BUILD_DIR" "$BASE_BRANCH_DIR" &&
+
+cd "$BASE_BRANCH_DIR" &&
+git checkout -qf "$TRAVIS_BRANCH" &&
+
+cd "$TRAVIS_BUILD_DIR" &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
+
+cd "$BASE_BRANCH_DIR" &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
+
+cd "$TRAVIS_BUILD_DIR" &&
+cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored

--- a/scripts/test-binary
+++ b/scripts/test-binary
@@ -2,26 +2,20 @@
 
 set -x;
 
-echo "--- Test binary compatibility ---" &&
+COMPAT_TESTS="${HOME}/.cache/master/tests" &&
 
-# Use mock vault file.
-unset SAFE_MOCK_IN_MEMORY_STORAGE &&
-export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
-mkdir -p "$SAFE_MOCK_VAULT_PATH" &&
+    if [[ -f "$COMPAT_TESTS" ]]; then
+        echo "--- Test binary compatibility ---" &&
 
-export BASE_BRANCH_DIR="${TRAVIS_BUILD_DIR}-$TRAVIS_BRANCH" &&
-rsync -av --exclude="target" "${TRAVIS_BUILD_DIR}/" "$BASE_BRANCH_DIR" &&
-cp -r "$TRAVIS_BUILD_DIR" "$BASE_BRANCH_DIR" &&
+            # Use mock vault file.
+            unset SAFE_MOCK_IN_MEMORY_STORAGE &&
+            export SAFE_MOCK_VAULT_PATH=$HOME/tmp &&
+            mkdir -p "$SAFE_MOCK_VAULT_PATH" &&
 
-cd "$BASE_BRANCH_DIR" &&
-git checkout -qf "$TRAVIS_BRANCH" &&
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
 
-cd "$TRAVIS_BUILD_DIR" &&
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
+            "$COMPAT_TESTS" read_data -- --ignored &&
+            "$COMPAT_TESTS" write_data -- --ignored &&
 
-cd "$BASE_BRANCH_DIR" &&
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored &&
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::write_data -- --ignored &&
-
-cd "$TRAVIS_BUILD_DIR" &&
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored
+            cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation::read_data -- --ignored;
+    fi

--- a/scripts/test-ffi-utils
+++ b/scripts/test-ffi-utils
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -x;
+
 cargo test --verbose --release --manifest-path=ffi_utils/Cargo.toml

--- a/scripts/test-mock
+++ b/scripts/test-mock
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x;
+
 cargo test config_mock_vault_path --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&
 export SAFE_MOCK_IN_MEMORY_STORAGE=1 &&
 cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml &&


### PR DESCRIPTION
+ fix cache issues by splitting up jobs and using build stages
+ build and cache the binary compatibility test whenever we push to master
+ run clippy with the `--release` flag

The final configuration uses four build stages. We can't get it down any lower without running into timeouts on an empty cache. With four build stages we do not have timeouts and we can avoid restarting CI, saving time overall.