### PR TITLE
Version change: safe_app to 0.8.0; safe_authenticator to 0.8.0; safe_core to 0.31.0;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,11 +120,13 @@ jobs:
 
       # Deploy
     - stage: deploy
+      script: set -x; true
       if: type = push
       os: linux
       rust: *stable
       env: RUN_DEPLOY=1
     - stage: deploy
+      script: set -x; true
       if: type = push
       os: osx
       rust: *stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,12 +73,13 @@ test_script:
     cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml
 
 before_deploy:
-  - cargo install cargo-script --vers=0.2.8
+  - $url2 = "https://s3.eu-west-2.amazonaws.com/download-native-libs/cargo-script.exe"
+  - Invoke-WebRequest $url2 -OutFile "cargo-script.exe"
   - ps: New-Item -Path ".\target\deploy" -ItemType directory
-  - cargo script -- ./scripts/package.rs --lib --name safe_app -d target/deploy --mock
-  - cargo script -- ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --mock
-  - cargo script -- ./scripts/package.rs --lib --name safe_app -d target/deploy
-  - cargo script -- ./scripts/package.rs --lib --name safe_authenticator -d target/deploy
+  - cargo-script.exe -- ./scripts/package.rs --lib --name safe_app -d target/deploy --mock
+  - cargo-script.exe -- ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --mock
+  - cargo-script.exe -- ./scripts/package.rs --lib --name safe_app -d target/deploy
+  - cargo-script.exe -- ./scripts/package.rs --lib --name safe_authenticator -d target/deploy
   - ps: $root = Resolve-Path .\target\deploy; [IO.Directory]::GetFiles($root.Path, '*.zip') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) }
 
 deploy:


### PR DESCRIPTION
Add a no-op `script` step to prevent Travis's default script from running.
Do not use `script: skip` so that `before_script` still runs.