### PR TITLE
Fixes for Java/JNI bugs [MAID-2659]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,21 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "android_log-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "android_logger"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "ascii"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -261,11 +276,14 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "2.5.2"
+version = "3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -409,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,12 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ffi_utils"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -630,7 +648,7 @@ dependencies = [
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -703,14 +721,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jni"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -787,12 +805,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -957,7 +975,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1341,7 +1359,7 @@ dependencies = [
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,7 +1393,7 @@ dependencies = [
  "fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1473,17 +1491,17 @@ version = "0.8.0"
 dependencies = [
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.8.0",
- "safe_bindgen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.31.0",
  "self_encryption 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1497,8 +1515,10 @@ dependencies = [
 name = "safe_app_jni"
 version = "0.1.0"
 dependencies = [
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.8.0",
  "safe_core 0.31.0",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,16 +1529,16 @@ name = "safe_authenticator"
 version = "0.8.0"
 dependencies = [
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe_bindgen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.31.0",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1531,8 +1551,10 @@ dependencies = [
 name = "safe_authenticator_jni"
 version = "0.1.0"
 dependencies = [
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.8.0",
  "safe_core 0.31.0",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1540,12 +1562,12 @@ dependencies = [
 
 [[package]]
 name = "safe_bindgen"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1562,11 +1584,11 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "maidsafe_utilities 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1877,7 +1899,7 @@ dependencies = [
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.8.0",
  "safe_authenticator 0.8.0",
@@ -1958,7 +1980,7 @@ dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2002,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2013,7 +2035,7 @@ dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2051,7 +2073,7 @@ dependencies = [
  "crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2102,7 +2124,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2281,7 +2303,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2396,11 +2418,13 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum alloc-no-stdlib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b21f6ad9c9957eb5d70c3dee16d31c092b3cab339628f821766b05e6833d72b8"
+"checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
+"checksum android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bad99185bc195e796e1591740c26716667b58ac9210a48731f71f803fc6ca43a"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
-"checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5fc969a8ce2c9c0c4b0429bb8431544f6658283c8326ba5ff8c762b75369335"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
@@ -2427,7 +2451,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7f1aabf260a8f3fefa8871f16b531038c98dd9eab1cfa2c575e78c459abfa3a0"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
+"checksum combine 3.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "97d6e3d17febfeac84d2d94f78c31ba1d66069ae14fbfc7ed86148875300a1b4"
 "checksum config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0103336b0f2ddd541c0c81a60fc3be2e6e1d4f5b3dd8d89d2b2869d79d04efc4"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -2444,11 +2468,11 @@ dependencies = [
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum encoding_rs 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2a91912d6f37c6a8fef8a2316a862542d036f13c923ad518b5aca7bcaac7544c"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "054bc2552b3f66fa8097e29e47255bfff583c08e737a67cbbb54b817ddaa5206"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d8098c37c3aa33404700f9097733de3bf28b0393aab28af03b5b179a230b81c"
-"checksum ffi_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7ba6ef16b3685b64dd428e5e9729c15eb88a78707738dbb27fe87afb2fd83c4"
+"checksum ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4b8aa3108be7585b021457ba43d044bbcd651e9e1a172962518e1ef36628ce1"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
@@ -2477,7 +2501,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
-"checksum jni 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5479b540809575c4d6e3e68be5cdc33e03e0ab3d2108479a65d0374f2e82c1b9"
+"checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
@@ -2490,7 +2514,7 @@ dependencies = [
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 "checksum log4rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9beb5748c7d304a7c07e74ff2f0e642146a1191f8e9d9fb398e46ccb128364d"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
@@ -2560,7 +2584,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
-"checksum safe_bindgen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94ee92d3894cf4693f60d518dbbc8781702936604428a2cfb544e7d58279d318"
+"checksum safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9dc29cb650c4c193e396b9bc0e956faa96aba2af5d349670ba4363f183310ce"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -44,11 +44,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.8.0"
+safe_bindgen = "~0.9.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -28,7 +28,7 @@ self_encryption = "~0.13.0"
 tiny-keccak = "~1.3.1"
 tokio-core = "~0.1.12"
 unwrap = "~1.2.0"
-jni = { version = "~0.10.1", optional = true }
+jni = { version = "~0.10.2", optional = true }
 
 [dev-dependencies]
 clap = "=2.25.1"
@@ -44,11 +44,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.9.0"
+safe_bindgen = "~0.10.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_app_jni/Cargo.toml
+++ b/safe_app_jni/Cargo.toml
@@ -8,10 +8,14 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.9.0"
-jni = "~0.10.1"
+ffi_utils = { version = "~0.10.0", features = ["java"] }
+jni = "~0.10.2"
+log = "~0.4.5"
 safe_core = { path = "../safe_core", version = "~0.31.0" }
 unwrap = "~1.2.0"
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "~0.6.0"
 
 [dependencies.safe_app]
 path = "../safe_app"

--- a/safe_app_jni/Cargo.toml
+++ b/safe_app_jni/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 jni = "~0.10.1"
 safe_core = { path = "../safe_core", version = "~0.31.0" }
 unwrap = "~1.2.0"

--- a/safe_app_jni/src/lib.rs
+++ b/safe_app_jni/src/lib.rs
@@ -18,21 +18,25 @@
     unused_qualifications
 )]
 
+#[cfg(target_os = "android")]
+extern crate android_logger;
+#[macro_use]
+extern crate ffi_utils;
 extern crate jni;
+#[macro_use]
+extern crate log;
 extern crate safe_app;
 extern crate safe_core;
 #[macro_use]
-extern crate ffi_utils;
-#[macro_use]
 extern crate unwrap;
 
-use ffi_utils::java::{convert_cb_from_java, object_array_to_java, JniResult};
+use ffi_utils::java::{convert_cb_from_java, object_array_to_java, EnvGuard, JniResult};
 use ffi_utils::*;
 use jni::errors::{Error as JniError, ErrorKind};
 use jni::objects::{AutoLocal, GlobalRef, JClass, JMethodID, JObject, JString, JValue};
 use jni::strings::JNIStr;
 use jni::sys::{jbyte, jbyteArray, jclass, jint, jlong, jobject, jsize};
-use jni::{signature::JavaType, JNIEnv, JavaVM};
+use jni::{signature::JavaType, AttachGuard, JNIEnv, JavaVM};
 use safe_app::ffi::object_cache::*;
 use safe_app::UserPermissionSet;
 use safe_core::arrays::*;
@@ -77,47 +81,80 @@ pub trait FromJava<T> {
 // This is called when `loadLibrary` is called on the Java side.
 #[no_mangle]
 pub unsafe extern "C" fn JNI_OnLoad(vm: *mut jni::sys::JavaVM, _reserved: *mut c_void) -> jint {
-    JVM = Some(unwrap!(JavaVM::from_raw(vm)));
-
-    let env = JVM
-        .as_ref()
-        .map(|vm| unwrap!(vm.attach_current_thread_as_daemon()))
-        .expect("no JVM reference found");
-
-    let res_class = unwrap!(env.find_class("net/maidsafe/safe_app/FfiResult"));
-
-    CLASS_LOADER = Some(unwrap!(env.new_global_ref(
-        unwrap!(unwrap!(env.call_method(  From::from(res_class),
-                "getClassLoader",
-                "()Ljava/lang/ClassLoader;",
-                &[]
-            )).l())
-    )));
-
-    FIND_CLASS_METHOD = Some(unwrap!(env.get_method_id(
-        "java/lang/ClassLoader",
-        "findClass",
-        "(Ljava/lang/String;)Ljava/lang/Class;",
-    )));
-
+    if let Err(e) = cache_class_loader(vm) {
+        error!("{}", e);
+        return -1;
+    }
     jni::sys::JNI_VERSION_1_4
 }
 
-pub(crate) fn find_class<'a>(env: &'a JNIEnv, class_name: &str) -> AutoLocal<'a> {
-    unsafe {
-        let cls = env.new_string(class_name).unwrap();
+unsafe fn cache_class_loader(vm: *mut jni::sys::JavaVM) -> Result<(), JniError> {
+    JVM = Some(JavaVM::from_raw(vm)?);
 
-        env.auto_local(From::from(
-            env.call_method_unsafe(
-                CLASS_LOADER.as_ref().unwrap().as_obj(),
-                FIND_CLASS_METHOD.unwrap(),
-                JavaType::from_str("Ljava/lang/Object;").unwrap(),
-                &[JValue::from(*cls)],
-            ).unwrap()
-            .l()
-            .unwrap(),
-        ))
-    }
+    let env = JVM
+        .as_ref()
+        .ok_or_else(|| From::from("no JVM reference found"))
+        .and_then(|vm| vm.get_env())?;
+
+    let res_class = env.find_class("net/maidsafe/safe_app/FfiResult")?;
+
+    CLASS_LOADER = Some(
+        env.new_global_ref(
+            env.call_method(
+                From::from(res_class),
+                "getClassLoader",
+                "()Ljava/lang/ClassLoader;",
+                &[],
+            )?.l()?,
+        )?,
+    );
+
+    FIND_CLASS_METHOD = Some(env.get_method_id(
+        "java/lang/ClassLoader",
+        "findClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+    )?);
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "android"))]
+pub(crate) fn init_jni_logging() -> Result<(), JniError> {
+    Ok(())
+}
+
+#[cfg(target_os = "android")]
+pub(crate) fn init_jni_logging() -> Result<(), JniError> {
+    use android_logger::Filter;
+    use log::Level;
+
+    android_logger::init_once(
+        Filter::default().with_min_level(Level::Info),
+        Some("safe_app_jni"),
+    );
+
+    Ok(())
+}
+
+/// Uses the cached class loader to find a Java class.
+pub(crate) unsafe fn find_class<'a>(
+    env: &'a JNIEnv,
+    class_name: &str,
+) -> Result<AutoLocal<'a>, JniError> {
+    let cls = env.new_string(class_name)?;
+
+    Ok(env.auto_local(From::from(
+        env.call_method_unsafe(
+            CLASS_LOADER
+                .as_ref()
+                .ok_or_else(|| JniError::from("Unexpected - no cached class loader"))?
+                .as_obj(),
+            FIND_CLASS_METHOD
+                .ok_or_else(|| JniError::from("Unexpected - no cached findClass method ID"))?,
+            JavaType::from_str("Ljava/lang/Object;")?,
+            &[JValue::from(*cls)],
+        )?.l()?,
+    )))
 }
 
 gen_primitive_type_converter!(u8, jbyte);
@@ -203,9 +240,14 @@ impl<'a> FromJava<JObject<'a>> for Vec<u8> {
 
 gen_object_array_converter!(find_class, MDataKey, "net/maidsafe/safe_app/MDataKey");
 gen_object_array_converter!(find_class, MDataValue, "net/maidsafe/safe_app/MDataValue");
-gen_object_array_converter!(find_class, UserPermissionSet, "net/maidsafe/safe_app/UserPermissionSet");
+gen_object_array_converter!(
+    find_class,
+    UserPermissionSet,
+    "net/maidsafe/safe_app/UserPermissionSet"
+);
 gen_object_array_converter!(find_class, MDataEntry, "net/maidsafe/safe_app/MDataEntry");
-gen_object_array_converter!(find_class,
+gen_object_array_converter!(
+    find_class,
     ContainerPermissions,
     "net/maidsafe/safe_app/ContainerPermissions"
 );

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -26,7 +26,7 @@ serde_derive = "~1.0.27"
 tiny-keccak = "~1.3.1"
 tokio-core = "~0.1.12"
 unwrap = "~1.2.0"
-jni = { version = "~0.10.1", optional = true }
+jni = { version = "~0.10.2", optional = true }
 
 [dev-dependencies.safe_core]
 path = "../safe_core"
@@ -34,11 +34,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.9.0"
+safe_bindgen = "~0.10.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -34,11 +34,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.8.0"
+safe_bindgen = "~0.9.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_authenticator_jni/Cargo.toml
+++ b/safe_authenticator_jni/Cargo.toml
@@ -8,10 +8,14 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.9.0"
-jni = "~0.10.1"
+ffi_utils = { version = "~0.10.0", features = ["java"] }
+jni = "~0.10.2"
+log = "~0.4.5"
 safe_core = { path = "../safe_core", version = "~0.31.0" }
 unwrap = "~1.2.0"
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "~0.6.0"
 
 [dependencies.safe_authenticator]
 path = "../safe_authenticator"

--- a/safe_authenticator_jni/Cargo.toml
+++ b/safe_authenticator_jni/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 jni = "~0.10.1"
 safe_core = { path = "../safe_core", version = "~0.31.0" }
 unwrap = "~1.2.0"

--- a/safe_authenticator_jni/src/lib.rs
+++ b/safe_authenticator_jni/src/lib.rs
@@ -18,15 +18,19 @@
     unused_qualifications
 )]
 
+#[cfg(target_os = "android")]
+extern crate android_logger;
 #[macro_use]
 extern crate ffi_utils;
 extern crate jni;
+#[macro_use]
+extern crate log;
 extern crate safe_authenticator;
 extern crate safe_core;
 #[macro_use]
 extern crate unwrap;
 
-use ffi_utils::java::{convert_cb_from_java, object_array_to_java, JniResult};
+use ffi_utils::java::{convert_cb_from_java, object_array_to_java, EnvGuard, JniResult};
 use ffi_utils::*;
 use jni::errors::{Error as JniError, ErrorKind};
 use jni::objects::{AutoLocal, GlobalRef, JClass, JMethodID, JObject, JString, JValue};
@@ -59,47 +63,80 @@ static mut FIND_CLASS_METHOD: Option<JMethodID> = None;
 // This is called when `loadLibrary` is called on the Java side.
 #[no_mangle]
 pub unsafe extern "C" fn JNI_OnLoad(vm: *mut jni::sys::JavaVM, _reserved: *mut c_void) -> jint {
-    JVM = Some(unwrap!(JavaVM::from_raw(vm)));
-
-    let env = JVM
-        .as_ref()
-        .map(|vm| unwrap!(vm.attach_current_thread_as_daemon()))
-        .expect("no JVM reference found");
-
-    let res_class = unwrap!(env.find_class("net/maidsafe/safe_app/FfiResult"));
-
-    CLASS_LOADER = Some(unwrap!(env.new_global_ref(
-        unwrap!(unwrap!(env.call_method(  From::from(res_class),
-                "getClassLoader",
-                "()Ljava/lang/ClassLoader;",
-                &[]
-            )).l())
-    )));
-
-    FIND_CLASS_METHOD = Some(unwrap!(env.get_method_id(
-        "java/lang/ClassLoader",
-        "findClass",
-        "(Ljava/lang/String;)Ljava/lang/Class;",
-    )));
-
+    if let Err(e) = cache_class_loader(vm) {
+        error!("{}", e);
+        return -1;
+    }
     jni::sys::JNI_VERSION_1_4
 }
 
-pub(crate) fn find_class<'a>(env: &'a JNIEnv, class_name: &str) -> AutoLocal<'a> {
-    unsafe {
-        let cls = env.new_string(class_name).unwrap();
+unsafe fn cache_class_loader(vm: *mut jni::sys::JavaVM) -> Result<(), JniError> {
+    JVM = Some(JavaVM::from_raw(vm)?);
 
-        env.auto_local(From::from(
-            env.call_method_unsafe(
-                CLASS_LOADER.as_ref().unwrap().as_obj(),
-                FIND_CLASS_METHOD.unwrap(),
-                JavaType::from_str("Ljava/lang/Object;").unwrap(),
-                &[JValue::from(*cls)],
-            ).unwrap()
-            .l()
-            .unwrap(),
-        ))
-    }
+    let env = JVM
+        .as_ref()
+        .ok_or_else(|| From::from("no JVM reference found"))
+        .and_then(|vm| vm.get_env())?;
+
+    let res_class = env.find_class("net/maidsafe/safe_authenticator/FfiResult")?;
+
+    CLASS_LOADER = Some(
+        env.new_global_ref(
+            env.call_method(
+                From::from(res_class),
+                "getClassLoader",
+                "()Ljava/lang/ClassLoader;",
+                &[],
+            )?.l()?,
+        )?,
+    );
+
+    FIND_CLASS_METHOD = Some(env.get_method_id(
+        "java/lang/ClassLoader",
+        "findClass",
+        "(Ljava/lang/String;)Ljava/lang/Class;",
+    )?);
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "android"))]
+pub(crate) fn init_jni_logging() -> Result<(), JniError> {
+    Ok(())
+}
+
+#[cfg(target_os = "android")]
+pub(crate) fn init_jni_logging() -> Result<(), JniError> {
+    use android_logger::Filter;
+    use log::Level;
+
+    android_logger::init_once(
+        Filter::default().with_min_level(Level::Info),
+        Some("safe_app_jni"),
+    );
+
+    Ok(())
+}
+
+/// Uses the cached class loader to find a Java class.
+pub(crate) unsafe fn find_class<'a>(
+    env: &'a JNIEnv,
+    class_name: &str,
+) -> Result<AutoLocal<'a>, JniError> {
+    let cls = env.new_string(class_name)?;
+
+    Ok(env.auto_local(From::from(
+        env.call_method_unsafe(
+            CLASS_LOADER
+                .as_ref()
+                .ok_or_else(|| JniError::from("Unexpected - no cached class loader"))?
+                .as_obj(),
+            FIND_CLASS_METHOD
+                .ok_or_else(|| JniError::from("Unexpected - no cached findClass method ID"))?,
+            JavaType::from_str("Ljava/lang/Object;")?,
+            &[JValue::from(*cls)],
+        )?.l()?,
+    )))
 }
 
 // Trait for conversion of rust value to java value.
@@ -200,15 +237,31 @@ gen_object_array_converter!(
     RegisteredApp,
     "net/maidsafe/safe_authenticator/RegisteredApp"
 );
-gen_object_array_converter!(find_class, AppAccess, "net/maidsafe/safe_authenticator/AppAccess");
+gen_object_array_converter!(
+    find_class,
+    AppAccess,
+    "net/maidsafe/safe_authenticator/AppAccess"
+);
 gen_object_array_converter!(
     find_class,
     AppExchangeInfo,
     "net/maidsafe/safe_authenticator/AppExchangeInfo"
 );
-gen_object_array_converter!(find_class, MDataKey, "net/maidsafe/safe_authenticator/MDataKey");
-gen_object_array_converter!(find_class, MDataValue, "net/maidsafe/safe_authenticator/MDataValue");
-gen_object_array_converter!(find_class, MDataEntry, "net/maidsafe/safe_authenticator/MDataEntry");
+gen_object_array_converter!(
+    find_class,
+    MDataKey,
+    "net/maidsafe/safe_authenticator/MDataKey"
+);
+gen_object_array_converter!(
+    find_class,
+    MDataValue,
+    "net/maidsafe/safe_authenticator/MDataValue"
+);
+gen_object_array_converter!(
+    find_class,
+    MDataEntry,
+    "net/maidsafe/safe_authenticator/MDataEntry"
+);
 gen_object_array_converter!(
     find_class,
     ContainerPermissions,

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.31.0"
 data-encoding = "~2.1.1"
 chrono = { version = "~0.4.0", features = ["serde"] }
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 fs2 = "~0.4.3"
 futures = "~0.1.17"
 lazy_static = "~1.0.0"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.31.0"
 data-encoding = "~2.1.1"
 chrono = { version = "~0.4.0", features = ["serde"] }
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 fs2 = "~0.4.3"
 futures = "~0.1.17"
 lazy_static = "~1.0.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.9.0"
+ffi_utils = "~0.10.0"
 futures = "~0.1.17"
 serde = "~1.0.24"
 serde_json = "~1.0.2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.8.0"
+ffi_utils = "~0.9.0"
 futures = "~0.1.17"
 serde = "~1.0.24"
 serde_json = "~1.0.2"


### PR DESCRIPTION
By default Android JNI derives the class loader from the last Java class available in the call stack. This fails in case if we call from non-Java context (as we do when we call Java callbacks from the event loop thread
in SAFE Client Libs). This PR fixes this by caching the class loader during the library load and using it afterwards to look up Java classes.

Also, this PR uses fixed & updated `ffi_utils` and `safe_bindgen` to generate more robust JNI code and also use proper JNI threads detachment (using [`EnvGuard`](https://github.com/maidsafe/ffi_utils/blob/f7567e63f7258b18268b889af542a2d65274bb1c/src/java.rs#L21-L32) from `ffi_utils`).