### PR TITLE
Fix mock vault corruption

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ test_script:
     cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml
 
 before_deploy:
+  - rmdir /s /q target\deploy
   - ps: |
         $url = "https://s3.eu-west-2.amazonaws.com/download-native-libs/cargo-script.exe"
         Invoke-WebRequest $url -OutFile "cargo-script.exe"

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -17,7 +17,7 @@ use rust_sodium::crypto::sign;
 use std::collections::HashMap;
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
@@ -326,6 +326,7 @@ impl Store for FileStore {
             if writing {
                 let raw_data = unwrap!(serialise(&cache));
                 unwrap!(file.set_len(0));
+                let _ = unwrap!(file.seek(SeekFrom::Start(0)));
                 unwrap!(file.write_all(&raw_data));
                 unwrap!(file.sync_all());
 


### PR DESCRIPTION
We didn't reposition the file cursor after truncating it which lead to DeserialiseExtraBytes error on a mock vault read attempt. Fixes #681.

Also incorporates changes from #682 