### PR TITLE
Jenkins Build for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,20 @@ clean:
 
 build:
 	rm -rf artifacts
-ifeq ($(OS),Windows_NT)
-	./scripts/build-real
-else
+ifeq ($(UNAME_S),Linux)
 	./scripts/build-with-container "real" "${SAFE_APP_VERSION}"
+else
+	./scripts/build-real
 endif
 	mkdir artifacts
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
 build-mock:
 	rm -rf artifacts
-ifeq ($(OS),Windows_NT)
-	./scripts/build-mock
-else
+ifeq ($(UNAME_S),Linux)
 	./scripts/build-with-container "mock" "${SAFE_APP_VERSION}"
+else
+	./scripts/build-mock
 endif
 	mkdir artifacts
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/Makefile
+++ b/Makefile
@@ -135,18 +135,26 @@ endif
 	mkdir -p artifacts/linux/mock/release
 	mkdir -p artifacts/win/real/release
 	mkdir -p artifacts/win/mock/release
+	mkdir -p artifacts/osx/real/release
+	mkdir -p artifacts/osx/mock/release
 	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz .
 	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz .
 	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz .
 	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz .
 	tar -C artifacts/linux/real/release -xvf ${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
 	tar -C artifacts/linux/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
 	tar -C artifacts/win/real/release -xvf ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
 	tar -C artifacts/win/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	tar -C artifacts/win/real/release -xvf ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	tar -C artifacts/win/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	rm ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	rm ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
 
 test-artifacts-mock:
 ifeq ($(UNAME_S),Linux)

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,8 @@ endif
 	tar -C artifacts/linux/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
 	tar -C artifacts/win/real/release -xvf ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
 	tar -C artifacts/win/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
-	tar -C artifacts/win/real/release -xvf ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
-	tar -C artifacts/win/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
+	tar -C artifacts/osx/real/release -xvf ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	tar -C artifacts/osx/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
 	rm ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -71,6 +71,12 @@ stage('test') {
             run_tests('mock')
         }
     },
+    mocked_macos: {
+        node('osx') {
+            retrieve_build_artifacts('mock', 'osx')
+            run_tests('mock')
+        }
+    },
     integration_linux: {
         node('docker') {
             retrieve_build_artifacts('mock', 'linux')

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -37,6 +37,24 @@ stage('build') {
             package_build_artifacts('mock', 'windows')
             upload_build_artifacts()
         }
+    },
+    real_osx: {
+        node('osx') {
+            git([url: env.REPO_URL, branch: env.BRANCH])
+            build_safe_client_libs('real')
+            strip_build_artifacts()
+            package_build_artifacts('real', 'osx')
+            upload_build_artifacts()
+        }
+    },
+    mock_osx: {
+        node('osx') {
+            git([url: env.REPO_URL, branch: env.BRANCH])
+            build_safe_client_libs('mock')
+            strip_build_artifacts()
+            package_build_artifacts('mock', 'osx')
+            upload_build_artifacts()
+        }
     }
 }
 

--- a/scripts/package.rs
+++ b/scripts/package.rs
@@ -281,7 +281,9 @@ fn main() {
             } else {
                 find_libs(krate, None, &target_dir)
             };
-            strip_libs(toolchain_path, arch, &arch_libs);
+            if strip {
+                strip_libs(toolchain_path, arch, &arch_libs);
+            }
             libs.extend_from_slice(&arch_libs)
         }
     }


### PR DESCRIPTION
Hi Nikita/Marcin,

This extends the Jenkins build for macOS (Stephen informed me that it's officially macOS now and not OSX :)).

It's very simple this time: it just copies what's already there for Linux and Windows. The bulk of the work was in the infrastructure, which is in the safe-build-infrastructure repo.

Cheers,

Chris