### PR TITLE
test/binary: fix binary compatibility test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
     # Build tests for binary compatibility
     - stage: tests-binary-compat
       script: set -x; scripts/build-binary
-      if: type = push
+      # if: type = push
       os: linux
 
     # Deploy

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -7,7 +7,8 @@ echo "--- Building the binary compatibility test ---" &&
     cargo test --verbose --release --no-run --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml &&
 
     # Find the file to run.
-    TEST_FILE=$(find target/release -maxdepth 1 -type f -perm -111 -name "safe_authenticator-*" | head -1) &&
+    TEST_FILE=$(find target/release -maxdepth 1 -type f -executable -name "safe_authenticator-*" -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ") &&
+    chmod +x "$TEST_FILE" &&
     COMPAT_DIR="${HOME}/.cache/master" &&
     COMPAT_TESTS="$COMPAT_DIR"/tests &&
     mkdir -p "$COMPAT_DIR" &&


### PR DESCRIPTION
The scripts/build-binary script was grabbing the oldest build instead of
the most recent. This commit fixes that with some command-line magic to cache
the binary we just built.