### PR TITLE
doc/readme: more explicitly encourage using the --release flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ To run tests:
 cargo test --release
 ```
 
+**Note:** Make sure to always build in release mode (indicated by the `--release` flag). When testing, this will catch rare FFI bugs that may not manifest themselves in debug mode. Debug mode is also unoptimized and can take an inordinate amount of time to run tests or examples.
+
 ### Features
 
 Rust supports conditional compilation through a mechanism called features. Features allow us to provide builds with different capabilities. The Client Libs features are:
@@ -66,7 +68,7 @@ Rust supports conditional compilation through a mechanism called features. Featu
 To build a library with a feature, pass the `--features` flag:
 
 ```
-cargo test --features "use-mock-routing"
+cargo test --release --features "use-mock-routing"
 ```
 
 You can pass multiple features:
@@ -89,13 +91,15 @@ After building the container, you can build the SCL libraries just by running `m
 
 When making changes, please run the appropriate tests, described below, before submitting a PR.
 
+**Note:** We run all tests in release mode (indicated by the `--release` flag). See [Building The Libraries](#building-the-libraries) for more information.
+
 ### Mock routing
 
 If a change is minor or does not involve potential breakage in data or API compatibility, it is not necessary to test against the actual network. In this case, it is enough to run unit tests using mock routing and make sure that they all pass. To do this, you will have to go to the crate you wish to test (e.g. the `safe_core` directory) and execute the following:
 
 `cargo test --release --features=use-mock-routing`
 
-This will run all unit tests for the crate. We run tests in release mode (indicated by the `--release` flag) in order to catch rare FFI bugs that may not manifest themselves in debug mode. Debug mode is also unoptimized and can take an inordinate amount of time to run tests.
+This will run all unit tests for the crate.
 
 ### Real network
 
@@ -105,15 +109,15 @@ When in doubt, perform an integration test against the real network, in addition
 - Make sure you are able to login to your account via the SAFE Browser.
 - Navigate to the `tests` directory.
 - Open `tests.config` and set your account locator and password. **Do not commit this.** Alternatively, you can set the environment variables `TEST_ACC_LOCATOR` and `TEST_ACC_PASSWORD`.
-- Run `cargo test authorisation_and_revocation --release -- --ignored --nocapture` and make sure that no errors are reported.
+- Run `cargo test --release authorisation_and_revocation -- --ignored --nocapture` and make sure that no errors are reported.
 
 #### Binary compatibility of data
 
 You may need to test whether your changes affected the binary compatibility of data on the network. This is necessary when updating compression or serialization dependencies to make sure that existing data can still be read using the new versions of the libraries.
 
 - Set your account locator and password as per the instructions above.
-- Run the following command on the **master** branch: `cargo test write_data -- --ignored --nocapture`
-- On the branch with your changes, ensure the following command completes successfully: `cargo test read_data -- --ignored --nocapture`
+- Run the following command on the **master** branch: `cargo test --release write_data -- --ignored --nocapture`
+- On the branch with your changes, ensure the following command completes successfully: `cargo test --release read_data -- --ignored --nocapture`
 
 ### Viewing debug logs
 

--- a/safe_app/README.md
+++ b/safe_app/README.md
@@ -9,19 +9,7 @@ This is the crate for interfacing with application frontends. It contains code f
 
 `safe_app` can interface conditionally against either the routing crate or a mock (routing and vault) used for local testing.
 
-To use it with the Mock:
-
-```
-cargo build --features "use-mock-routing"
-cargo test --features "use-mock-routing testing"
-```
-
-To interface it with actual routing (default):
-
-```
-cargo build
-cargo test
-```
+Please see [the project README](https://github.com/maidsafe/safe_client_libs#building-from-source) for full build instructions.
 
 ## License
 

--- a/safe_app/README.md
+++ b/safe_app/README.md
@@ -10,12 +10,14 @@ This is the crate for interfacing with application frontends. It contains code f
 `safe_app` can interface conditionally against either the routing crate or a mock (routing and vault) used for local testing.
 
 To use it with the Mock:
+
 ```
 cargo build --features "use-mock-routing"
 cargo test --features "use-mock-routing testing"
 ```
 
 To interface it with actual routing (default):
+
 ```
 cargo build
 cargo test

--- a/safe_authenticator/README.md
+++ b/safe_authenticator/README.md
@@ -3,7 +3,6 @@
 | [![](http://meritbadge.herokuapp.com/safe_authenticator)](https://crates.io/crates/safe_authenticator) | [![Documentation](https://docs.rs/safe_authenticator/badge.svg)](https://docs.rs/safe_authenticator) |
 |:----------:|:----------:|
 
-
 This is the crate for interfacing with `Authenticator` frontend. It contains the business logic for the `Authenticator` UI and code for building the URI for communicating with [safe_app](../safe_app).
 
 ## Build Instructions
@@ -11,12 +10,14 @@ This is the crate for interfacing with `Authenticator` frontend. It contains the
 `safe_authenticator` can interface conditionally against either the routing crate or a mock used for local testing.
 
 To use it with the Mock:
+
 ```
 cargo build --features "use-mock-routing"
 cargo test --features "use-mock-routing"
 ```
 
 To interface it with actual routing (default):
+
 ```
 cargo build
 cargo test

--- a/safe_authenticator/README.md
+++ b/safe_authenticator/README.md
@@ -9,19 +9,7 @@ This is the crate for interfacing with `Authenticator` frontend. It contains the
 
 `safe_authenticator` can interface conditionally against either the routing crate or a mock used for local testing.
 
-To use it with the Mock:
-
-```
-cargo build --features "use-mock-routing"
-cargo test --features "use-mock-routing"
-```
-
-To interface it with actual routing (default):
-
-```
-cargo build
-cargo test
-```
+Please see [the project README](https://github.com/maidsafe/safe_client_libs#building-from-source) for full build instructions.
 
 ## License
 

--- a/safe_core/README.md
+++ b/safe_core/README.md
@@ -7,19 +7,7 @@
 
 `safe_core` can interface conditionally against either the routing crate or a mock used for local testing.
 
-To use it with the Mock:
-
-```
-cargo build --features "use-mock-routing"
-cargo test --features "use-mock-routing"
-```
-
-To interface it with actual routing (default):
-
-```
-cargo build
-cargo test
-```
+Please see [the project README](https://github.com/maidsafe/safe_client_libs#building-from-source) for full build instructions.
 
 ## License
 

--- a/safe_core/README.md
+++ b/safe_core/README.md
@@ -3,18 +3,19 @@
 | [![](http://meritbadge.herokuapp.com/safe_core)](https://crates.io/crates/safe_core) | [![Documentation](https://docs.rs/safe_core/badge.svg)](https://docs.rs/safe_core) |
 |:----------:|:----------:|
 
-
 ## Build Instructions
 
 `safe_core` can interface conditionally against either the routing crate or a mock used for local testing.
 
 To use it with the Mock:
+
 ```
 cargo build --features "use-mock-routing"
 cargo test --features "use-mock-routing"
 ```
 
 To interface it with actual routing (default):
+
 ```
 cargo build
 cargo test


### PR DESCRIPTION
+ Clean up commands in README to consistently use `--release`.
+ Fix some minor markdownlint errors about blank lines.