### PR TITLE
Use case insensitive URIs for IPC [MAID-3149]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 vars:
   - &stable "1.28.0"
-  - &nightly "nightly-2018-07-07"
 env:
   global:
     - RUST_BACKTRACE=1
     - RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
     - PATH=$PATH:$HOME/.cargo/bin
     - RUST_STABLE=1.28.0
-    - RUST_NIGHTLY=nightly-2018-07-07
-    - RUST_RUSTFMT=0.99.2
-    - RUST_CLIPPY=0.0.212
 language: rust
 stages:
   - warmup-ffi
   - warmup-real
   - warmup-mock
   - tests-stable
-  - tests-nightly
+  - tests-binary-compat
   - deploy
 jobs:
   include:
@@ -25,35 +21,20 @@ jobs:
       script: set -x; scripts/build-real-core
       os: linux
       rust: *stable
-    - stage: warmup-ffi
-      script: set -x; scripts/build-real-core
-      if: type = pull_request
-      os: linux
-      rust: *nightly
 
     # Warm up the cache for a real build
     - stage: warmup-real
       script: set -x; scripts/build-real
       os: linux
       rust: *stable
-    - stage: warmup-real
-      script: set -x; scripts/build-real
-      if: type = pull_request
-      os: linux
-      rust: *nightly
 
     # Warm up the cache for a mock build
     - stage: warmup-mock
       script: set -x; scripts/build-mock
       os: linux
       rust: *stable
-    - stage: warmup-mock
-      script: set -x; scripts/build-mock
-      if: type = pull_request
-      os: linux
-      rust: *nightly
 
-    # Stable + nightly clippy
+    # Stable + clippy
     - stage: tests-stable
       script: set -x; scripts/stable && scripts/test-binary
       os: linux
@@ -62,26 +43,21 @@ jobs:
       script: set -x; scripts/stable
       os: osx
       rust: *stable
-    - stage: tests-stable
-      script: set -x; scripts/rustfmt && scripts/clippy-all
-      if: type = pull_request
-      os: linux
-      rust: *nightly
-      env: RUN_RUSTFMT=1
+    # Temporarily disable clippy until SCL compiles on 1.29 stable
+    # - stage: tests-stable
+    #   script: set -x; scripts/clippy-all
+    #   if: type = pull_request
+    #   os: linux
+    #   rust: *stable
 
-    # Nightly tests
-    - stage: tests-nightly
-      script: set -x; scripts/test-all
-      if: type = pull_request
-      os: linux
-      rust: *nightly
-    - stage: tests-nightly
+    # Build tests for binary compatibility
+    - stage: tests-binary-compat
       script: set -x; scripts/build-binary
       if: type = push
       os: linux
       rust: *stable
 
-      # Deploy
+    # Deploy
     - stage: deploy
       script: set -x; true
       if: type = push
@@ -124,10 +100,6 @@ before_script:
     fi
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - if [ "$TRAVIS_RUST_VERSION" = "$RUST_NIGHTLY" ] && [ "$RUN_RUSTFMT" ]; then
-      bash cargo_install.sh rustfmt-nightly "$RUST_RUSTFMT";
-      bash cargo_install.sh clippy "$RUST_CLIPPY";
-    fi
 after_script:
   - if [[ $TRAVIS_EVENT_TYPE = pull_request && -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then
       echo "Working tree is dirty after building.  Probably Cargo.lock should be updated.";

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "diff"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,9 +1559,9 @@ dependencies = [
 name = "safe_core"
 version = "0.31.0"
 dependencies = [
- "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2432,6 +2437,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crust 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b86ca17b25d736df789b9f788a7ca7bc9e434c136ee93f3f2d91d70d28759413"
+"checksum data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "67df0571a74bf0d97fb8b2ed22abdd9a48475c96bd327db968b7d9cace99655e"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b29c278aa8fd30796bd977169e8004b4aa88cdcd2f32a6eb22bc2d5d38df94a"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.31.0"
 
 [dependencies]
-base64 = "~0.9.0"
+data-encoding = "~2.1.1"
 chrono = { version = "~0.4.0", features = ["serde"] }
 config_file_handler = "~0.11.0"
 ffi_utils = "~0.8.0"

--- a/safe_core/src/ipc/errors.rs
+++ b/safe_core/src/ipc/errors.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use base64::DecodeError;
+use data_encoding::DecodeError;
 use ffi_utils::StringError;
 use futures::sync::mpsc::SendError;
 use maidsafe_utilities::serialisation::SerialisationError;

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -132,9 +132,9 @@
     allow(implicit_hasher, too_many_arguments, use_debug)
 )]
 
-extern crate base64;
 extern crate chrono;
 extern crate config_file_handler;
+extern crate data_encoding;
 extern crate ffi_utils;
 #[cfg(feature = "use-mock-routing")]
 extern crate fs2;


### PR DESCRIPTION
Using case sensitive base64 encoding caused some issues on different platforms. Base32 is case insensitive and more versatile.