### PR TITLE
chore/ci: conditionally create package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,12 +107,20 @@ before_cache:
 before_deploy:
   - bash cargo_install.sh cargo-script 0.2.8
   - mkdir -p target/deploy
-  # Build for mock.
-  - ./scripts/package.rs --lib --name safe_app -d target/deploy --mock
-  - ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --mock
-  # Build for production.
-  - ./scripts/package.rs --lib --name safe_app -d target/deploy
-  - ./scripts/package.rs --lib --name safe_authenticator -d target/deploy
+  - if [[ "$TRAVIS_COMMIT_MESSAGE" =~ [Vv]ersion[[:space:]]change.*safe_authenticator[[:space:]]to[[:space:]]([^;]+) ]]; then
+      ./scripts/package.rs --lib --name safe_app -d target/deploy --mock;
+      ./scripts/package.rs --lib --name safe_app -d target/deploy;
+    else
+      ./scripts/package.rs --lib --name safe_app -d target/deploy --mock --commit;
+      ./scripts/package.rs --lib --name safe_app -d target/deploy --commit;
+    fi
+  - if [[ "$TRAVIS_COMMIT_MESSAGE" =~ [Vv]ersion[[:space:]]change.*safe_app[[:space:]]to[[:space:]]([^;]+) ]]; then
+      ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --mock;
+      ./scripts/package.rs --lib --name safe_authenticator -d target/deploy;
+    else
+      ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --mock --commit;
+      ./scripts/package.rs --lib --name safe_authenticator -d target/deploy --commit;
+    fi
 deploy:
   provider: s3
   access_key_id: AKIAIA2TXTG7EV5VIG2Q


### PR DESCRIPTION
Without checking for the version-based commit message, the package that
gets produced will always have a version number in it. This is the same
condition that gets checked during the `before_script` step, but it's
easier to just check the same condition again, as it's hard to share
information between steps. We don't need the 2nd condition that appears
in `before_script` because the build will have already failed if that's
wrong.