### PR TITLE
MAID-2894 - make callback delegates readonly in csharp  manual bindings

### DIFF
--- a/safe_app/resources/SafeApp.AppBindings/AppBindings.Manual.cs
+++ b/safe_app/resources/SafeApp.AppBindings/AppBindings.Manual.cs
@@ -52,7 +52,7 @@ namespace SafeApp.AppBindings {
       action();
     }
 
-    private static NoneCb DelegateOnAppDisconnectCb = OnAppDisconnectCb;
+    private static readonly NoneCb DelegateOnAppDisconnectCb = OnAppDisconnectCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(FfiResultAppCb))]
@@ -66,7 +66,7 @@ namespace SafeApp.AppBindings {
       action(Marshal.PtrToStructure<FfiResult>(result), app, GCHandle.FromIntPtr(userData));
     }
 
-    private static FfiResultAppCb DelegateOnAppCreateCb = OnAppCreateCb;
+    private static readonly FfiResultAppCb DelegateOnAppCreateCb = OnAppCreateCb;
 
     public Task<IpcMsg> DecodeIpcMsgAsync(string msg) {
       var (task, userData) = BindingUtils.PrepareTask<IpcMsg>();
@@ -94,7 +94,7 @@ namespace SafeApp.AppBindings {
           new AuthGranted(Marshal.PtrToStructure<AuthGrantedNative>(authGranted))));
     }
 
-    private static UIntAuthGrantedCb DelegateOnDecodeIpcMsgAuthCb = OnDecodeIpcMsgAuthCb;
+    private static readonly UIntAuthGrantedCb DelegateOnDecodeIpcMsgAuthCb = OnDecodeIpcMsgAuthCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(UIntByteListCb))]
@@ -105,7 +105,7 @@ namespace SafeApp.AppBindings {
       tcs.SetResult(new UnregisteredIpcMsg(reqId, serialisedCfgPtr, serialisedCfgLen));
     }
 
-    private static UIntByteListCb DelegateOnDecodeIpcMsgUnregisteredCb = OnDecodeIpcMsgUnregisteredCb;
+    private static readonly UIntByteListCb DelegateOnDecodeIpcMsgUnregisteredCb = OnDecodeIpcMsgUnregisteredCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(UIntCb))]
@@ -116,7 +116,7 @@ namespace SafeApp.AppBindings {
       tcs.SetResult(new ContainersIpcMsg(reqId));
     }
 
-    private static UIntCb DelegateOnDecodeIpcMsgContainersCb = OnDecodeIpcMsgContainersCb;
+    private static readonly UIntCb DelegateOnDecodeIpcMsgContainersCb = OnDecodeIpcMsgContainersCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(UIntCb))]
@@ -127,7 +127,7 @@ namespace SafeApp.AppBindings {
       tcs.SetResult(new ShareMDataIpcMsg(reqId));
     }
 
-    private static UIntCb DelegateOnDecodeIpcMsgShareMdataCb = OnDecodeIpcMsgShareMdataCb;
+    private static readonly UIntCb DelegateOnDecodeIpcMsgShareMdataCb = OnDecodeIpcMsgShareMdataCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(NoneCb))]
@@ -138,7 +138,7 @@ namespace SafeApp.AppBindings {
       tcs.SetResult(new RevokedIpcMsg());
     }
 
-    private static NoneCb DelegateOnDecodeIpcMsgRevokedCb = OnDecodeIpcMsgRevokedCb;
+    private static readonly NoneCb DelegateOnDecodeIpcMsgRevokedCb = OnDecodeIpcMsgRevokedCb;
 
     #if __IOS__
     [MonoPInvokeCallback(typeof(FfiResultUIntCb))]
@@ -150,7 +150,7 @@ namespace SafeApp.AppBindings {
       tcs.SetException(new IpcMsgException(reqId, res.ErrorCode, res.Description));
     }
 
-    private static FfiResultUIntCb DelegateOnDecodeIpcMsgErrCb = OnDecodeIpcMsgErrCb;
+    private static readonly FfiResultUIntCb DelegateOnDecodeIpcMsgErrCb = OnDecodeIpcMsgErrCb;
   }
 }
 #endif

--- a/safe_authenticator/resources/SafeAuth.AuthBindings/AuthBindings.Manual.cs
+++ b/safe_authenticator/resources/SafeAuth.AuthBindings/AuthBindings.Manual.cs
@@ -54,7 +54,7 @@ namespace SafeAuth.AuthBindings {
 
       action(Marshal.PtrToStructure<FfiResult>(result), app, GCHandle.FromIntPtr(userData));
     }
-    private static FfiResultAuthenticatorCb DelegateOnAuthenticatorCreateCb = OnAuthenticatorCreateCb;
+    private static readonly FfiResultAuthenticatorCb DelegateOnAuthenticatorCreateCb = OnAuthenticatorCreateCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(NoneCb))]
@@ -64,7 +64,7 @@ namespace SafeAuth.AuthBindings {
 
       action();
     }
-    private static NoneCb DelegateOnAuthenticatorDisconnectCb = OnAuthenticatorDisconnectCb;
+    private static readonly NoneCb DelegateOnAuthenticatorDisconnectCb = OnAuthenticatorDisconnectCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(UIntAuthReqCb))]
@@ -73,7 +73,7 @@ namespace SafeAuth.AuthBindings {
       var tcs = BindingUtils.FromHandlePtr<TaskCompletionSource<IpcReq>>(userData);
       tcs.SetResult(new AuthIpcReq(reqId, new AuthReq(Marshal.PtrToStructure<AuthReqNative>(authReq))));
     }
-    private static UIntAuthReqCb DelegateOnDecodeIpcReqAuthCb = OnDecodeIpcReqAuthCb;
+    private static readonly UIntAuthReqCb DelegateOnDecodeIpcReqAuthCb = OnDecodeIpcReqAuthCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(UIntContainersReqCb))]
@@ -82,7 +82,7 @@ namespace SafeAuth.AuthBindings {
       var tcs = BindingUtils.FromHandlePtr<TaskCompletionSource<IpcReq>>(userData);
       tcs.SetResult(new ContainersIpcReq(reqId, new ContainersReq(Marshal.PtrToStructure<ContainersReqNative>(authReq))));
     }
-    private static UIntContainersReqCb DelegateOnDecodeIpcReqContainersCb = OnDecodeIpcReqContainersCb;
+    private static readonly UIntContainersReqCb DelegateOnDecodeIpcReqContainersCb = OnDecodeIpcReqContainersCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(UIntShareMDataReqMetadataResponseCb))]
@@ -93,7 +93,7 @@ namespace SafeAuth.AuthBindings {
       var metadataResponse = Marshal.PtrToStructure<MetadataResponse>(metadata);
       tcs.SetResult(new ShareMDataIpcReq(reqId, shareMdReq, metadataResponse));
     }
-    private static UIntShareMDataReqMetadataResponseCb DelegateOnDecodeIpcReqShareMDataCb = OnDecodeIpcReqShareMDataCb;
+    private static readonly UIntShareMDataReqMetadataResponseCb DelegateOnDecodeIpcReqShareMDataCb = OnDecodeIpcReqShareMDataCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(UIntByteListCb))]
@@ -102,7 +102,7 @@ namespace SafeAuth.AuthBindings {
       var tcs = BindingUtils.FromHandlePtr<TaskCompletionSource<IpcReq>>(userData);
       tcs.SetResult(new UnregisteredIpcReq(reqId, extraData, (ulong)size));
     }
-    private static UIntByteListCb DelegateOnDecodeIpcReqUnregisteredCb = OnDecodeIpcReqUnregisteredCb;
+    private static readonly UIntByteListCb DelegateOnDecodeIpcReqUnregisteredCb = OnDecodeIpcReqUnregisteredCb;
 
 #if __IOS__
     [MonoPInvokeCallback(typeof(FfiResultIpcReqErrorCb))]
@@ -112,7 +112,7 @@ namespace SafeAuth.AuthBindings {
       var ffiResult = Marshal.PtrToStructure<FfiResult>(result);
       tcs.SetResult(new IpcReqError(ffiResult.ErrorCode, ffiResult.Description, msg));
     }
-    private static FfiResultStringCb DelegateOnFfiResultIpcReqErrorCb = OnFfiResultIpcReqErrorCb;
+    private static readonly FfiResultStringCb DelegateOnFfiResultIpcReqErrorCb = OnFfiResultIpcReqErrorCb;
 
     // ReSharper disable once UnusedMember.Local
     private delegate void FfiResultIpcReqErrorCb(IntPtr userData, IntPtr result, string msg);


### PR DESCRIPTION
linter fix : make delegates readonly in manual resource files.