### PR TITLE
chore/ci: remove deploy directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ test_script:
     cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml
 
 before_deploy:
+  - rmdir /s /q target\deploy
   - ps: |
         $url = "https://s3.eu-west-2.amazonaws.com/download-native-libs/cargo-script.exe"
         Invoke-WebRequest $url -OutFile "cargo-script.exe"


### PR DESCRIPTION
The subsequent Powershell script errors if this directory already exists.

Not sure why this only started failing now, but this seems to sort the issue. I ran a build with this change twice, just to make sure.