### PR TITLE
Fix Java/JNI bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ffi_utils"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,7 +547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -555,7 +555,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -643,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,7 +666,7 @@ name = "hyper-tls"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1337,7 +1337,7 @@ name = "relay"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1491,8 +1491,8 @@ version = "0.8.0"
 dependencies = [
  "clap 2.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1501,7 +1501,7 @@ dependencies = [
  "routing 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.8.0",
- "safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_bindgen 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.31.0",
  "self_encryption 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1516,7 +1516,7 @@ name = "safe_app_jni"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.8.0",
@@ -1529,8 +1529,8 @@ name = "safe_authenticator"
 version = "0.8.0"
 dependencies = [
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1538,7 +1538,7 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_bindgen 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.31.0",
  "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1552,7 +1552,7 @@ name = "safe_authenticator_jni"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.8.0",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "safe_bindgen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1584,9 +1584,9 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1661,7 +1661,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "brotli 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1899,8 +1899,8 @@ dependencies = [
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.8.0",
  "safe_authenticator 0.8.0",
  "safe_core 0.31.0",
@@ -1947,7 +1947,7 @@ name = "tokio"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +1968,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1978,7 +1978,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1995,7 +1995,7 @@ name = "tokio-current-thread"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2004,7 +2004,7 @@ name = "tokio-executor"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ name = "tokio-fs"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2023,7 +2023,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2033,7 +2033,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2049,7 +2049,7 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2072,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2085,7 +2085,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2095,7 +2095,7 @@ name = "tokio-tls"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2107,7 +2107,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2121,7 +2121,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2302,7 +2302,7 @@ name = "want"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2472,7 +2472,7 @@ dependencies = [
 "checksum extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "054bc2552b3f66fa8097e29e47255bfff583c08e737a67cbbb54b817ddaa5206"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d8098c37c3aa33404700f9097733de3bf28b0393aab28af03b5b179a230b81c"
-"checksum ffi_utils 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4b8aa3108be7585b021457ba43d044bbcd651e9e1a172962518e1ef36628ce1"
+"checksum ffi_utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7661c2339c4c262f5af28935112603fce37a8b9bf179180b3c37cc9af03a86"
 "checksum filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da4b9849e77b13195302c174324b5ba73eec9b236b24c221a61000daefb95c5f"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
@@ -2483,7 +2483,7 @@ dependencies = [
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "884dbe32a6ae4cd7da5c6db9b78114449df9953b8d490c9d7e1b51720b922c62"
+"checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
@@ -2584,7 +2584,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
-"checksum safe_bindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9dc29cb650c4c193e396b9bc0e956faa96aba2af5d349670ba4363f183310ce"
+"checksum safe_bindgen 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "348de6c3b1f99f959b39f2dbb82e2cc2fc90930c20804d65fdc1b3f0c892ae10"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -26,7 +26,7 @@ safe_authenticator = { path = "../safe_authenticator", version = "~0.8.0", optio
 safe_core = { path = "../safe_core", version = "~0.31.0" }
 self_encryption = "~0.13.0"
 tiny-keccak = "~1.3.1"
-tokio-core = "~0.1.12"
+tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
 jni = { version = "~0.10.2", optional = true }
 
@@ -44,11 +44,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.10.0"
+safe_bindgen = "~0.11.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_app/build.rs
+++ b/safe_app/build.rs
@@ -143,6 +143,9 @@ fn gen_bindings_java() {
     let mut bindgen = unwrap!(Bindgen::new());
     let mut lang = LangJava::new(type_map);
 
+    lang.filter("app_registered");
+    lang.filter("app_unregistered");
+
     lang.set_namespace("net.maidsafe.safe_app");
     lang.set_model_namespace("net.maidsafe.safe_app");
 

--- a/safe_app_jni/Cargo.toml
+++ b/safe_app_jni/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = { version = "~0.10.0", features = ["java"] }
+ffi_utils = { version = "~0.11.0", features = ["java"] }
 jni = "~0.10.2"
 log = "~0.4.5"
 safe_core = { path = "../safe_core", version = "~0.31.0" }

--- a/safe_app_jni/src/lib.rs
+++ b/safe_app_jni/src/lib.rs
@@ -141,7 +141,7 @@ pub(crate) unsafe fn find_class<'a>(
     env: &'a JNIEnv,
     class_name: &str,
 ) -> Result<AutoLocal<'a>, JniError> {
-    let cls = env.new_string(class_name)?;
+    let cls = env.auto_local(*env.new_string(class_name)?);
 
     Ok(env.auto_local(From::from(
         env.call_method_unsafe(
@@ -152,7 +152,7 @@ pub(crate) unsafe fn find_class<'a>(
             FIND_CLASS_METHOD
                 .ok_or_else(|| JniError::from("Unexpected - no cached findClass method ID"))?,
             JavaType::from_str("Ljava/lang/Object;")?,
-            &[JValue::from(*cls)],
+            &[JValue::from(cls.as_obj())],
         )?.l()?,
     )))
 }

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 futures = "~0.1.17"
 log = "~0.4.1"
 lru-cache = "~0.1.1"
@@ -24,7 +24,7 @@ safe_core = { path = "../safe_core", version = "~0.31.0" }
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
 tiny-keccak = "~1.3.1"
-tokio-core = "~0.1.12"
+tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
 jni = { version = "~0.10.2", optional = true }
 
@@ -34,11 +34,11 @@ version = "~0.31.0"
 features = ["testing"]
 
 [build-dependencies]
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 jni = "~0.10.1"
 routing = "~0.37.0"
 rust_sodium = "~0.10.0"
-safe_bindgen = "~0.10.0"
+safe_bindgen = "~0.11.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_authenticator/build.rs
+++ b/safe_authenticator/build.rs
@@ -142,6 +142,10 @@ fn gen_bindings_java() {
     let mut bindgen = unwrap!(Bindgen::new());
     let mut lang = LangJava::new(type_map);
 
+    lang.reset_filter(FilterMode::Blacklist);
+    lang.filter("login");
+    lang.filter("create_acc");
+
     lang.set_namespace("net.maidsafe.safe_authenticator");
     lang.set_model_namespace("net.maidsafe.safe_authenticator");
 

--- a/safe_authenticator_jni/Cargo.toml
+++ b/safe_authenticator_jni/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = { version = "~0.10.0", features = ["java"] }
+ffi_utils = { version = "~0.11.0", features = ["java"] }
 jni = "~0.10.2"
 log = "~0.4.5"
 safe_core = { path = "../safe_core", version = "~0.31.0" }

--- a/safe_authenticator_jni/src/lib.rs
+++ b/safe_authenticator_jni/src/lib.rs
@@ -123,7 +123,7 @@ pub(crate) unsafe fn find_class<'a>(
     env: &'a JNIEnv,
     class_name: &str,
 ) -> Result<AutoLocal<'a>, JniError> {
-    let cls = env.new_string(class_name)?;
+    let cls = env.auto_local(*env.new_string(class_name)?);
 
     Ok(env.auto_local(From::from(
         env.call_method_unsafe(
@@ -134,7 +134,7 @@ pub(crate) unsafe fn find_class<'a>(
             FIND_CLASS_METHOD
                 .ok_or_else(|| JniError::from("Unexpected - no cached findClass method ID"))?,
             JavaType::from_str("Ljava/lang/Object;")?,
-            &[JValue::from(*cls)],
+            &[JValue::from(cls.as_obj())],
         )?.l()?,
     )))
 }

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.31.0"
 data-encoding = "~2.1.1"
 chrono = { version = "~0.4.0", features = ["serde"] }
 config_file_handler = "~0.11.0"
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 fs2 = "~0.4.3"
 futures = "~0.1.17"
 lazy_static = "~1.0.0"
@@ -27,7 +27,7 @@ self_encryption = "~0.13.0"
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
 tiny-keccak = "~1.3.1"
-tokio-core = "~0.1.12"
+tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
 
 [dev-dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/maidsafe/safe_client_libs"
 version = "0.1.0"
 
 [dependencies]
-ffi_utils = "~0.10.0"
+ffi_utils = "~0.11.0"
 futures = "~0.1.17"
 serde = "~1.0.24"
 serde_json = "~1.0.2"


### PR DESCRIPTION
1. Fix leaking local references. `env.new_string()` call creates new local references for each string.
We didn't deallocate them properly and now it's fixed by wrapping the returned ref into the `AutoLocal` type.

2. Manually reimplement the disconnect notifier callback because bindgen has no knowledge about the lifetimes of the callback objects, assuming that all of them are one-off calls. Disconnect notifier can be called continuously, so to account for this case we use a bindgen filter to filter out functions that have the disconnect cb.

3. Desktop JNI implementation doesn't need the tricky class loader caching as for Android. For desktop we just redirect the `find_class` calls to use the native JNI library class loading facilities.

4. `ffi_utils` and `safe_bindgen` dependencies have been updated to include the fixes from the new versions.