### PR TITLE
Add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ This will run all unit tests for the crate. We run tests in release mode (indica
 
 When in doubt, perform an integration test against the real network, in addition to mock routing tests above. This will test various network operations, so please make sure you have some available account mutations. The steps:
 
-* You will need a SAFE network account. You can register one from within the [SAFE Browser](https://github.com/maidsafe/safe_browser/releases).
-* Make sure you are able to login to your account via the SAFE Browser.
-* Navigate to the `tests` directory.
-* Open `tests.config` and set your account locator and password. **Do not commit this.** Alternatively, you can set the environment variables `TEST_ACC_LOCATOR` and `TEST_ACC_PASSWORD`.
-* Run `cargo test authorisation_and_revocation --release -- --ignored --nocapture` and make sure that no errors are reported.
+- You will need a SAFE network account. You can register one from within the [SAFE Browser](https://github.com/maidsafe/safe_browser/releases).
+- Make sure you are able to login to your account via the SAFE Browser.
+- Navigate to the `tests` directory.
+- Open `tests.config` and set your account locator and password. **Do not commit this.** Alternatively, you can set the environment variables `TEST_ACC_LOCATOR` and `TEST_ACC_PASSWORD`.
+- Run `cargo test authorisation_and_revocation --release -- --ignored --nocapture` and make sure that no errors are reported.
 
 #### Binary compatibility of data
 
 You may need to test whether your changes affected the binary compatibility of data on the network. This is necessary when updating compression or serialization dependencies to make sure that existing data can still be read using the new versions of the libraries.
 
-* Set your account locator and password as per the instructions above.
-* Run the following command on the **master** branch: `cargo test write_data -- --ignored --nocapture`
-* On the branch with your changes, ensure the following command completes successfully: `cargo test read_data -- --ignored --nocapture`
+- Set your account locator and password as per the instructions above.
+- Run the following command on the **master** branch: `cargo test write_data -- --ignored --nocapture`
+- On the branch with your changes, ensure the following command completes successfully: `cargo test read_data -- --ignored --nocapture`
 
 ### Viewing debug logs
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,66 @@ This is the project workspace. Please refer to individual members for details:
 
 ## Building from Source
 
+### Installing Rust
+
+The Rust compiler is required in order to build Client Libs. Please follow the official [Rust installation instructions](https://www.rust-lang.org/en-US/install.html).
+
+The latest **Stable** version of Rust is required.
+
+If you already have Rust installed, you may need to upgrade to the latest stable:
+
+```
+rustup update stable
+```
+
+### Downloading Client Libs
+
+The Client Libs repository can be downloaded either as a zip archive from the [official repository](https://github.com/maidsafe/safe_client_libs) or by using Git:
+
+```
+git clone https://github.com/maidsafe/safe_client_libs.git
+```
+
+### Building The Libraries
+
+To build one of the libraries, first navigate to its directory: this will be either `safe_core`, `safe_authenticator`, or `safe_app`.
+
+To build the library in debug mode, simply use the command
+
+```
+cargo build --release
+```
+
+This builds the library in release mode, which is how we build our official binaries.
+
+To run tests:
+
+```
+cargo test --release
+```
+
+### Features
+
+Rust supports conditional compilation through a mechanism called features. Features allow us to provide builds with different capabilities. The Client Libs features are:
+
+`use-mock-routing`: This feature enables Mock Routing, a fake routing network that does not make a connection to the live network. This is what we use when running most of our tests. The entire mock network is stored locally in a file named `MockVault`, which gives us the ability to reproduce conditions of any local mock network.
+
+`testing`: This feature enables building with test utilities, which include functions for setting up random test clients. Some test utilities, such as the functions that set up routing hooks, also require the `use-mock-routing` flag to be built.
+
+`bindings`: This feature enables the generation of bindings for C, C# and Java so that the Safe Authenticator and Safe App libraries can be natively called from those languages. This feature is not available for Safe Core.
+
+To build a library with a feature, pass the `--features` flag:
+
+```
+cargo test --features "use-mock-routing"
+```
+
+You can pass multiple features:
+
+```
+cargo build --release --features "use-mock-routing testing"
+```
+
 ### Docker
 
 One option for building the libraries is to use Docker. If you're not familiar with it, the official [getting started guide](https://docs.docker.com/get-started/) is a good general introduction to the concepts and terminology. Docker provides a mechanism to build SCL without having to install anything else in the build environment.


### PR DESCRIPTION
- Also fix a `markdownlint` warning (inconsistent bullet-point style).