### PR TITLE
Package Artifacts as Tar Archive

### DIFF
--- a/scripts/package.rs
+++ b/scripts/package.rs
@@ -381,7 +381,7 @@ fn package_artifacts_as_tar_gz(
     for path in libs {
         println!("Adding {:?} to {:?}", path, archive_name);
         archive
-            .append_path_with_name(path, Path::new(path).file_name().unwrap().to_str().unwrap())
+            .append_path_with_name(path, path.file_name().unwrap().to_str().unwrap())
             .unwrap();
     }
 }


### PR DESCRIPTION
Hi Nikita/Marcin,

This extends the packaging to produce both a zip and a tar.gz. I haven't added any arguments to control producing either a tar or a zip, assuming it's ok to just produce both. I could add those if you would prefer for it to be more controlled.

Even although this is just a packaging script, I would appreciate if you could advise me on line 384. I need to take the full path of the lib to add to the archive and just grab the filename of it, otherwise in a tar it will add the folders to the archive. I've used path functions in other programming languages, so that part is fine. The issue is the conversion of the path to a string and all the unwrapping. I wasn't sure about that: is there a more concise way to do what I'm trying to do there?

Cheers,

Chris