### PR TITLE
issue 734

### DIFF
--- a/access_container.rs
+++ b/access_container.rs
@@ -1,0 +1,223 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK};
+use futures::Future;
+use safe_core::ffi::ipc::req::ContainerPermissions;
+use safe_core::ffi::MDataInfo;
+use safe_core::ipc::req::containers_into_vec;
+use safe_core::FutureExt;
+use std::os::raw::{c_char, c_void};
+use {App, AppError};
+
+/// Fetch access info from the network.
+#[no_mangle]
+pub unsafe extern "C" fn access_container_refresh_access_info(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |client, context| {
+            context
+                .refresh_access_info(client)
+                .then(move |res| {
+                    call_result_cb!(res, user_data, o_cb);
+                    Ok(())
+                })
+                .into_box()
+                .into()
+        })
+    })
+}
+
+/// Retrieve a list of container names that an app has access to.
+#[no_mangle]
+pub unsafe extern "C" fn access_container_fetch(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        container_perms: *const ContainerPermissions,
+        container_perms_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |client, context| {
+            context
+                .get_access_info(client)
+                .and_then(move |containers| {
+                    let ffi_containers = containers_into_vec(
+                        containers.into_iter().map(|(key, (_, value))| (key, value)),
+                    )?;
+                    o_cb(
+                        user_data.0,
+                        FFI_RESULT_OK,
+                        ffi_containers.as_safe_ptr(),
+                        ffi_containers.len(),
+                    );
+                    Ok(())
+                })
+                .map_err(move |e| {
+                    call_result_cb!(Err::<(), _>(e), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })
+    })
+}
+
+/// Retrieve `MDataInfo` for the given container name from the access container.
+#[no_mangle]
+pub unsafe extern "C" fn access_container_get_container_mdata_info(
+    app: *const App,
+    name: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        mdata_info: *const MDataInfo,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let name = from_c_str(name)?;
+
+        (*app).send(move |client, context| {
+            context
+                .get_access_info(client)
+                .map(move |mut containers| {
+                    if let Some((mdata_info, _)) = containers.remove(&name) {
+                        let mdata_info = mdata_info.into_repr_c();
+                        o_cb(user_data.0, FFI_RESULT_OK, &mdata_info);
+                    } else {
+                        call_result_cb!(
+                            Err::<(), _>(AppError::NoSuchContainer(name)),
+                            user_data,
+                            o_cb
+                        );
+                    }
+                })
+                .map_err(move |err| {
+                    call_result_cb!(Err::<(), _>(err), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use errors::AppError;
+    use ffi::access_container::*;
+    use ffi_utils::test_utils::{call_0, call_1, call_vec};
+    use ffi_utils::{from_c_str, ReprC};
+    use safe_core::ffi::ipc::req::ContainerPermissions as FfiContainerPermissions;
+    use safe_core::ipc::req::ContainerPermissions;
+    use safe_core::ipc::req::{container_perms_from_repr_c, Permission};
+    use safe_core::{MDataInfo, DIR_TAG};
+    use std::collections::HashMap;
+    use std::ffi::CString;
+    use std::rc::Rc;
+    use test_utils::{create_app_by_req, create_auth_req_with_access, run};
+
+    // Test refreshing access info by fetching it from the network.
+    #[test]
+    fn refresh_access_info() {
+        // Shared container
+        let mut container_permissions = HashMap::new();
+        let _ = container_permissions.insert(
+            "_videos".to_string(),
+            btree_set![Permission::Read, Permission::Insert],
+        );
+
+        let app = unwrap!(create_app_by_req(&create_auth_req_with_access(
+            container_permissions.clone()
+        )));
+
+        run(&app, move |_client, context| {
+            let reg = Rc::clone(unwrap!(context.as_registered()));
+            assert!(reg.access_info.borrow().is_empty());
+            Ok(())
+        });
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| access_container_refresh_access_info(
+                &app, ud, cb
+            )))
+        }
+
+        run(&app, move |_client, context| {
+            let reg = Rc::clone(unwrap!(context.as_registered()));
+            assert!(!reg.access_info.borrow().is_empty());
+
+            let access_info = reg.access_info.borrow();
+            assert_eq!(
+                unwrap!(access_info.get("_videos")).1,
+                *unwrap!(container_permissions.get("_videos"))
+            );
+
+            Ok(())
+        });
+    }
+
+    // Test getting info about access containers and their mutable data.
+    #[test]
+    fn get_access_info() {
+        let mut container_permissions = HashMap::new();
+        let _ = container_permissions.insert("_videos".to_string(), btree_set![Permission::Read]);
+        let app = unwrap!(create_app_by_req(&create_auth_req_with_access(
+            container_permissions
+        )));
+
+        // Get access container info
+        let perms: Vec<PermSet> =
+            unsafe { unwrap!(call_vec(|ud, cb| access_container_fetch(&app, ud, cb))) };
+
+        let perms: HashMap<_, _> = perms.into_iter().map(|val| (val.0, val.1)).collect();
+        assert_eq!(perms["_videos"], btree_set![Permission::Read]);
+        assert_eq!(perms.len(), 2);
+
+        // Get MD info
+        let md_info: MDataInfo = {
+            let videos_str = unwrap!(CString::new("_videos"));
+            unsafe {
+                unwrap!(call_1(|ud, cb| access_container_get_container_mdata_info(
+                    &app,
+                    videos_str.as_ptr(),
+                    ud,
+                    cb
+                )))
+            }
+        };
+
+        assert_eq!(md_info.type_tag, DIR_TAG);
+    }
+
+    struct PermSet(String, ContainerPermissions);
+
+    impl ReprC for PermSet {
+        type C = *const FfiContainerPermissions;
+        type Error = AppError;
+
+        unsafe fn clone_from_repr_c(c_repr: Self::C) -> Result<Self, Self::Error> {
+            Ok(PermSet(
+                from_c_str((*c_repr).cont_name)?,
+                container_perms_from_repr_c((*c_repr).access)?,
+            ))
+        }
+    }
+
+}

--- a/apps.rs
+++ b/apps.rs
@@ -1,0 +1,511 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use app_auth::{app_state, AppState};
+use app_container;
+use config;
+use ffi_utils::{
+    catch_unwind_cb, from_c_str, vec_into_raw_parts, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK,
+};
+use futures::Future;
+use maidsafe_utilities::serialisation::deserialise;
+use routing::User::Key;
+use routing::XorName;
+use safe_core::ffi::arrays::XorNameArray;
+use safe_core::ffi::ipc::req::{AppExchangeInfo, ContainerPermissions};
+use safe_core::ffi::ipc::resp::AppAccess;
+use safe_core::ipc::req::containers_into_vec;
+use safe_core::ipc::resp::{AccessContainerEntry, AppAccess as NativeAppAccess};
+use safe_core::ipc::{access_container_enc_key, IpcError};
+use safe_core::utils::symmetric_decrypt;
+use safe_core::{Client, FutureExt};
+use std::collections::HashMap;
+use std::os::raw::{c_char, c_void};
+use AuthError;
+use Authenticator;
+
+/// Application registered in the authenticator
+#[repr(C)]
+pub struct RegisteredApp {
+    /// Unique application identifier
+    pub app_info: AppExchangeInfo,
+    /// List of containers that this application has access to
+    pub containers: *const ContainerPermissions,
+    /// Length of the containers array
+    pub containers_len: usize,
+    /// Capacity of the containers array. Internal data required
+    /// for the Rust allocator.
+    pub containers_cap: usize,
+}
+
+impl Drop for RegisteredApp {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = Vec::from_raw_parts(
+                self.containers as *mut ContainerPermissions,
+                self.containers_len,
+                self.containers_cap,
+            );
+        }
+    }
+}
+
+/// Removes a revoked app from the authenticator config.
+#[no_mangle]
+pub unsafe extern "C" fn auth_rm_revoked_app(
+    auth: *const Authenticator,
+    app_id: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
+        let app_id = from_c_str(app_id)?;
+        let app_id2 = app_id.clone();
+        let app_id3 = app_id.clone();
+
+        (*auth).send(move |client| {
+            let c2 = client.clone();
+            let c3 = client.clone();
+            let c4 = client.clone();
+
+            config::list_apps(client)
+                .and_then(move |(apps_version, apps)| {
+                    app_state(&c2, &apps, &app_id)
+                        .map(move |app_state| (app_state, apps, apps_version))
+                })
+                .and_then(move |(app_state, apps, apps_version)| match app_state {
+                    AppState::Revoked => Ok((apps, apps_version)),
+                    AppState::Authenticated => Err(AuthError::from("App is not revoked")),
+                    AppState::NotAuthenticated => Err(AuthError::IpcError(IpcError::UnknownApp)),
+                })
+                .and_then(move |(apps, apps_version)| {
+                    config::remove_app(&c3, apps, config::next_version(apps_version), &app_id2)
+                })
+                .and_then(move |_| app_container::remove(c4, &app_id3))
+                .then(move |res| {
+                    call_result_cb!(res, user_data, o_cb);
+                    Ok(())
+                })
+                .into_box()
+                .into()
+        })
+    });
+}
+
+/// Get a list of apps revoked from authenticator.
+#[no_mangle]
+pub unsafe extern "C" fn auth_revoked_apps(
+    auth: *const Authenticator,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        app_exchange_info: *const AppExchangeInfo,
+        app_exchange_info_len: usize,
+    ),
+) {
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
+        (*auth).send(move |client| {
+            let c2 = client.clone();
+            let c3 = client.clone();
+
+            config::list_apps(client)
+                .map(move |(_, auth_cfg)| (c2.access_container(), auth_cfg))
+                .and_then(move |(access_container, auth_cfg)| {
+                    c3.list_mdata_entries(access_container.name, access_container.type_tag)
+                        .map_err(From::from)
+                        .map(move |entries| (access_container, entries, auth_cfg))
+                })
+                .and_then(move |(access_container, entries, auth_cfg)| {
+                    let mut apps = Vec::new();
+                    let nonce = access_container.nonce().ok_or_else(|| {
+                        AuthError::from("No nonce on access container's MDataInfo")
+                    })?;
+
+                    for app in auth_cfg.values() {
+                        let key = access_container_enc_key(&app.info.id, &app.keys.enc_key, nonce)?;
+
+                        // If the app is not in the access container, or if the app entry has
+                        // been deleted (is empty), then it's revoked.
+                        let revoked = entries
+                            .get(&key)
+                            .map(|entry| entry.content.is_empty())
+                            .unwrap_or(true);
+
+                        if revoked {
+                            apps.push(app.info.clone().into_repr_c()?);
+                        }
+                    }
+
+                    o_cb(user_data.0, FFI_RESULT_OK, apps.as_safe_ptr(), apps.len());
+
+                    Ok(())
+                })
+                .map_err(move |e| {
+                    call_result_cb!(Err::<(), _>(e), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })?;
+
+        Ok(())
+    })
+}
+
+/// Get a list of apps registered in authenticator.
+#[no_mangle]
+pub unsafe extern "C" fn auth_registered_apps(
+    auth: *const Authenticator,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        registered_app: *const RegisteredApp,
+        registered_app_len: usize,
+    ),
+) {
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
+        (*auth).send(move |client| {
+            let c2 = client.clone();
+            let c3 = client.clone();
+
+            config::list_apps(client)
+                .map(move |(_, auth_cfg)| (c2.access_container(), auth_cfg))
+                .and_then(move |(access_container, auth_cfg)| {
+                    c3.list_mdata_entries(access_container.name, access_container.type_tag)
+                        .map_err(From::from)
+                        .map(move |entries| (access_container, entries, auth_cfg))
+                })
+                .and_then(move |(access_container, entries, auth_cfg)| {
+                    let mut apps = Vec::new();
+
+                    let nonce = access_container.nonce().ok_or_else(|| {
+                        AuthError::from("No nonce on access container's MDataInfo")
+                    })?;
+
+                    for app in auth_cfg.values() {
+                        let key = access_container_enc_key(&app.info.id, &app.keys.enc_key, nonce)?;
+
+                        // Empty entry means it has been deleted.
+                        let entry = match entries.get(&key) {
+                            Some(entry) if !entry.content.is_empty() => Some(entry),
+                            _ => None,
+                        };
+
+                        if let Some(entry) = entry {
+                            let plaintext = symmetric_decrypt(&entry.content, &app.keys.enc_key)?;
+                            let app_access = deserialise::<AccessContainerEntry>(&plaintext)?;
+
+                            let containers = containers_into_vec(
+                                app_access.into_iter().map(|(key, (_, perms))| (key, perms)),
+                            )?;
+
+                            let (containers_ptr, len, cap) = vec_into_raw_parts(containers);
+                            let reg_app = RegisteredApp {
+                                app_info: app.info.clone().into_repr_c()?,
+                                containers: containers_ptr,
+                                containers_len: len,
+                                containers_cap: cap,
+                            };
+
+                            apps.push(reg_app);
+                        }
+                    }
+
+                    o_cb(user_data.0, FFI_RESULT_OK, apps.as_safe_ptr(), apps.len());
+
+                    Ok(())
+                })
+                .map_err(move |e| {
+                    call_result_cb!(Err::<(), _>(e), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })?;
+
+        Ok(())
+    })
+}
+
+/// Return a list of apps having access to an arbitrary MD object.
+/// `md_name` and `md_type_tag` together correspond to a single MD.
+#[no_mangle]
+pub unsafe extern "C" fn auth_apps_accessing_mutable_data(
+    auth: *const Authenticator,
+    md_name: *const XorNameArray,
+    md_type_tag: u64,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        app_access: *const AppAccess,
+        app_access_len: usize,
+    ),
+) {
+    let user_data = OpaqueCtx(user_data);
+    let name = XorName(*md_name);
+
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_, AuthError> {
+        (*auth).send(move |client| {
+            let c2 = client.clone();
+
+            client
+                .list_mdata_permissions(name, md_type_tag)
+                .map_err(AuthError::from)
+                .join(
+                    // Fetch a list of registered apps in parallel
+                    config::list_apps(&c2).map(|(_, apps)| {
+                        // Convert the HashMap keyed by id to one keyed by public key
+                        apps.into_iter()
+                            .map(|(_, app_info)| (app_info.keys.sign_pk, app_info.info))
+                            .collect::<HashMap<_, _>>()
+                    }),
+                )
+                .and_then(move |(permissions, apps)| {
+                    // Map the list of keys retrieved from MD to a list of registered apps (even if
+                    // they're in the Revoked state) and create a new `AppAccess` struct object
+                    let mut app_access_vec: Vec<AppAccess> = Vec::new();
+
+                    for (user, perm_set) in permissions {
+                        if let Key(public_key) = user {
+                            let app_access = match apps.get(&public_key) {
+                                Some(app_info) => NativeAppAccess {
+                                    sign_key: public_key,
+                                    permissions: perm_set,
+                                    name: Some(app_info.name.clone()),
+                                    app_id: Some(app_info.id.clone()),
+                                },
+                                None => {
+                                    // If an app is listed in the MD permissions list, but is not
+                                    // listed in the registered apps list in Authenticator, then set
+                                    // the app_id and app_name fields to ptr::null(), but provide
+                                    // the public sign key and the list of permissions.
+                                    NativeAppAccess {
+                                        sign_key: public_key,
+                                        permissions: perm_set,
+                                        name: None,
+                                        app_id: None,
+                                    }
+                                }
+                            };
+                            app_access_vec.push(app_access.into_repr_c()?);
+                        }
+                    }
+
+                    o_cb(
+                        user_data.0,
+                        FFI_RESULT_OK,
+                        app_access_vec.as_safe_ptr(),
+                        app_access_vec.len(),
+                    );
+
+                    Ok(())
+                })
+                .map_err(move |e| {
+                    call_result_cb!(Err::<(), _>(e), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })?;
+
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app_container::fetch;
+    use config;
+    use errors::{ERR_UNEXPECTED, ERR_UNKNOWN_APP};
+    use ffi_utils::test_utils::call_0;
+    use revocation::revoke_app;
+    use safe_core::ipc::AuthReq;
+    use test_utils::{
+        create_account_and_login, create_file, fetch_file, get_app_or_err, rand_app, register_app,
+        run,
+    };
+
+    // Negative test - non-existing app:
+    // 1. Try to call `auth_rm_revoked_app` with a random, non-existing app_id
+    // 2. Verify that `IpcError::UnknownApp` is returned
+    #[test]
+    fn rm_revoked_nonexisting() {
+        let auth = create_account_and_login();
+        let app_info = rand_app();
+        let app_info_ffi = unwrap!(app_info.into_repr_c());
+
+        let result =
+            unsafe { call_0(|ud, cb| auth_rm_revoked_app(&auth, app_info_ffi.id, ud, cb)) };
+
+        match result {
+            Err(ERR_UNKNOWN_APP) => (),
+            Err(x) => panic!("Unexpected {:?}", x),
+            Ok(()) => panic!("Unexpected successful removal of non-existing app"),
+        };
+    }
+
+    // Negative test - authorised app:
+    // 1. Authorise a new app A
+    // 2. Try to call `auth_rm_revoked_app` with an app id corresponding to the app A
+    // 3. Verify that an error is returned (app is not revoked)
+    // 4. Verify that `app_state` for the app A is still `AppState::Authenticated`
+    #[test]
+    fn rm_revoked_authorised() {
+        let auth = create_account_and_login();
+        let app_info = rand_app();
+        let app_id = app_info.id.clone();
+
+        let _ = unwrap!(register_app(
+            &auth,
+            &AuthReq {
+                app: app_info.clone(),
+                app_container: false,
+                containers: HashMap::new(),
+            },
+        ));
+
+        let app_info_ffi = unwrap!(app_info.into_repr_c());
+        let result =
+            unsafe { call_0(|ud, cb| auth_rm_revoked_app(&auth, app_info_ffi.id, ud, cb)) };
+
+        match result {
+            Err(ERR_UNEXPECTED) => (),
+            Err(x) => panic!("Unexpected {:?}", x),
+            Ok(()) => panic!("Unexpected successful removal of non-existing app"),
+        };
+
+        // Verify that the app is still authenticated
+        run(&auth, |client| {
+            let c2 = client.clone();
+
+            config::list_apps(client)
+                .and_then(move |(_, apps)| app_state(&c2, &apps, &app_id))
+                .and_then(move |res| match res {
+                    AppState::Authenticated => Ok(()),
+                    _ => panic!("App state changed after failed revocation"),
+                })
+        });
+    }
+
+    // Test complete app removal
+    // 1. Authorise a new app A with `app_container` set to `true`.
+    // 2. Put a file with predefined content into app A's own container.
+    // 3. Revoke app A
+    // 4. Verify that app A is still listed in the authenticator config.
+    // 5. Verify that the app A container is still accessible.
+    // 6. Call `auth_rm_revoked_app` with an app id corresponding to app A.
+    // The operation should succeed.
+    // 7. Verify that the app A is not listed anywhere in the authenticator config.
+    // 8. Verify that the app A's container entry corresponding to the file created
+    // at the step 2 is emptied out/removed.
+    // 9. Try to authorise app A again as app A2 (app_container set to `true`)
+    // 10. Verify that the app A2 is listed in the authenticator config.
+    // 11. Verify that the app A2 keys are different from the set of the app A keys
+    // (i.e. the app keys should have been regenerated rather than reused).
+    // 12. Verify that the app A2 container does not contain the file created at step 2.
+    #[test]
+    fn rm_revoked_complete() {
+        let auth = create_account_and_login();
+        let app_info = rand_app();
+        let app_id = app_info.id.clone();
+        let app_id2 = app_id.clone();
+        let app_id3 = app_id.clone();
+        let app_id4 = app_id.clone();
+        let app_id5 = app_id.clone();
+
+        // Authorise app A with `app_container` set to `true`.
+        let auth_granted1 = unwrap!(register_app(
+            &auth,
+            &AuthReq {
+                app: app_info.clone(),
+                app_container: true,
+                containers: HashMap::new(),
+            },
+        ));
+
+        // Put a file with predefined content into app A's own container.
+        let mdata_info = unwrap!({ run(&auth, move |client| fetch(client, &app_id3)) });
+        unwrap!(create_file(&auth, mdata_info.clone(), "test", vec![1; 10]));
+
+        // Revoke app A
+        {
+            run(&auth, move |client| revoke_app(client, &app_id2))
+        }
+
+        // Verify that app A is still listed in the authenticator config.
+        assert!(get_app_or_err(&auth, &app_id).is_ok());
+
+        // Verify that the app A container is still accessible.
+        {
+            run(&auth, move |client| {
+                fetch(client, &app_id4).and_then(move |res| match res {
+                    Some(_) => Ok(()),
+                    None => panic!("App container not accessible"),
+                })
+            })
+        }
+
+        // Call `auth_rm_revoked_app` with an app id corresponding to app A.
+        let app_info_ffi = unwrap!(app_info.clone().into_repr_c());
+        unsafe {
+            unwrap!(call_0(|ud, cb| auth_rm_revoked_app(
+                &auth,
+                app_info_ffi.id,
+                ud,
+                cb
+            )))
+        };
+        // Verify that the app A is not listed anywhere in the authenticator config.
+        let res = get_app_or_err(&auth, &app_id);
+        match res {
+            Err(AuthError::IpcError(IpcError::UnknownApp)) => (),
+            Err(x) => panic!("Unexpected {:?}", x),
+            Ok(_) => panic!("App still listed in the authenticator config"),
+        };
+
+        // Verify that the app A's container entry corresponding to the file created
+        // at step 2 is emptied out/removed.
+        let res = fetch_file(&auth, mdata_info, "test");
+        match res {
+            Err(_) => (),
+            Ok(_) => panic!("File not removed"),
+        }
+
+        // Try to authorise app A again as app A2 (app_container set to `true`)
+        let auth_granted2 = unwrap!(register_app(
+            &auth,
+            &AuthReq {
+                app: app_info,
+                app_container: true,
+                containers: HashMap::new(),
+            },
+        ));
+
+        // Verify that the app A2 is listed in the authenticator config.
+        assert!(get_app_or_err(&auth, &app_id).is_ok());
+
+        // Verify that the app A2 keys are different from the set of the app A keys
+        // (i.e. the app keys should have been regenerated rather than reused).
+        assert_ne!(auth_granted1.app_keys, auth_granted2.app_keys);
+
+        // Verify that the app A2 container does not contain the file created at step 2.
+        let mdata_info = unwrap!({ run(&auth, move |client| fetch(client, &app_id5)) });
+        let res = fetch_file(&auth, mdata_info, "test");
+        match res {
+            Err(_) => (),
+            Ok(_) => panic!("File not removed"),
+        }
+    }
+}

--- a/crypto.rs
+++ b/crypto.rs
@@ -1,0 +1,1120 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use errors::AppError;
+use ffi::helper::send_sync;
+use ffi::object_cache::{
+    EncryptPubKeyHandle, EncryptSecKeyHandle, SignPubKeyHandle, SignSecKeyHandle,
+    NULL_OBJECT_HANDLE,
+};
+use ffi_utils::{
+    catch_unwind_cb, vec_clone_from_raw_parts, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK,
+};
+use maidsafe_utilities::serialisation::{deserialise, serialise};
+use rust_sodium::crypto::{box_, sealedbox, sign};
+use safe_core::crypto::{shared_box, shared_sign};
+use safe_core::ffi::arrays::{
+    AsymNonce, AsymPublicKey, AsymSecretKey, SignPublicKey, SignSecretKey,
+};
+use safe_core::Client;
+use std::os::raw::c_void;
+use std::slice;
+use tiny_keccak::sha3_256;
+use App;
+
+/// Special value that represents that a message should be signed by the app.
+#[no_mangle]
+pub static SIGN_WITH_APP: SignSecKeyHandle = NULL_OBJECT_HANDLE;
+
+/// Get the public signing key of the app.
+#[no_mangle]
+pub unsafe extern "C" fn app_pub_sign_key(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, handle: SignPubKeyHandle),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |client, context| {
+            let key = client
+                .public_signing_key()
+                .ok_or(AppError::UnregisteredClientAccess)?;
+            Ok(context.object_cache().insert_pub_sign_key(key))
+        })
+    })
+}
+
+/// Generate a new sign key pair (public & private key).
+#[no_mangle]
+pub unsafe extern "C" fn sign_generate_key_pair(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        public_key_h: SignPubKeyHandle,
+        secret_key_h: SignSecKeyHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let (ourpk, oursk) = shared_sign::gen_keypair();
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_, context| {
+            let pk_h = context.object_cache().insert_pub_sign_key(ourpk);
+            let sk_h = context.object_cache().insert_sec_sign_key(oursk);
+
+            o_cb(user_data.0, FFI_RESULT_OK, pk_h, sk_h);
+
+            None
+        })
+    })
+}
+
+/// Create new public signing key from raw array.
+#[no_mangle]
+pub unsafe extern "C" fn sign_pub_key_new(
+    app: *const App,
+    data: *const SignPublicKey,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, handle: SignPubKeyHandle),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let key = sign::PublicKey(*data);
+        send_sync(app, user_data, o_cb, move |_, context| {
+            Ok(context.object_cache().insert_pub_sign_key(key))
+        })
+    })
+}
+
+/// Retrieve the public signing key as a raw array.
+#[no_mangle]
+pub unsafe extern "C" fn sign_pub_key_get(
+    app: *const App,
+    handle: SignPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        pub_sign_key: *const SignPublicKey,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let key = context.object_cache().get_pub_sign_key(handle)?;
+            Ok(&key.0)
+        })
+    })
+}
+
+/// Free public signing key from memory.
+#[no_mangle]
+pub unsafe extern "C" fn sign_pub_key_free(
+    app: *const App,
+    handle: SignPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let _ = context.object_cache().remove_pub_sign_key(handle)?;
+            Ok(())
+        })
+    })
+}
+
+/// Create new secret signing key from raw array.
+#[no_mangle]
+pub unsafe extern "C" fn sign_sec_key_new(
+    app: *const App,
+    data: *const SignSecretKey,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, handle: SignSecKeyHandle),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let key = shared_sign::SecretKey::from_raw(&*data);
+        send_sync(app, user_data, o_cb, move |_, context| {
+            Ok(context.object_cache().insert_sec_sign_key(key))
+        })
+    })
+}
+
+/// Retrieve the secret signing key as a raw array.
+#[no_mangle]
+pub unsafe extern "C" fn sign_sec_key_get(
+    app: *const App,
+    handle: SignSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        pub_sign_key: *const SignSecretKey,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let key = context.object_cache().get_sec_sign_key(handle)?;
+            Ok(&key.0)
+        })
+    })
+}
+
+/// Free secret signing key from memory.
+#[no_mangle]
+pub unsafe extern "C" fn sign_sec_key_free(
+    app: *const App,
+    handle: SignSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let _ = context.object_cache().remove_sec_sign_key(handle)?;
+            Ok(())
+        })
+    })
+}
+
+/// Get the public encryption key of the app.
+#[no_mangle]
+pub unsafe extern "C" fn app_pub_enc_key(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        public_key_h: EncryptPubKeyHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |client, context| {
+            let key = client
+                .public_encryption_key()
+                .ok_or(AppError::UnregisteredClientAccess)?;
+            Ok(context.object_cache().insert_encrypt_key(key))
+        })
+    })
+}
+
+/// Generate a new encryption key pair (public & private key).
+#[no_mangle]
+pub unsafe extern "C" fn enc_generate_key_pair(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        public_key_h: EncryptPubKeyHandle,
+        secret_key_h: EncryptSecKeyHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let (ourpk, oursk) = shared_box::gen_keypair();
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_, context| {
+            let pk_h = context.object_cache().insert_encrypt_key(ourpk);
+            let sk_h = context.object_cache().insert_secret_key(oursk);
+
+            o_cb(user_data.0, FFI_RESULT_OK, pk_h, sk_h);
+
+            None
+        })
+    })
+}
+
+/// Create new public encryption key from raw array.
+#[no_mangle]
+pub unsafe extern "C" fn enc_pub_key_new(
+    app: *const App,
+    data: *const AsymPublicKey,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        public_key_h: EncryptPubKeyHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let key = box_::PublicKey(*data);
+        send_sync(app, user_data, o_cb, move |_, context| {
+            Ok(context.object_cache().insert_encrypt_key(key))
+        })
+    })
+}
+
+/// Retrieve the public encryption key as a raw array.
+#[no_mangle]
+pub unsafe extern "C" fn enc_pub_key_get(
+    app: *const App,
+    handle: EncryptPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        pub_enc_key: *const AsymPublicKey,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let key = context.object_cache().get_encrypt_key(handle)?;
+            Ok(&key.0)
+        })
+    })
+}
+
+/// Free encryption key from memory.
+#[no_mangle]
+pub unsafe extern "C" fn enc_pub_key_free(
+    app: *const App,
+    handle: EncryptPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let _ = context.object_cache().remove_encrypt_key(handle)?;
+            Ok(())
+        })
+    })
+}
+
+/// Create new private encryption key from raw array.
+#[no_mangle]
+pub unsafe extern "C" fn enc_secret_key_new(
+    app: *const App,
+    data: *const AsymSecretKey,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        sk_h: EncryptSecKeyHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let key = shared_box::SecretKey::from_raw(&*data);
+        send_sync(app, user_data, o_cb, move |_, context| {
+            Ok(context.object_cache().insert_secret_key(key))
+        })
+    })
+}
+
+/// Retrieve the private encryption key as a raw array.
+#[no_mangle]
+pub unsafe extern "C" fn enc_secret_key_get(
+    app: *const App,
+    handle: EncryptSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        sec_enc_key: *const AsymSecretKey,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let key = context.object_cache().get_secret_key(handle)?;
+            Ok(&key.0)
+        })
+    })
+}
+
+/// Free private key from memory.
+#[no_mangle]
+pub unsafe extern "C" fn enc_secret_key_free(
+    app: *const App,
+    handle: EncryptSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let _ = context.object_cache().remove_secret_key(handle)?;
+            Ok(())
+        })
+    })
+}
+
+/// Signs arbitrary data using a given secret sign key.
+///
+/// If `sign_sk_h` is `SIGN_WITH_APP`, then uses the app's own secret key to sign.
+#[no_mangle]
+pub unsafe extern "C" fn sign(
+    app: *const App,
+    data: *const u8,
+    data_len: usize,
+    sign_sk_h: SignSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        signed_data: *const u8,
+        signed_data_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let plaintext = vec_clone_from_raw_parts(data, data_len);
+
+        (*app).send(move |client, context| {
+            let sign_sk = if sign_sk_h == SIGN_WITH_APP {
+                try_cb!(
+                    client
+                        .secret_signing_key()
+                        .ok_or_else(|| AppError::Unexpected(
+                            "Secret signing key not found".to_string()
+                        )),
+                    user_data,
+                    o_cb
+                )
+            } else {
+                let sign_sk = try_cb!(
+                    context.object_cache().get_sec_sign_key(sign_sk_h),
+                    user_data,
+                    o_cb
+                );
+                sign_sk.clone()
+            };
+
+            let signed_text = sign::sign(&plaintext, &sign_sk);
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                signed_text.as_safe_ptr(),
+                signed_text.len(),
+            );
+
+            None
+        })
+    })
+}
+
+/// Verifies signed data using a given public sign key.
+/// Returns an error if the message could not be verified.
+#[no_mangle]
+pub unsafe extern "C" fn verify(
+    app: *const App,
+    signed_data: *const u8,
+    signed_data_len: usize,
+    sign_pk_h: SignPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        verified_data: *const u8,
+        verified_data_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let signed = vec_clone_from_raw_parts(signed_data, signed_data_len);
+
+        (*app).send(move |_, context| {
+            let sign_pk = try_cb!(
+                context.object_cache().get_pub_sign_key(sign_pk_h),
+                user_data,
+                o_cb
+            );
+
+            let verified = try_cb!(
+                sign::verify(&signed, &sign_pk).map_err(|()| AppError::EncodeDecodeError),
+                user_data,
+                o_cb
+            );
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                verified.as_safe_ptr(),
+                verified.len(),
+            );
+
+            None
+        })
+    })
+}
+
+/// Encrypts arbitrary data using a given key pair.
+/// You should provide a recipient's public key and a sender's secret key.
+#[no_mangle]
+pub unsafe extern "C" fn encrypt(
+    app: *const App,
+    data: *const u8,
+    data_len: usize,
+    public_key_h: EncryptPubKeyHandle,
+    secret_key_h: EncryptSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        ciphertext: *const u8,
+        ciphertext_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let plaintext = vec_clone_from_raw_parts(data, data_len);
+
+        (*app).send(move |_, context| {
+            let pk = try_cb!(
+                context.object_cache().get_encrypt_key(public_key_h),
+                user_data,
+                o_cb
+            );
+            let sk = try_cb!(
+                context.object_cache().get_secret_key(secret_key_h),
+                user_data,
+                o_cb
+            );
+
+            let nonce = box_::gen_nonce();
+
+            let ciphertext = box_::seal(&plaintext, &nonce, &pk, &sk);
+
+            match serialise(&(nonce, ciphertext)) {
+                Ok(result) => o_cb(user_data.0, FFI_RESULT_OK, result.as_ptr(), result.len()),
+                res @ Err(..) => {
+                    call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                }
+            }
+
+            None
+        })
+    })
+}
+
+/// Decrypts arbitrary data using a given key pair.
+/// You should provide a sender's public key and a recipient's secret key.
+#[no_mangle]
+pub unsafe extern "C" fn decrypt(
+    app: *const App,
+    data: *const u8,
+    data_len: usize,
+    public_key_h: EncryptPubKeyHandle,
+    secret_key_h: EncryptSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        plaintext: *const u8,
+        plaintext_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let encrypted_text = vec_clone_from_raw_parts(data, data_len);
+
+        (*app).send(move |_, context| {
+            let pk = try_cb!(
+                context.object_cache().get_encrypt_key(public_key_h),
+                user_data,
+                o_cb
+            );
+            let sk = try_cb!(
+                context.object_cache().get_secret_key(secret_key_h),
+                user_data,
+                o_cb
+            );
+
+            match deserialise::<(box_::Nonce, Vec<u8>)>(&encrypted_text) {
+                Ok((nonce, ciphertext)) => {
+                    let plaintext = try_cb!(
+                        box_::open(&ciphertext, &nonce, &pk, &sk)
+                            .map_err(|()| AppError::EncodeDecodeError),
+                        user_data,
+                        o_cb
+                    );
+                    o_cb(
+                        user_data.0,
+                        FFI_RESULT_OK,
+                        plaintext.as_ptr(),
+                        plaintext.len(),
+                    );
+                }
+                res @ Err(..) => {
+                    call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                }
+            }
+
+            None
+        })
+    })
+}
+
+/// Encrypts arbitrary data for a single recipient.
+/// You should provide a recipient's public key.
+#[no_mangle]
+pub unsafe extern "C" fn encrypt_sealed_box(
+    app: *const App,
+    data: *const u8,
+    data_len: usize,
+    public_key_h: EncryptPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        ciphertext: *const u8,
+        ciphertext_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let plaintext = vec_clone_from_raw_parts(data, data_len);
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_, context| {
+            let pk = *try_cb!(
+                context.object_cache().get_encrypt_key(public_key_h),
+                user_data,
+                o_cb
+            );
+
+            let ciphertext = sealedbox::seal(&plaintext, &pk);
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                ciphertext.as_ptr(),
+                ciphertext.len(),
+            );
+
+            None
+        })
+    })
+}
+
+/// Decrypts arbitrary data for a single recipient.
+/// You should provide a recipients's private and public key.
+#[no_mangle]
+pub unsafe extern "C" fn decrypt_sealed_box(
+    app: *const App,
+    data: *const u8,
+    data_len: usize,
+    public_key_h: EncryptPubKeyHandle,
+    secret_key_h: EncryptSecKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        plaintext: *const u8,
+        plaintext_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let plaintext = vec_clone_from_raw_parts(data, data_len);
+
+        (*app).send(move |_, context| {
+            let pk = try_cb!(
+                context.object_cache().get_encrypt_key(public_key_h),
+                user_data,
+                o_cb
+            );
+            let sk = try_cb!(
+                context.object_cache().get_secret_key(secret_key_h),
+                user_data,
+                o_cb
+            );
+
+            let plaintext = try_cb!(
+                sealedbox::open(&plaintext, &pk, &sk).map_err(|()| AppError::EncodeDecodeError),
+                user_data,
+                o_cb
+            );
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                plaintext.as_ptr(),
+                plaintext.len(),
+            );
+
+            None
+        })
+    })
+}
+
+/// Returns a sha3 hash for a given data.
+#[no_mangle]
+pub unsafe extern "C" fn sha3_hash(
+    data: *const u8,
+    data_len: usize,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        hash: *const u8,
+        hash_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let plaintext = slice::from_raw_parts(data, data_len);
+
+        let hash = sha3_256(plaintext);
+        o_cb(user_data, FFI_RESULT_OK, hash.as_ptr(), hash.len());
+
+        Ok(())
+    });
+}
+
+/// Generates a unique nonce and returns the result.
+#[no_mangle]
+pub unsafe extern "C" fn generate_nonce(
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, nonce: *const AsymNonce),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let nonce = box_::gen_nonce();
+        o_cb(user_data, FFI_RESULT_OK, &nonce.0);
+
+        Ok(())
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use errors::ERR_INVALID_SIGN_PUB_KEY_HANDLE;
+    use ffi::mutable_data::permissions::USER_ANYONE;
+    use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8};
+    use rust_sodium::crypto::box_;
+    use safe_core::arrays::{AsymNonce, AsymPublicKey, SignPublicKey, SignSecretKey};
+    use test_utils::{create_app, run_now};
+
+    // Test signing and verifying messages between apps.
+    #[test]
+    fn sign_verify() {
+        let app1 = create_app();
+        let app2 = create_app();
+
+        let (app1_pk_h, app1_sk_h): (SignPubKeyHandle, SignSecKeyHandle) =
+            unsafe { unwrap!(call_2(|ud, cb| sign_generate_key_pair(&app1, ud, cb))) };
+
+        // Copying app1 pubkey to app2 object cache
+        let pk_raw: SignPublicKey =
+            unsafe { unwrap!(call_1(|ud, cb| sign_pub_key_get(&app1, app1_pk_h, ud, cb))) };
+
+        let app2_pk_h: SignPubKeyHandle =
+            unsafe { unwrap!(call_1(|ud, cb| sign_pub_key_new(&app2, &pk_raw, ud, cb))) };
+
+        // Trying to sign a message from app1
+        let data = b"hi there";
+        let signed = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| sign(
+                &app1,
+                data.as_ptr(),
+                data.len(),
+                app1_sk_h,
+                ud,
+                cb
+            )))
+        };
+
+        // Trying to verify the message in app2
+        let verified = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| verify(
+                &app2,
+                signed.as_ptr(),
+                signed.len(),
+                app2_pk_h,
+                ud,
+                cb
+            )))
+        };
+
+        assert_eq!(&verified, data);
+
+        // Trying to sign a message from app1 using its secret sign key
+        let signed = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| sign(
+                &app1,
+                data.as_ptr(),
+                data.len(),
+                SIGN_WITH_APP,
+                ud,
+                cb
+            )))
+        };
+
+        // Trying to verify the message in app2
+        let app1_pk_h = unsafe { unwrap!(call_1(|ud, cb| app_pub_sign_key(&app1, ud, cb))) };
+        // Copying app1 pubkey to app2 object cache
+        let pk_raw: AsymPublicKey =
+            unsafe { unwrap!(call_1(|ud, cb| sign_pub_key_get(&app1, app1_pk_h, ud, cb))) };
+
+        let app2_pk2_h =
+            unsafe { unwrap!(call_1(|ud, cb| sign_pub_key_new(&app2, &pk_raw, ud, cb))) };
+        let verified = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| verify(
+                &app2,
+                signed.as_ptr(),
+                signed.len(),
+                app2_pk2_h,
+                ud,
+                cb
+            )))
+        };
+
+        assert_eq!(&verified, data);
+    }
+
+    // Test encrypting and decrypting messages between apps.
+    #[test]
+    fn encrypt_decrypt() {
+        let app1 = create_app();
+        let app2 = create_app();
+
+        let (app1_pk1_h, app1_sk1_h): (EncryptPubKeyHandle, EncryptSecKeyHandle) =
+            unsafe { unwrap!(call_2(|ud, cb| enc_generate_key_pair(&app1, ud, cb))) };
+        let (app2_pk2_h, app2_sk2_h): (EncryptPubKeyHandle, EncryptSecKeyHandle) =
+            unsafe { unwrap!(call_2(|ud, cb| enc_generate_key_pair(&app2, ud, cb))) };
+
+        // Copying app2 pubkey to app1 object cache
+        // and app1 pubkey to app2 object cache
+        let pk2_raw: AsymPublicKey =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
+        let pk1_raw: AsymPublicKey =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app1, app1_pk1_h, ud, cb))) };
+
+        let app1_pk2_h =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_new(&app1, &pk2_raw, ud, cb))) };
+        let app2_pk1_h =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_new(&app2, &pk1_raw, ud, cb))) };
+
+        // Trying to encrypt a message for app2 from app1
+        let data = b"hi there";
+        let encrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| encrypt(
+                &app1,
+                data.as_ptr(),
+                data.len(),
+                app1_pk2_h,
+                app1_sk1_h,
+                ud,
+                cb,
+            )))
+        };
+
+        // Trying to decrypt the message in app2
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| decrypt(
+                &app2,
+                encrypted.as_ptr(),
+                encrypted.len(),
+                app2_pk1_h,
+                app2_sk2_h,
+                ud,
+                cb,
+            )))
+        };
+
+        assert_eq!(&decrypted, data);
+    }
+
+    // Test encrypting and decrypting sealed box messages between apps.
+    #[test]
+    fn encrypt_decrypt_sealed() {
+        let app1 = create_app();
+        let app2 = create_app();
+
+        let (app2_pk2_h, app2_sk2_h): (EncryptPubKeyHandle, EncryptSecKeyHandle) =
+            unsafe { unwrap!(call_2(|ud, cb| enc_generate_key_pair(&app2, ud, cb))) };
+
+        // Copying app2 pubkey to app1 object cache
+        // and app1 pubkey to app2 object cache
+        let pk2_raw: AsymPublicKey =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_get(&app2, app2_pk2_h, ud, cb))) };
+
+        let app1_pk2_h =
+            unsafe { unwrap!(call_1(|ud, cb| enc_pub_key_new(&app1, &pk2_raw, ud, cb))) };
+
+        // Trying to encrypt a message for app2 from app1
+        let data = b"sealed box message";
+        let encrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| encrypt_sealed_box(
+                &app1,
+                data.as_ptr(),
+                data.len(),
+                app1_pk2_h,
+                ud,
+                cb
+            )))
+        };
+
+        // Trying to decrypt the message in app2
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| decrypt_sealed_box(
+                &app2,
+                encrypted.as_ptr(),
+                encrypted.len(),
+                app2_pk2_h,
+                app2_sk2_h,
+                ud,
+                cb,
+            )))
+        };
+
+        assert_eq!(&decrypted, data);
+    }
+
+    // Test creating and fetching public sign keys.
+    #[test]
+    fn sign_public_key_basics() {
+        let app = create_app();
+        let app_sign_key1_h = unsafe { unwrap!(call_1(|ud, cb| app_pub_sign_key(&app, ud, cb))) };
+
+        let app_sign_key1 = run_now(&app, move |client, context| {
+            let app_sign_key1 = unwrap!(client.public_signing_key());
+            let app_sign_key2 = unwrap!(context.object_cache().get_pub_sign_key(app_sign_key1_h));
+            assert_eq!(app_sign_key1, *app_sign_key2);
+
+            app_sign_key1
+        });
+
+        let app_sign_key1_raw: SignPublicKey = unsafe {
+            unwrap!(call_1(|ud, cb| sign_pub_key_get(
+                &app,
+                app_sign_key1_h,
+                ud,
+                cb
+            )))
+        };
+
+        let app_sign_key2_h = unsafe {
+            unwrap!(call_1(|ud, cb| sign_pub_key_new(
+                &app,
+                &app_sign_key1_raw,
+                ud,
+                cb
+            )))
+        };
+
+        let app_sign_key2 = run_now(&app, move |_, context| {
+            *unwrap!(context.object_cache().get_pub_sign_key(app_sign_key2_h))
+        });
+
+        assert_eq!(app_sign_key1, app_sign_key2);
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| sign_pub_key_free(
+                &app,
+                app_sign_key2_h,
+                ud,
+                cb
+            )))
+        }
+
+        // Test that calling `sign_pub_key_get` on `USER_ANYONE` returns an error.
+        let user: Result<SignPublicKey, i32> =
+            unsafe { call_1(|ud, cb| sign_pub_key_get(&app, USER_ANYONE, ud, cb)) };
+        match user {
+            Err(ERR_INVALID_SIGN_PUB_KEY_HANDLE) => (),
+            Err(_) => panic!("Unexpected error"),
+            Ok(_) => panic!("Unexpected success"),
+        }
+    }
+
+    // Test creating and fetching private sign keys.
+    #[test]
+    fn sign_secret_key_basics() {
+        let app = create_app();
+
+        let app_sign_key1 = run_now(&app, move |client, _| {
+            let app_sign_key1 = unwrap!(client.secret_signing_key());
+
+            app_sign_key1
+        });
+
+        let app_sign_key1_h = unsafe {
+            unwrap!(call_1(|ud, cb| sign_sec_key_new(
+                &app,
+                &app_sign_key1.0,
+                ud,
+                cb
+            )))
+        };
+
+        let app_sign_key1_raw: SignSecretKey = unsafe {
+            unwrap!(call_1(|ud, cb| sign_sec_key_get(
+                &app,
+                app_sign_key1_h,
+                ud,
+                cb
+            )))
+        };
+
+        let app_sign_key2_h = unsafe {
+            unwrap!(call_1(|ud, cb| sign_sec_key_new(
+                &app,
+                &app_sign_key1_raw,
+                ud,
+                cb
+            )))
+        };
+
+        run_now(&app, move |_, context| {
+            let sign_key = unwrap!(context.object_cache().get_sec_sign_key(app_sign_key2_h));
+            assert_eq!(*app_sign_key1, *sign_key.clone());
+        });
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| sign_sec_key_free(
+                &app,
+                app_sign_key2_h,
+                ud,
+                cb
+            )))
+        }
+    }
+
+    // Test creating and fetching public encryption keys.
+    #[test]
+    fn enc_public_key_basics() {
+        let app = create_app();
+        let app_enc_key1_h = unsafe { unwrap!(call_1(|ud, cb| app_pub_enc_key(&app, ud, cb))) };
+
+        let app_enc_key1 = run_now(&app, move |client, context| {
+            let app_enc_key1 = unwrap!(client.public_encryption_key());
+            let app_enc_key2 = unwrap!(context.object_cache().get_encrypt_key(app_enc_key1_h));
+            assert_eq!(app_enc_key1, *app_enc_key2);
+
+            app_enc_key1
+        });
+
+        let app_enc_key1_raw: AsymPublicKey = unsafe {
+            unwrap!(call_1(|ud, cb| enc_pub_key_get(
+                &app,
+                app_enc_key1_h,
+                ud,
+                cb
+            )))
+        };
+
+        let app_enc_key2_h = unsafe {
+            unwrap!(call_1(|ud, cb| enc_pub_key_new(
+                &app,
+                &app_enc_key1_raw,
+                ud,
+                cb
+            )))
+        };
+
+        let app_enc_key2 = run_now(&app, move |_, context| {
+            *unwrap!(context.object_cache().get_encrypt_key(app_enc_key2_h))
+        });
+
+        assert_eq!(app_enc_key1, app_enc_key2);
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| enc_pub_key_free(
+                &app,
+                app_enc_key2_h,
+                ud,
+                cb
+            )))
+        }
+    }
+
+    // Test creating and fetching secret encryption keys.
+    #[test]
+    fn enc_secret_key_basics() {
+        let app = create_app();
+        let (app_public_key_h, app_secret_key1_h) =
+            unsafe { unwrap!(call_2(|ud, cb| enc_generate_key_pair(&app, ud, cb))) };
+
+        let app_public_key1: AsymPublicKey = unsafe {
+            unwrap!(call_1(|ud, cb| enc_pub_key_get(
+                &app,
+                app_public_key_h,
+                ud,
+                cb
+            )))
+        };
+        let app_secret_key1: AsymSecretKey = unsafe {
+            unwrap!(call_1(|ud, cb| enc_secret_key_get(
+                &app,
+                app_secret_key1_h,
+                ud,
+                cb
+            )))
+        };
+
+        let app_secret_key1 = run_now(&app, move |_client, context| {
+            let app_public_key2 = unwrap!(context.object_cache().get_encrypt_key(app_public_key_h));
+            assert_eq!(box_::PublicKey(app_public_key1), *app_public_key2);
+
+            let app_secret_key2 = unwrap!(context.object_cache().get_secret_key(app_secret_key1_h));
+            assert_eq!(app_secret_key1, app_secret_key2.0);
+
+            app_secret_key1
+        });
+
+        let app_secret_key1_raw: AsymSecretKey = unsafe {
+            unwrap!(call_1(|ud, cb| enc_secret_key_get(
+                &app,
+                app_secret_key1_h,
+                ud,
+                cb
+            )))
+        };
+
+        let app_secret_key2_h = unsafe {
+            unwrap!(call_1(|ud, cb| enc_secret_key_new(
+                &app,
+                &app_secret_key1_raw,
+                ud,
+                cb
+            )))
+        };
+
+        run_now(&app, move |_, context| {
+            let app_secret_key2 = unwrap!(context.object_cache().get_secret_key(app_secret_key2_h));
+            assert_eq!(app_secret_key1, app_secret_key2.0);
+        });
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| enc_secret_key_free(
+                &app,
+                app_secret_key2_h,
+                ud,
+                cb
+            )))
+        }
+    }
+
+    // Test that generated nonces are the correct length.
+    #[test]
+    fn nonce_smoke_test() {
+        let nonce: AsymNonce = unsafe { unwrap!(call_1(|ud, cb| generate_nonce(ud, cb))) };
+        assert_eq!(nonce.len(), box_::NONCEBYTES);
+    }
+
+    // Test that generated sha3 hashes are the correct length.
+    #[test]
+    fn sha3_smoke_test() {
+        let data = b"test message";
+        let sha3 = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| sha3_hash(
+                data.as_ptr(),
+                data.len(),
+                ud,
+                cb
+            )))
+        };
+
+        assert_eq!(sha3.len(), 256 / 8);
+
+        let data = b"";
+        let sha3 = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| sha3_hash(
+                data.as_ptr(),
+                data.len(),
+                ud,
+                cb
+            )))
+        };
+
+        assert_eq!(sha3.len(), 256 / 8);
+    }
+}

--- a/immutable_data.rs
+++ b/immutable_data.rs
@@ -1,0 +1,283 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use client::Client;
+use crypto::shared_secretbox;
+use event_loop::CoreFuture;
+use futures::Future;
+use maidsafe_utilities::serialisation::{deserialise, serialise};
+use routing::{ImmutableData, XorName};
+use self_encryption::{DataMap, SelfEncryptor};
+use self_encryption_storage::SelfEncryptionStorage;
+use utils::{self, FutureExt};
+
+#[derive(Serialize, Deserialize)]
+enum DataTypeEncoding {
+    Serialised(Vec<u8>),
+    DataMap(DataMap),
+}
+
+/// Create and obtain immutable data out of the given raw bytes. This will encrypt the right content
+/// if the keys are provided and will ensure the maximum immutable data chunk size is respected.
+pub fn create(
+    client: &impl Client,
+    value: &[u8],
+    encryption_key: Option<shared_secretbox::Key>,
+) -> Box<CoreFuture<ImmutableData>> {
+    trace!("Creating conformant ImmutableData.");
+
+    let client = client.clone();
+    let storage = SelfEncryptionStorage::new(client.clone());
+    let self_encryptor = fry!(SelfEncryptor::new(storage, DataMap::None));
+
+    self_encryptor
+        .write(value, 0)
+        .and_then(move |_| self_encryptor.close())
+        .map_err(From::from)
+        .and_then(move |(data_map, _)| {
+            let serialised_data_map = fry!(serialise(&data_map));
+
+            let value = if let Some(key) = encryption_key {
+                let cipher_text = fry!(utils::symmetric_encrypt(&serialised_data_map, &key, None));
+                fry!(serialise(&DataTypeEncoding::Serialised(cipher_text)))
+            } else {
+                fry!(serialise(&DataTypeEncoding::Serialised(
+                    serialised_data_map
+                )))
+            };
+
+            pack(client, value)
+        })
+        .into_box()
+}
+
+/// Get the raw bytes from `ImmutableData` created via the `create` function in this module.
+pub fn extract_value(
+    client: &impl Client,
+    data: &ImmutableData,
+    decryption_key: Option<shared_secretbox::Key>,
+) -> Box<CoreFuture<Vec<u8>>> {
+    let client = client.clone();
+
+    unpack(client.clone(), data)
+        .and_then(move |value| {
+            let data_map = if let Some(key) = decryption_key {
+                let plain_text = utils::symmetric_decrypt(&value, &key)?;
+                deserialise(&plain_text)?
+            } else {
+                deserialise(&value)?
+            };
+
+            let storage = SelfEncryptionStorage::new(client);
+            Ok(SelfEncryptor::new(storage, data_map)?)
+        })
+        .and_then(|self_encryptor| {
+            let length = self_encryptor.len();
+            self_encryptor.read(0, length).map_err(From::from)
+        })
+        .into_box()
+}
+
+/// Get immutable data from the network and extract its value, decrypting it in the process (if keys
+/// provided). This combines `get_idata` in `Client` and `extract_value` in this module into one
+/// function.
+pub fn get_value(
+    client: &impl Client,
+    name: &XorName,
+    decryption_key: Option<shared_secretbox::Key>,
+) -> Box<CoreFuture<Vec<u8>>> {
+    let client2 = client.clone();
+    client
+        .get_idata(*name)
+        .and_then(move |data| extract_value(&client2, &data, decryption_key))
+        .into_box()
+}
+
+// TODO: consider rewriting these two function to not use recursion.
+
+fn pack(client: impl Client, value: Vec<u8>) -> Box<CoreFuture<ImmutableData>> {
+    let data = ImmutableData::new(value);
+    let serialised_data = fry!(serialise(&data));
+
+    if !data.validate_size() {
+        let storage = SelfEncryptionStorage::new(client.clone());
+        let self_encryptor = fry!(SelfEncryptor::new(storage, DataMap::None));
+        self_encryptor
+            .write(&serialised_data, 0)
+            .and_then(move |_| self_encryptor.close())
+            .map_err(From::from)
+            .and_then(move |(data_map, _)| {
+                let value = fry!(serialise(&DataTypeEncoding::DataMap(data_map)));
+                pack(client, value)
+            })
+            .into_box()
+    } else {
+        ok!(data)
+    }
+}
+
+fn unpack(client: impl Client, data: &ImmutableData) -> Box<CoreFuture<Vec<u8>>> {
+    match fry!(deserialise(data.value())) {
+        DataTypeEncoding::Serialised(value) => ok!(value),
+        DataTypeEncoding::DataMap(data_map) => {
+            let storage = SelfEncryptionStorage::new(client.clone());
+            let self_encryptor = fry!(SelfEncryptor::new(storage, data_map));
+            let length = self_encryptor.len();
+            self_encryptor
+                .read(0, length)
+                .map_err(From::from)
+                .and_then(move |serialised_data| {
+                    let data = fry!(deserialise(&serialised_data));
+                    unpack(client, &data)
+                })
+                .into_box()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::Future;
+    use utils;
+    use utils::test_utils::{finish, random_client};
+
+    // Test creating and retrieving a 1kb idata.
+    #[test]
+    fn create_and_retrieve_1kb() {
+        create_and_retrieve(1024)
+    }
+
+    // Test creating and retrieving a 1mb idata.
+    #[test]
+    fn create_and_retrieve_1mb() {
+        create_and_retrieve(1024 * 1024)
+    }
+
+    // Test creating and retrieving a 2mb idata.
+    #[test]
+    fn create_and_retrieve_2mb() {
+        create_and_retrieve(2 * 1024 * 1024)
+    }
+
+    // Test creating and retrieving a 10mb idata.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn create_and_retrieve_10mb() {
+        create_and_retrieve(10 * 1024 * 1024)
+    }
+
+    fn create_and_retrieve(size: usize) {
+        let value = unwrap!(utils::generate_random_vector(size));
+
+        // Unencrypted
+        {
+            let value_before = value.clone();
+
+            random_client(move |client| {
+                let client2 = client.clone();
+                let client3 = client.clone();
+
+                create(client, &value_before.clone(), None)
+                    .then(move |res| {
+                        let data_before = unwrap!(res);
+                        let data_name = *data_before.name();
+                        client2.put_idata(data_before).map(move |_| data_name)
+                    })
+                    .then(move |res| {
+                        let data_name = unwrap!(res);
+                        get_value(&client3, &data_name, None)
+                    })
+                    .then(move |res| {
+                        let value_after = unwrap!(res);
+                        assert_eq!(value_after, value_before);
+                        finish()
+                    })
+            })
+        }
+
+        // Encrypted
+        {
+            let value_before = value.clone();
+            let key = shared_secretbox::gen_key();
+
+            random_client(move |client| {
+                let client2 = client.clone();
+                let client3 = client.clone();
+
+                create(client, &value_before.clone(), Some(key.clone()))
+                    .then(move |res| {
+                        let data_before = unwrap!(res);
+                        let data_name = *data_before.name();
+                        client2.put_idata(data_before).map(move |_| data_name)
+                    })
+                    .then(move |res| {
+                        let data_name = unwrap!(res);
+                        get_value(&client3, &data_name, Some(key))
+                    })
+                    .then(move |res| {
+                        let value_after = unwrap!(res);
+                        assert_eq!(value_after, value_before);
+                        finish()
+                    })
+            })
+        }
+
+        // Put unencrypted Retrieve encrypted - Should fail
+        {
+            let value = value.clone();
+            let key = shared_secretbox::gen_key();
+
+            random_client(move |client| {
+                let client2 = client.clone();
+                let client3 = client.clone();
+
+                create(client, &value, None)
+                    .then(move |res| {
+                        let data = unwrap!(res);
+                        let data_name = *data.name();
+                        client2.put_idata(data).map(move |_| data_name)
+                    })
+                    .then(move |res| {
+                        let data_name = unwrap!(res);
+                        get_value(&client3, &data_name, Some(key))
+                    })
+                    .then(|res| {
+                        assert!(res.is_err());
+                        finish()
+                    })
+            })
+        }
+
+        // Put encrypted Retrieve unencrypted - Should fail
+        {
+            let value = value.clone();
+            let key = shared_secretbox::gen_key();
+
+            random_client(move |client| {
+                let client2 = client.clone();
+                let client3 = client.clone();
+
+                create(client, &value, Some(key))
+                    .then(move |res| {
+                        let data = unwrap!(res);
+                        let data_name = *data.name();
+                        client2.put_idata(data).map(move |_| data_name)
+                    })
+                    .then(move |res| {
+                        let data_name = unwrap!(res);
+                        get_value(&client3, &data_name, None)
+                    })
+                    .then(|res| {
+                        assert!(res.is_err());
+                        finish()
+                    })
+            })
+        }
+    }
+}

--- a/logging.rs
+++ b/logging.rs
@@ -1,0 +1,145 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Logging utilities
+
+use super::AuthError;
+use config_file_handler::FileHandler;
+use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, FFI_RESULT_OK};
+use maidsafe_utilities::log;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+
+/// This function should be called to enable logging to a file.
+/// If `output_file_name_override` is provided, then this path will be used for
+/// the log output file.
+#[no_mangle]
+pub unsafe extern "C" fn auth_init_logging(
+    output_file_name_override: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AuthError> {
+        if output_file_name_override.is_null() {
+            log::init(false)?;
+        } else {
+            let output_file_name_override = from_c_str(output_file_name_override)?;
+            log::init_with_output_file(false, output_file_name_override)?;
+        }
+        o_cb(user_data, FFI_RESULT_OK);
+        Ok(())
+    });
+}
+
+/// This function should be called to find where log file will be created. It
+/// will additionally create an empty log file in the path in the deduced
+/// location and will return the file name along with complete path to it.
+#[no_mangle]
+pub unsafe extern "C" fn auth_output_log_path(
+    output_file_name: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AuthError> {
+        let op_file = from_c_str(output_file_name)?;
+        let fh = FileHandler::<()>::new(&op_file, true)
+            .map_err(|e| AuthError::Unexpected(format!("{}", e)))?;
+        let op_file_path = CString::new(
+            fh.path()
+                .to_path_buf()
+                .into_os_string()
+                .into_string()
+                .map_err(|_| AuthError::Unexpected("Couldn't convert OsString".to_string()))?
+                .into_bytes(),
+        )?;
+        o_cb(user_data, FFI_RESULT_OK, op_file_path.as_ptr());
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config_file_handler::current_bin_dir;
+    use ffi_utils::test_utils::{call_0, call_1};
+    use std::env;
+    use std::fs::{self, File};
+    use std::io::Read;
+    use std::thread;
+    use std::time::Duration;
+
+    // Test path where log file is created.
+    #[test]
+    fn output_log_path() {
+        let name = "_test path";
+        let path_str = unwrap!(CString::new(name));
+
+        let path: String = unsafe {
+            unwrap!(call_1(|ud, cb| auth_output_log_path(
+                path_str.as_ptr(),
+                ud,
+                cb
+            )))
+        };
+
+        assert!(path.contains(name));
+    }
+
+    // Test logging errors to file.
+    #[test]
+    fn file_logging() {
+        setup_log_config();
+
+        let mut current_exe_path = unwrap!(current_bin_dir());
+        current_exe_path.push("auth-log-output.log");
+
+        let log_file_path = unwrap!(CString::new(unwrap!(current_exe_path
+            .clone()
+            .into_os_string()
+            .into_string())));
+        unsafe {
+            unwrap!(call_0(|ud, cb| auth_init_logging(
+                log_file_path.as_ptr(),
+                ud,
+                cb
+            )));
+        }
+
+        let debug_msg = "This is a sample debug message".to_owned();
+        let junk_msg = "This message should not exist in the log file".to_owned();
+
+        error!("{}", debug_msg);
+        debug!("{}", junk_msg);
+
+        // Give some time to the async logging to flush in the background thread
+        thread::sleep(Duration::from_secs(10));
+
+        let mut log_file = unwrap!(File::open(current_exe_path));
+        let mut file_content = String::new();
+
+        let num_bytes = unwrap!(log_file.read_to_string(&mut file_content));
+        assert!(num_bytes > 0);
+
+        assert!(file_content.contains(&debug_msg[..]));
+        assert!(!file_content.contains(&junk_msg[..]));
+    }
+
+    fn setup_log_config() {
+        let mut current_dir = unwrap!(env::current_dir());
+        let mut current_bin_dir = unwrap!(current_bin_dir());
+
+        if current_dir.as_path() != current_bin_dir.as_path() {
+            // Try to copy log.toml from the current dir to bin dir
+            // so that the config_file_handler can find it
+            current_dir.push("sample_log_file/log.toml");
+            current_bin_dir.push("log.toml");
+
+            let _ = unwrap!(fs::copy(current_dir, current_bin_dir));
+        }
+    }
+}

--- a/metadata.rs
+++ b/metadata.rs
@@ -1,0 +1,71 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! FFI routines for handling mutable data metadata.
+
+use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
+use maidsafe_utilities::serialisation::serialise;
+use safe_core::ffi::ipc::resp::MetadataResponse;
+use safe_core::ipc::resp::UserMetadata;
+use std::os::raw::c_void;
+use AppError;
+
+/// Serialize metadata.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_encode_metadata(
+    metadata: *const MetadataResponse,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        encoded: *const u8,
+        encoded_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+        let metadata = UserMetadata::clone_from_repr_c(metadata)?;
+        let encoded = serialise(&metadata)?;
+        o_cb(user_data, FFI_RESULT_OK, encoded.as_ptr(), encoded.len());
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ffi::mutable_data::metadata::mdata_encode_metadata;
+    use ffi_utils::test_utils::call_vec_u8;
+    use maidsafe_utilities::serialisation::deserialise;
+    use safe_core::ipc::resp::UserMetadata;
+
+    // Test serializing and deserializing metadata.
+    #[test]
+    fn serialize_metadata() {
+        let metadata1 = UserMetadata {
+            name: None,
+            description: Some(String::from("test")),
+        };
+
+        let metadata_resp = match metadata1.clone().into_md_response(Default::default(), 0) {
+            Ok(val) => val,
+            _ => panic!("An error occurred"),
+        };
+
+        let serialised = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| mdata_encode_metadata(
+                &metadata_resp,
+                ud,
+                cb
+            )))
+        };
+
+        let metadata2 = unwrap!(deserialise::<UserMetadata>(&serialised));
+
+        assert_eq!(metadata1, metadata2);
+    }
+}

--- a/mod.rs
+++ b/mod.rs
@@ -1,0 +1,270 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+mod mutable_data;
+
+use ffi::test_utils::test_create_app_with_access;
+use ffi_utils::test_utils::call_1;
+use futures::Future;
+#[cfg(feature = "use-mock-routing")]
+use routing::{ClientError, Request, Response};
+use safe_authenticator::test_utils as authenticator;
+use safe_authenticator::test_utils::revoke;
+use safe_authenticator::Authenticator;
+use safe_core::ffi::AccountInfo;
+use safe_core::ipc::req::{AppExchangeInfo, AuthReq};
+use safe_core::ipc::Permission;
+#[cfg(feature = "use-mock-routing")]
+use safe_core::MockRouting;
+use std::collections::HashMap;
+use std::rc::Rc;
+use test_utils::gen_app_exchange_info;
+use test_utils::{create_app_by_req, create_auth_req, create_auth_req_with_access, run};
+use App;
+
+// Test refreshing access info by fetching it from the network.
+#[test]
+fn refresh_access_info() {
+    // Shared container
+    let mut container_permissions = HashMap::new();
+    let _ = container_permissions.insert(
+        "_videos".to_string(),
+        btree_set![Permission::Read, Permission::Insert],
+    );
+
+    let app = unwrap!(create_app_by_req(&create_auth_req_with_access(
+        container_permissions.clone()
+    )));
+
+    run(&app, move |client, context| {
+        let reg = Rc::clone(unwrap!(context.as_registered()));
+        assert!(reg.access_info.borrow().is_empty());
+
+        context.refresh_access_info(client).then(move |result| {
+            unwrap!(result);
+            let access_info = reg.access_info.borrow();
+            assert_eq!(
+                unwrap!(access_info.get("_videos")).1,
+                *unwrap!(container_permissions.get("_videos"))
+            );
+
+            Ok(())
+        })
+    });
+}
+
+// Test fetching containers that an app has access to.
+#[test]
+#[allow(unsafe_code)]
+fn get_access_info() {
+    let mut container_permissions = HashMap::new();
+    let _ = container_permissions.insert("_videos".to_string(), btree_set![Permission::Read]);
+    let _ = container_permissions.insert("_downloads".to_string(), btree_set![Permission::Insert]);
+
+    let auth_req = create_auth_req(None, Some(container_permissions));
+    let auth_req_ffi = unwrap!(auth_req.into_repr_c());
+
+    let app: *mut App = unsafe {
+        unwrap!(call_1(|ud, cb| test_create_app_with_access(
+            &auth_req_ffi,
+            ud,
+            cb
+        )))
+    };
+
+    run(unsafe { &*app }, move |client, context| {
+        context.get_access_info(client).then(move |res| {
+            let info = unwrap!(res);
+            assert!(info.contains_key(&"_videos".to_string()));
+            assert!(info.contains_key(&"_downloads".to_string()));
+            assert_eq!(info.len(), 3); // third item is the app container
+
+            let (ref _md_info, ref perms) = info["_videos"];
+            assert_eq!(perms, &btree_set![Permission::Read]);
+
+            let (ref _md_info, ref perms) = info["_downloads"];
+            assert_eq!(perms, &btree_set![Permission::Insert]);
+
+            Ok(())
+        })
+    });
+}
+
+// Make sure we can login to a registered app with low balance.
+#[cfg(feature = "use-mock-routing")]
+#[test]
+pub fn login_registered_with_low_balance() {
+    // Register a hook prohibiting mutations and login
+    let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+        routing.set_request_hook(move |req| {
+            match *req {
+                Request::PutIData { msg_id, .. } => Some(Response::PutIData {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                Request::PutMData { msg_id, .. } => Some(Response::PutMData {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                Request::MutateMDataEntries { msg_id, .. } => Some(Response::MutateMDataEntries {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                Request::SetMDataUserPermissions { msg_id, .. } => {
+                    Some(Response::SetMDataUserPermissions {
+                        res: Err(ClientError::LowBalance),
+                        msg_id,
+                    })
+                }
+                Request::DelMDataUserPermissions { msg_id, .. } => {
+                    Some(Response::DelMDataUserPermissions {
+                        res: Err(ClientError::LowBalance),
+                        msg_id,
+                    })
+                }
+                Request::ChangeMDataOwner { msg_id, .. } => Some(Response::ChangeMDataOwner {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                Request::InsAuthKey { msg_id, .. } => Some(Response::InsAuthKey {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                Request::DelAuthKey { msg_id, .. } => Some(Response::DelAuthKey {
+                    res: Err(ClientError::LowBalance),
+                    msg_id,
+                }),
+                // Pass-through
+                _ => None,
+            }
+        });
+        routing
+    };
+
+    // Login to the client
+    let auth = authenticator::create_account_and_login();
+
+    // Register and login to the app
+    let app_info = gen_app_exchange_info();
+    let app_id = app_info.id.clone();
+
+    let auth_granted = unwrap!(authenticator::register_app(
+        &auth,
+        &AuthReq {
+            app: app_info,
+            app_container: false,
+            containers: HashMap::new(),
+        },
+    ));
+
+    let _app = unwrap!(App::registered_with_hook(
+        app_id,
+        auth_granted,
+        || (),
+        routing_hook,
+    ));
+}
+
+// Authorise an app with `app_container`.
+fn authorise_app(
+    auth: &Authenticator,
+    app_info: &AppExchangeInfo,
+    app_id: &str,
+    app_container: bool,
+) -> App {
+    let auth_granted = unwrap!(authenticator::register_app(
+        auth,
+        &AuthReq {
+            app: app_info.clone(),
+            app_container,
+            containers: HashMap::new(),
+        },
+    ));
+
+    unwrap!(App::registered(String::from(app_id), auth_granted, || ()))
+}
+
+// Get the number of containers for `app`
+fn num_containers(app: &App) -> usize {
+    run(app, move |client, context| {
+        context.get_access_info(client).then(move |res| {
+            let info = unwrap!(res);
+            Ok(info.len())
+        })
+    })
+}
+
+// Test app container creation under the following circumstances:
+// 1. An app is authorised for the first time with `app_container` set to `true`.
+// 2. If an app is authorised for the first time with `app_container` set to `false`,
+// then any subsequent authorisation with `app_container` set to `true` should trigger
+// the creation of the app's own container.
+// 3. If an app is authorised with `app_container` set to `true`, then subsequent
+// authorisation should not use up any mutations.
+// 4. Make sure that the app's own container is also created when it's re-authorised
+// with `app_container` set to `true` after it's been revoked.
+#[test]
+#[allow(unsafe_code)]
+fn app_container_creation() {
+    use ffi::app_account_info;
+    use ffi_utils::test_utils::call_1;
+
+    // Authorise an app for the first time with `app_container` set to `true`.
+    let auth = authenticator::create_account_and_login();
+
+    let app_info = gen_app_exchange_info();
+    let app_id = app_info.id.clone();
+    let app = authorise_app(&auth, &app_info, &app_id, true);
+
+    assert_eq!(num_containers(&app), 1); // should only contain app container
+
+    // Authorise a new app with `app_container` set to `false`.
+    let auth = authenticator::create_account_and_login();
+
+    let app_info = gen_app_exchange_info();
+    let app_id = app_info.id.clone();
+    let mut app = authorise_app(&auth, &app_info, &app_id, false);
+
+    assert_eq!(num_containers(&app), 0); // should be empty
+
+    // Re-authorise the app with `app_container` set to `true`.
+    app = authorise_app(&auth, &app_info, &app_id, true);
+
+    assert_eq!(num_containers(&app), 1); // should only contain app container
+
+    // Make sure no mutations are done when re-authorising the app now.
+    let acct_info1: AccountInfo =
+        unsafe { unwrap!(call_1(|ud, cb| app_account_info(&mut app, ud, cb))) };
+
+    app = authorise_app(&auth, &app_info, &app_id, true);
+
+    let acct_info2: AccountInfo =
+        unsafe { unwrap!(call_1(|ud, cb| app_account_info(&mut app, ud, cb))) };
+    assert_eq!(
+        acct_info1.mutations_available,
+        acct_info2.mutations_available
+    );
+
+    // Authorise a new app with `app_container` set to `false`.
+    let auth = authenticator::create_account_and_login();
+
+    let app_info = gen_app_exchange_info();
+    let app_id = app_info.id.clone();
+    let app = authorise_app(&auth, &app_info, &app_id, false);
+
+    assert_eq!(num_containers(&app), 0); // should be empty
+
+    // Revoke the app
+    revoke(&auth, &app_id);
+
+    // Re-authorise the app with `app_container` set to `true`.
+    let app = authorise_app(&auth, &app_info, &app_id, true);
+
+    assert_eq!(num_containers(&app), 1); // should only contain app container
+}

--- a/nfs.rs
+++ b/nfs.rs
@@ -1,0 +1,372 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use client::AppClient;
+use errors::AppError;
+use ffi::helper::send;
+use ffi::object_cache::FileContextHandle;
+use ffi_utils::{
+    catch_unwind_cb, from_c_str, vec_clone_from_raw_parts, FfiResult, OpaqueCtx, ReprC, SafePtr,
+    FFI_RESULT_OK,
+};
+use futures::future::{self, Either};
+use futures::Future;
+use safe_core::ffi::nfs::File;
+use safe_core::ffi::MDataInfo;
+use safe_core::nfs::file_helper::{self, Version};
+use safe_core::nfs::File as NativeFile;
+use safe_core::nfs::{Mode, Reader, Writer};
+use safe_core::{FutureExt, MDataInfo as NativeMDataInfo};
+use std::os::raw::{c_char, c_void};
+use App;
+
+/// Holds context for file operations, depending on the mode.
+pub struct FileContext {
+    reader: Option<Reader<AppClient>>,
+    writer: Option<Writer<AppClient>>,
+    original_file: NativeFile,
+}
+
+/// Constant to pass to `dir_update_file()` or `dir_delete_file()` when the next version should be
+/// retrieved and used automatically.
+pub const GET_NEXT_VERSION: u64 = 0;
+
+/// Replaces the entire content of the file when writing data.
+pub static OPEN_MODE_OVERWRITE: u64 = 1;
+/// Appends to existing data in the file.
+pub static OPEN_MODE_APPEND: u64 = 2;
+/// Open file to read.
+pub static OPEN_MODE_READ: u64 = 4;
+/// Read entire contents of a file.
+pub static FILE_READ_TO_END: u64 = 0;
+
+/// Retrieve file with the given name, and its version, from the directory.
+#[no_mangle]
+pub unsafe extern "C" fn dir_fetch_file(
+    app: *const App,
+    parent_info: *const MDataInfo,
+    file_name: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        file: *const File,
+        version: u64,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
+        let file_name = from_c_str(file_name)?;
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |client, _| {
+            file_helper::fetch(client.clone(), parent_info, file_name)
+                .map(move |(version, file)| {
+                    let ffi_file = file.into_repr_c();
+                    o_cb(user_data.0, FFI_RESULT_OK, &ffi_file, version)
+                })
+                .map_err(AppError::from)
+                .map_err(move |err| {
+                    call_result_cb!(Err::<(), _>(err), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })
+    })
+}
+
+/// Insert the file into the parent directory.
+#[no_mangle]
+pub unsafe extern "C" fn dir_insert_file(
+    app: *const App,
+    parent_info: *const MDataInfo,
+    file_name: *const c_char,
+    file: *const File,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
+        let file = NativeFile::clone_from_repr_c(file)?;
+        let file_name = from_c_str(file_name)?;
+
+        send(app, user_data, o_cb, move |client, _| {
+            file_helper::insert(client.clone(), parent_info, file_name, &file)
+        })
+    })
+}
+
+/// Replace the file in the parent directory.
+///
+/// If `version` is `GET_NEXT_VERSION`, the correct version is obtained automatically.
+#[no_mangle]
+pub unsafe extern "C" fn dir_update_file(
+    app: *const App,
+    parent_info: *const MDataInfo,
+    file_name: *const c_char,
+    file: *const File,
+    version: u64,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, new_version: u64),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
+        let file = NativeFile::clone_from_repr_c(file)?;
+        let file_name = from_c_str(file_name)?;
+
+        send(app, user_data, o_cb, move |client, _| {
+            let version = if version == GET_NEXT_VERSION {
+                Version::GetNext
+            } else {
+                Version::Custom(version)
+            };
+            file_helper::update(client.clone(), parent_info, file_name, &file, version)
+        })
+    })
+}
+
+/// Delete the file in the parent directory.
+///
+/// If `version` is `GET_NEXT_VERSION`, the correct version is obtained automatically.
+#[no_mangle]
+pub unsafe extern "C" fn dir_delete_file(
+    app: *const App,
+    parent_info: *const MDataInfo,
+    file_name: *const c_char,
+    version: u64,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, new_version: u64),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
+        let file_name = from_c_str(file_name)?;
+
+        send(app, user_data, o_cb, move |client, _| {
+            let version = if version == GET_NEXT_VERSION {
+                Version::GetNext
+            } else {
+                Version::Custom(version)
+            };
+            file_helper::delete(client.clone(), parent_info, file_name, version)
+        })
+    })
+}
+
+/// Open the file to read or write its contents.
+#[no_mangle]
+pub unsafe extern "C" fn file_open(
+    app: *const App,
+    parent_info: *const MDataInfo,
+    file: *const File,
+    open_mode: u64,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        file_h: FileContextHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
+        let file = NativeFile::clone_from_repr_c(file)?;
+
+        send(app, user_data, o_cb, move |client, context| {
+            let context = context.clone();
+            let original_file = file.clone();
+
+            // Initialise the reader if OPEN_MODE_READ is requested.
+            let reader = if open_mode & OPEN_MODE_READ != 0 {
+                let fut = file_helper::read(client.clone(), &file, parent_info.enc_key().cloned())
+                    .map(Some);
+                Either::A(fut)
+            } else {
+                Either::B(future::ok(None))
+            };
+
+            // Initialise the writer if one of write modes is requested.
+            let writer = if open_mode & (OPEN_MODE_OVERWRITE | OPEN_MODE_APPEND) != 0 {
+                let writer_mode = if open_mode & OPEN_MODE_APPEND != 0 {
+                    Mode::Append
+                } else {
+                    Mode::Overwrite
+                };
+                let fut = file_helper::write(
+                    client.clone(),
+                    file,
+                    writer_mode,
+                    parent_info.enc_key().cloned(),
+                )
+                .map(Some);
+                Either::A(fut)
+            } else {
+                Either::B(future::ok(None))
+            };
+
+            reader.join(writer).map(move |(reader, writer)| {
+                let file_ctx = FileContext {
+                    reader,
+                    writer,
+                    original_file,
+                };
+                context.object_cache().insert_file(file_ctx)
+            })
+        })
+    })
+}
+
+/// Get a size of file opened for read.
+#[no_mangle]
+pub unsafe extern "C" fn file_size(
+    app: *const App,
+    file_h: FileContextHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, size: u64),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_client, context| {
+            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+
+            if let Some(ref reader) = file_ctx.reader {
+                o_cb(user_data.0, FFI_RESULT_OK, reader.size());
+            } else {
+                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
+            }
+            None
+        })
+    })
+}
+
+/// Read data from file.
+#[no_mangle]
+pub unsafe extern "C" fn file_read(
+    app: *const App,
+    file_h: FileContextHandle,
+    position: u64,
+    len: u64,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        data: *const u8,
+        data_len: usize,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_client, context| {
+            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+
+            if let Some(ref reader) = file_ctx.reader {
+                reader
+                    .read(
+                        position,
+                        if len == FILE_READ_TO_END {
+                            reader.size() - position
+                        } else {
+                            len
+                        },
+                    )
+                    .map(move |data| {
+                        o_cb(user_data.0, FFI_RESULT_OK, data.as_safe_ptr(), data.len());
+                    })
+                    .map_err(move |err| {
+                        call_result_cb!(Err::<(), _>(AppError::from(err)), user_data, o_cb);
+                    })
+                    .into_box()
+                    .into()
+            } else {
+                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
+                None
+            }
+        })
+    })
+}
+
+/// Write data to file in smaller chunks.
+#[no_mangle]
+pub unsafe extern "C" fn file_write(
+    app: *const App,
+    file_h: FileContextHandle,
+    data: *const u8,
+    data_len: usize,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+        let data = vec_clone_from_raw_parts(data, data_len);
+
+        (*app).send(move |_client, context| {
+            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+
+            if let Some(ref writer) = file_ctx.writer {
+                writer
+                    .write(&data)
+                    .then(move |res| {
+                        call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                        Ok(())
+                    })
+                    .into_box()
+                    .into()
+            } else {
+                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
+                None
+            }
+        })
+    })
+}
+
+/// Close is invoked only after all the data is completely written. The
+/// file is saved only when `close` is invoked.
+///
+/// If the file was opened in any of the write modes, returns the modified
+/// file structure as a result. If the file was opened in the read mode,
+/// returns the original file structure that was passed as an argument to
+/// `file_open`.
+///
+/// Frees the file context handle.
+#[no_mangle]
+pub unsafe extern "C" fn file_close(
+    app: *const App,
+    file_h: FileContextHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, file: *const File),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_client, context| {
+            let file_ctx = try_cb!(context.object_cache().remove_file(file_h), user_data, o_cb);
+
+            if let Some(writer) = file_ctx.writer {
+                writer
+                    .close()
+                    .map(move |file| {
+                        o_cb(user_data.0, FFI_RESULT_OK, &file.into_repr_c());
+                    })
+                    .map_err(move |err| {
+                        call_result_cb!(Err::<(), _>(AppError::from(err)), user_data, o_cb);
+                    })
+                    .into_box()
+                    .into()
+            } else {
+                // The reader will be dropped automatically.
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    &file_ctx.original_file.into_repr_c(),
+                );
+                None
+            }
+        })
+    })
+}

--- a/permissions.rs
+++ b/permissions.rs
@@ -1,0 +1,214 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! FFI for mutable data permissions and permission sets.
+
+use errors::AppError;
+use ffi::helper::send_sync;
+use ffi::mutable_data::helper;
+use ffi::object_cache::{MDataPermissionsHandle, SignPubKeyHandle, NULL_OBJECT_HANDLE};
+use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK};
+use permissions;
+use routing::User;
+use safe_core::ffi::ipc::req::PermissionSet;
+use safe_core::ipc::req::{permission_set_clone_from_repr_c, permission_set_into_repr_c};
+use std::os::raw::c_void;
+use App;
+
+/// Special value that represents `User::Anyone` in permission sets.
+#[no_mangle]
+pub static USER_ANYONE: SignPubKeyHandle = NULL_OBJECT_HANDLE;
+
+/// FFI object representing a (User, Permission Set) pair.
+#[repr(C)]
+pub struct UserPermissionSet {
+    /// User's sign key handle.
+    pub user_h: SignPubKeyHandle,
+    /// User's permission set.
+    pub perm_set: PermissionSet,
+}
+
+/// Create new permissions.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_permissions_new(
+    app: *const App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        perm_h: MDataPermissionsHandle,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, |_, context| {
+            Ok(context
+                .object_cache()
+                .insert_mdata_permissions(Default::default()))
+        })
+    })
+}
+
+/// Get the number of entries in the permissions.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_permissions_len(
+    app: *const App,
+    permissions_h: MDataPermissionsHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, size: usize),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let permissions = context
+                .object_cache()
+                .get_mdata_permissions(permissions_h)?;
+            Ok(permissions.len())
+        })
+    })
+}
+
+/// Get the permission set corresponding to the given user.
+///
+/// User is either handle to a signing key or `USER_ANYONE`.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_permissions_get(
+    app: *const App,
+    permissions_h: MDataPermissionsHandle,
+    user_h: SignPubKeyHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        perm_set: *const PermissionSet,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_, context| {
+            let permissions = try_cb!(
+                context.object_cache().get_mdata_permissions(permissions_h),
+                user_data,
+                o_cb
+            );
+            let user = try_cb!(
+                helper::get_user(context.object_cache(), user_h),
+                user_data,
+                o_cb
+            );
+
+            let permission_set = *try_cb!(
+                permissions
+                    .get(&user)
+                    .ok_or(AppError::InvalidSignPubKeyHandle),
+                user_data,
+                o_cb
+            );
+            let permission_set = permission_set_into_repr_c(permission_set);
+
+            o_cb(user_data.0, FFI_RESULT_OK, &permission_set);
+            None
+        })
+    })
+}
+
+/// Return each (user, permission set) pair in the permissions.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_list_permission_sets(
+    app: *const App,
+    permissions_h: MDataPermissionsHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        user_perm_sets: *const UserPermissionSet,
+        user_perm_sets_len: usize,
+    ),
+) {
+    let user_data = OpaqueCtx(user_data);
+
+    catch_unwind_cb(user_data, o_cb, || {
+        (*app).send(move |_, context| {
+            let permissions = try_cb!(
+                context.object_cache().get_mdata_permissions(permissions_h),
+                user_data,
+                o_cb
+            );
+            let user_perm_sets: Vec<UserPermissionSet> = permissions
+                .iter()
+                .map(|(user_key, permission_set)| {
+                    let user_h = match *user_key {
+                        User::Key(key) => context.object_cache().insert_pub_sign_key(key),
+                        User::Anyone => USER_ANYONE,
+                    };
+                    permissions::UserPermissionSet {
+                        user_h,
+                        perm_set: *permission_set,
+                    }
+                    .into_repr_c()
+                })
+                .collect();
+
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                user_perm_sets.as_safe_ptr(),
+                user_perm_sets.len(),
+            );
+
+            None
+        })
+    })
+}
+
+/// Insert permission set for the given user to the permissions.
+///
+/// User is either handle to a signing key or `USER_ANYONE`.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_permissions_insert(
+    app: *const App,
+    permissions_h: MDataPermissionsHandle,
+    user_h: SignPubKeyHandle,
+    permission_set: *const PermissionSet,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let permission_set = *permission_set;
+
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let mut permissions = context
+                .object_cache()
+                .get_mdata_permissions(permissions_h)?;
+            let _ = permissions.insert(
+                helper::get_user(context.object_cache(), user_h)?,
+                permission_set_clone_from_repr_c(permission_set)?,
+            );
+
+            Ok(())
+        })
+    })
+}
+
+/// Free the permissions from memory.
+#[no_mangle]
+pub unsafe extern "C" fn mdata_permissions_free(
+    app: *const App,
+    permissions_h: MDataPermissionsHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, move |_, context| {
+            let _ = context
+                .object_cache()
+                .remove_mdata_permissions(permissions_h)?;
+            Ok(())
+        })
+    })
+}

--- a/real_network.rs
+++ b/real_network.rs
@@ -1,0 +1,772 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec};
+use ffi_utils::{from_c_str, FfiResult, ReprC, StringError};
+use safe_app::ffi::app_registered;
+use safe_app::ffi::ipc::*;
+use safe_app::ffi::mdata_info::mdata_info_random_public;
+use safe_app::ffi::mutable_data::entries::{
+    mdata_entries_insert, mdata_entries_new, mdata_list_entries,
+};
+use safe_app::ffi::mutable_data::entry_actions::{
+    mdata_entry_actions_delete, mdata_entry_actions_insert, mdata_entry_actions_new,
+    mdata_entry_actions_update,
+};
+use safe_app::ffi::mutable_data::permissions::{
+    mdata_permissions_insert, mdata_permissions_new, USER_ANYONE,
+};
+use safe_app::ffi::mutable_data::{mdata_entries, mdata_mutate_entries, mdata_put};
+use safe_app::{Action, App, PermissionSet};
+use safe_authenticator::ffi::apps::*;
+use safe_authenticator::ffi::ipc::*;
+use safe_authenticator::ffi::*;
+use safe_authenticator::test_utils::*;
+use safe_authenticator::{AuthError, Authenticator};
+use safe_core::ffi::ipc::resp::AuthGranted as FfiAuthGranted;
+use safe_core::ipc::req::{
+    permission_set_into_repr_c, AppExchangeInfo, AuthReq, ContainerPermissions,
+};
+use safe_core::ipc::resp::{MDataEntry, MDataKey, MDataValue};
+use safe_core::ipc::{AuthGranted, Permission};
+use safe_core::nfs::{Mode, NfsError};
+use safe_core::MDataInfo;
+use safe_core::{utils, CoreError};
+use serde_json;
+use std::collections::HashMap;
+use std::env;
+use std::ffi::CString;
+use std::fs::File;
+use std::io;
+use std::io::{Read, Write};
+use std::os::raw::c_void;
+
+static READ_WRITE_APP_ID: &str = "0123456789";
+static READ_WRITE_FILE_NAME: &str = "test.mp4";
+
+// Configuration for tests.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct TestConfig {
+    /// Developer options.
+    pub test_account: AccountConfig,
+}
+
+// Configuration for accounts.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AccountConfig {
+    acc_locator: String, // account secret
+    acc_password: String,
+}
+
+// Gets account credentials from the env vars "TEST_ACC_LOCATOR" and "TEST_ACC_PASSWORD".
+// If not found, reads the `tests.config` config file and returns it or panics if this fails.
+fn get_config() -> TestConfig {
+    let env_locator = env::var("TEST_ACC_LOCATOR");
+    let env_password = env::var("TEST_ACC_PASSWORD");
+    let env = env_locator.iter().zip(env_password.iter()).next();
+
+    match env {
+        Some((acc_locator, acc_password)) => TestConfig {
+            test_account: AccountConfig {
+                acc_locator: acc_locator.clone(),
+                acc_password: acc_password.clone(),
+            },
+        },
+        None => {
+            let file = unwrap!(File::open("tests.config"));
+            unwrap!(serde_json::from_reader(file))
+        }
+    }
+}
+
+// Copies over crust.config and logs into the Authenticator.
+fn setup_test() -> *mut Authenticator {
+    // Copy crust.config file to <exe>.crust.config
+    {
+        let exe_path = unwrap!(env::current_exe());
+        let exe_path = exe_path.as_path();
+
+        // Test `auth_exe_file_stem`
+        let auth_exe: String = unsafe { unwrap!(call_1(|ud, cb| auth_exe_file_stem(ud, cb))) };
+        assert_eq!(auth_exe, unwrap!(unwrap!(exe_path.file_name()).to_str()));
+
+        let crust_config_file = format!("{}.crust.config", unwrap!(exe_path.to_str()));
+        println!("Copying crust.config to \"{}\"", crust_config_file);
+
+        let config_contents = unwrap!(read_file_str("crust.config"));
+        unwrap!(write_file_str(&crust_config_file, &config_contents));
+    }
+
+    let test_acc = get_config().test_account;
+    let locator = unwrap!(CString::new(test_acc.acc_locator.clone()));
+    let password = unwrap!(CString::new(test_acc.acc_password.clone()));
+
+    // Login to the Authenticator.
+    println!(
+        "Logging in\n... locator: {}\n... password: {}",
+        test_acc.acc_locator, test_acc.acc_password
+    );
+    let auth_h: *mut Authenticator = unsafe {
+        unwrap!(call_1(|ud, cb| login(
+            locator.as_ptr(),
+            password.as_ptr(),
+            ud,
+            disconnect_cb,
+            cb
+        )))
+    };
+    auth_h
+}
+
+// Write data for the `read_data` step. This must be run before `read_data`.
+//
+// This test in conjunction with `read_data` is useful for verifying data compatibility after
+// making possibly breaking changes.
+#[ignore]
+#[test]
+fn write_data() {
+    let auth_h = setup_test();
+
+    let app_id = READ_WRITE_APP_ID;
+    let file_name = READ_WRITE_FILE_NAME;
+
+    let ffi_app_id = unwrap!(CString::new(app_id));
+    println!("App ID: {}", app_id);
+
+    let app_info = AppExchangeInfo {
+        id: app_id.to_string(),
+        scope: None,
+        // Use ID for name so the app is easier to find in Browser.
+        name: app_id.to_string(),
+        vendor: app_id.to_string(),
+    };
+
+    println!("Authorising app...");
+    let auth_granted = ffi_authorise_app(auth_h, &app_info);
+
+    // Register the app.
+    println!("Registering app...");
+    let _app: *mut App = unsafe {
+        unwrap!(call_1(|ud, cb| app_registered(
+            ffi_app_id.as_ptr(),
+            &unwrap!(auth_granted.clone().into_repr_c()),
+            ud,
+            disconnect_cb,
+            cb,
+        )))
+    };
+
+    // Put file into container.
+    println!("File name: {}", file_name);
+
+    unsafe {
+        let mut ac_entries = access_container(&*auth_h, app_id, auth_granted.clone());
+        let (videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+
+        match fetch_file(&*auth_h, videos_md.clone(), file_name) {
+            Ok(file) => {
+                println!("Writing to file...");
+
+                unwrap!(write_file(
+                    &*auth_h,
+                    file,
+                    Mode::Overwrite,
+                    videos_md.enc_key().cloned(),
+                    vec![1; 10],
+                ));
+            }
+            Err(e) => {
+                println!("Could not fetch file: {:?}", e);
+                println!("Creating file...");
+
+                unwrap!(create_file(
+                    &*auth_h,
+                    videos_md.clone(),
+                    file_name,
+                    vec![1; 10],
+                ));
+            }
+        }
+    }
+
+    println!("Data written successfully.");
+}
+
+// Test that data written during the `write_data` step can be read successfully. `write_data` must
+// be run first.
+//
+// This test in conjunction with `write_data` is useful for verifying data compatibility after
+// making possibly breaking changes.
+#[ignore]
+#[test]
+fn read_data() {
+    let auth_h = setup_test();
+
+    let app_id = READ_WRITE_APP_ID;
+    let file_name = READ_WRITE_FILE_NAME;
+
+    let _ffi_app_id = unwrap!(CString::new(app_id));
+    println!("App ID: {}", app_id);
+
+    let app_info = AppExchangeInfo {
+        id: app_id.to_string(),
+        scope: None,
+        name: app_id.to_string(),
+        vendor: app_id.to_string(),
+    };
+
+    // Authorise the app.
+    println!("Authorising app...");
+    let auth_granted = ffi_authorise_app(auth_h, &app_info);
+
+    // Get a list of registered apps, confirm our app is in it.
+    let registered_apps: Vec<RegisteredAppId> =
+        unsafe { unwrap!(call_vec(|ud, cb| auth_registered_apps(auth_h, ud, cb))) };
+    let any = registered_apps
+        .iter()
+        .any(|registered_app_id| registered_app_id.0 == app_id);
+    assert!(any);
+
+    let videos_md = unsafe {
+        let mut ac_entries = access_container(&*auth_h, app_id, auth_granted.clone());
+        let (videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+        videos_md
+    };
+
+    // The app can access the file.
+    println!("Confirming we can read written data...");
+    unsafe {
+        let file = unwrap!(fetch_file(&*auth_h, videos_md.clone(), file_name));
+
+        let content = unwrap!(read_file(&*auth_h, file, videos_md.enc_key().cloned()));
+        assert_eq!(content, vec![1; 10]);
+    }
+
+    println!("Data read successfully.");
+}
+
+// Test that basic mdata operations work on the real network.
+#[ignore]
+#[test]
+fn mdata_operations() {
+    let auth_h = setup_test();
+
+    // Create and authorise an app.
+    let app_id = unwrap!(utils::generate_readable_string(10));
+    let ffi_app_id = unwrap!(CString::new(app_id.clone()));
+    println!("App ID: {}", app_id);
+
+    let app_info = AppExchangeInfo {
+        id: app_id.clone(),
+        scope: None,
+        name: app_id.clone(), // Use ID for name so the app is easier to find in Browser.
+        vendor: app_id.clone(),
+    };
+
+    println!("Authorising app...");
+
+    let auth_granted = ffi_authorise_app(auth_h, &app_info);
+
+    println!("Registering app...");
+
+    let app: *mut App = unsafe {
+        unwrap!(call_1(|ud, cb| app_registered(
+            ffi_app_id.as_ptr(),
+            &unwrap!(auth_granted.clone().into_repr_c()),
+            ud,
+            disconnect_cb,
+            cb,
+        )))
+    };
+
+    println!("Creating random mdata...");
+
+    let type_tag = 15_000;
+    let mdata_info: MDataInfo =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_info_random_public(type_tag, ud, cb))) };
+    let mdata_info = mdata_info.into_repr_c();
+
+    // Create permissions for anyone
+    let perms_h = unsafe { unwrap!(call_1(|ud, cb| mdata_permissions_new(app, ud, cb))) };
+    {
+        // Create a permissions set
+        let perms_set = PermissionSet::new()
+            .allow(Action::Insert)
+            .allow(Action::Update)
+            .allow(Action::Delete);
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| mdata_permissions_insert(
+                app,
+                perms_h,
+                USER_ANYONE,
+                &permission_set_into_repr_c(perms_set),
+                ud,
+                cb,
+            )))
+        };
+    }
+
+    let entries_h = unsafe { unwrap!(call_1(|ud, cb| mdata_entries_new(app, ud, cb))) };
+
+    let key0 = b"random_key_1".to_vec();
+    let value0 = b"Scotland to try Scotch whisky".to_vec();
+    let key1 = b"random_key_2".to_vec();
+    let value1 = b"Patagonia before I'm too old".to_vec();
+    let value1_2 = b"Bogota before I'm too old".to_vec();
+    let key2 = b"random_key_3".to_vec();
+    let value2 = b"Cyprus for falafels and kebab".to_vec();
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_entries_insert(
+            app,
+            entries_h,
+            key0.as_ptr(),
+            key0.len(),
+            value0.as_ptr(),
+            value0.len(),
+            ud,
+            cb
+        )));
+        unwrap!(call_0(|ud, cb| mdata_entries_insert(
+            app,
+            entries_h,
+            key1.as_ptr(),
+            key1.len(),
+            value1.as_ptr(),
+            value1.len(),
+            ud,
+            cb
+        )));
+    }
+
+    // Put the entries to the mdata.
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_put(
+            app,
+            &mdata_info,
+            perms_h,
+            entries_h,
+            ud,
+            cb
+        )))
+    };
+
+    println!("Getting the list of mdata entries...");
+
+    let entries: Vec<MDataEntry> = unsafe {
+        unwrap!(call_vec(|ud, cb| mdata_list_entries(
+            app, entries_h, ud, cb
+        )))
+    };
+
+    assert_eq!(entries[0].key, MDataKey(key0.clone()));
+    assert_eq!(
+        entries[0].value,
+        MDataValue {
+            content: value0,
+            entry_version: 0
+        }
+    );
+    assert_eq!(entries[1].key, MDataKey(key1.clone()));
+    assert_eq!(
+        entries[1].value,
+        MDataValue {
+            content: value1,
+            entry_version: 0
+        }
+    );
+
+    println!("Inserting, mutating, and deleting the entries...");
+
+    let actions_h = unsafe { unwrap!(call_1(|ud, cb| mdata_entry_actions_new(app, ud, cb))) };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_entry_actions_insert(
+            app,
+            actions_h,
+            key2.as_ptr(),
+            key2.len(),
+            value2.as_ptr(),
+            value2.len(),
+            ud,
+            cb
+        )));
+
+        unwrap!(call_0(|ud, cb| mdata_entry_actions_update(
+            app,
+            actions_h,
+            key1.as_ptr(),
+            key1.len(),
+            value1_2.as_ptr(),
+            value1_2.len(),
+            1,
+            ud,
+            cb
+        )));
+
+        unwrap!(call_0(|ud, cb| mdata_entry_actions_delete(
+            app,
+            actions_h,
+            key0.as_ptr(),
+            key0.len(),
+            1,
+            ud,
+            cb
+        )))
+    }
+
+    // Apply the mutation.
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_mutate_entries(
+            app,
+            &mdata_info,
+            actions_h,
+            ud,
+            cb
+        )))
+    }
+
+    println!("Getting the list of mdata entries...");
+
+    let entries_h = unsafe { unwrap!(call_1(|ud, cb| mdata_entries(app, &mdata_info, ud, cb))) };
+
+    let entries: Vec<MDataEntry> = unsafe {
+        unwrap!(call_vec(|ud, cb| mdata_list_entries(
+            app, entries_h, ud, cb
+        )))
+    };
+
+    assert_eq!(entries[0].key, MDataKey(key0));
+    assert_eq!(
+        entries[0].value,
+        MDataValue {
+            content: b"".to_vec(),
+            entry_version: 1
+        }
+    );
+    assert_eq!(entries[1].key, MDataKey(key1));
+    assert_eq!(
+        entries[1].value,
+        MDataValue {
+            content: value1_2,
+            entry_version: 1
+        }
+    );
+    assert_eq!(entries[2].key, MDataKey(key2));
+    assert_eq!(
+        entries[2].value,
+        MDataValue {
+            content: value2,
+            entry_version: 0
+        }
+    );
+}
+
+#[ignore]
+#[test]
+fn authorisation_and_revocation() {
+    let auth_h = setup_test();
+
+    // Create and authorise an app.
+    let app_id = unwrap!(utils::generate_readable_string(10));
+    let ffi_app_id = unwrap!(CString::new(app_id.clone()));
+    println!("App ID: {}", app_id);
+
+    let app_info = AppExchangeInfo {
+        id: app_id.clone(),
+        scope: None,
+        name: app_id.clone(), // Use ID for name so the app is easier to find in Browser.
+        vendor: app_id.clone(),
+    };
+
+    println!("Authorising app...");
+
+    let auth_granted = ffi_authorise_app(auth_h, &app_info);
+
+    println!("Registering app...");
+
+    let _app: *mut App = unsafe {
+        unwrap!(call_1(|ud, cb| app_registered(
+            ffi_app_id.as_ptr(),
+            &unwrap!(auth_granted.clone().into_repr_c()),
+            ud,
+            disconnect_cb,
+            cb,
+        )))
+    };
+
+    // Get a list of registered apps, confirm our app is in it.
+    let registered_apps: Vec<RegisteredAppId> =
+        unsafe { unwrap!(call_vec(|ud, cb| auth_registered_apps(auth_h, ud, cb))) };
+    let any = registered_apps
+        .iter()
+        .any(|registered_app_id| registered_app_id.0 == app_id);
+    assert!(any);
+
+    // Put file into container.
+    println!("Creating file...");
+
+    let file_name = format!("{}.mp4", unwrap!(utils::generate_readable_string(10)));
+    println!("File name: {}", file_name.clone());
+
+    let videos_md = unsafe {
+        let mut ac_entries = access_container(&*auth_h, app_id.clone(), auth_granted.clone());
+        let (videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+        unwrap!(create_file(
+            &*auth_h,
+            videos_md.clone(),
+            file_name.as_str(),
+            vec![1; 10],
+        ));
+        videos_md
+    };
+
+    // The app can access the file.
+    unsafe {
+        let _ = unwrap!(fetch_file(&*auth_h, videos_md.clone(), file_name.as_str()));
+    }
+
+    println!("Revoking app...");
+
+    let _: String = unsafe {
+        unwrap!(call_1(|ud, cb| auth_revoke_app(
+            auth_h,
+            ffi_app_id.as_ptr(),
+            ud,
+            cb
+        )))
+    };
+
+    // Get list of revoked apps, confirm our app is in it.
+    let revoked_apps: Vec<AppExchangeInfo> =
+        unsafe { unwrap!(call_vec(|ud, cb| auth_revoked_apps(auth_h, ud, cb))) };
+    assert!(revoked_apps
+        .iter()
+        .any(|revoked_app| revoked_app.id == app_id));
+
+    // The app is no longer in the access container.
+    unsafe {
+        let ac = try_access_container(&*auth_h, app_id.clone(), auth_granted.clone());
+        assert!(ac.is_none());
+
+        // The app can no longer access the file.
+        match fetch_file(&*auth_h, videos_md.clone(), file_name.as_str()) {
+            Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+    }
+
+    println!("Re-authorising app...");
+
+    let auth_granted = ffi_authorise_app(auth_h, &app_info);
+
+    println!("Re-registering app...");
+
+    let _app: *mut App = unsafe {
+        unwrap!(call_1(|ud, cb| app_registered(
+            ffi_app_id.as_ptr(),
+            &unwrap!(auth_granted.clone().into_repr_c()),
+            ud,
+            disconnect_cb,
+            cb,
+        )))
+    };
+
+    // Get a list of registered apps, confirm our app is in it.
+    let registered_apps: Vec<RegisteredAppId> =
+        unsafe { unwrap!(call_vec(|ud, cb| auth_registered_apps(auth_h, ud, cb))) };
+    let any = registered_apps
+        .iter()
+        .any(|registered_app_id| registered_app_id.0 == app_id);
+    assert!(any);
+
+    // The app can access the file again.
+    unsafe {
+        let mut ac_entries = access_container(&*auth_h, app_id.clone(), auth_granted.clone());
+        let (videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+        let _ = unwrap!(fetch_file(&*auth_h, videos_md.clone(), file_name));
+    };
+
+    println!("Revoking app...");
+
+    let _: String = unsafe {
+        unwrap!(call_1(|ud, cb| auth_revoke_app(
+            auth_h,
+            ffi_app_id.as_ptr(),
+            ud,
+            cb
+        )))
+    };
+
+    // Remove the revoked app
+    unsafe {
+        unwrap!(call_0(|ud, cb| auth_rm_revoked_app(
+            auth_h,
+            ffi_app_id.as_ptr(),
+            ud,
+            cb
+        )))
+    }
+}
+
+// Authorises the app.
+fn ffi_authorise_app(auth_h: *mut Authenticator, app_info: &AppExchangeInfo) -> AuthGranted {
+    let auth_req = AuthReq {
+        app: app_info.clone(),
+        app_container: false,
+        containers: create_containers_req(),
+    };
+    let ffi_auth_req = unwrap!(auth_req.clone().into_repr_c());
+
+    let (req_id, _encoded): (u32, String) =
+        unsafe { unwrap!(call_2(|ud, cb| encode_auth_req(&ffi_auth_req, ud, cb))) };
+
+    let encoded_auth_resp: String = unsafe {
+        unwrap!(call_1(|ud, cb| {
+            let auth_req = unwrap!(auth_req.into_repr_c());
+            encode_auth_resp(
+                auth_h, &auth_req, req_id, true, // is_granted
+                ud, cb,
+            )
+        }))
+    };
+    let encoded_auth_resp = unwrap!(CString::new(encoded_auth_resp));
+
+    let mut context = Context {
+        unexpected_cb: false,
+        req_id: 0,
+        auth_granted: None,
+    };
+
+    let context_ptr: *mut Context = &mut context;
+    unsafe {
+        decode_ipc_msg(
+            encoded_auth_resp.as_ptr(),
+            context_ptr as *mut c_void,
+            auth_cb,
+            unregistered_cb,
+            containers_cb,
+            share_mdata_cb,
+            revoked_cb,
+            err_cb,
+        );
+    }
+
+    assert!(!context.unexpected_cb);
+    assert_eq!(context.req_id, req_id);
+
+    unwrap!(context.auth_granted)
+}
+
+// Creates a containers request asking for "videos with all the permissions possible".
+fn create_containers_req() -> HashMap<String, ContainerPermissions> {
+    let mut containers = HashMap::new();
+    let _ = containers.insert(
+        "_videos".to_owned(),
+        btree_set![
+            Permission::Read,
+            Permission::Insert,
+            Permission::Update,
+            Permission::Delete,
+            Permission::ManagePermissions,
+        ],
+    );
+    containers
+}
+
+struct Context {
+    unexpected_cb: bool,
+    req_id: u32,
+    auth_granted: Option<AuthGranted>,
+}
+
+extern "C" fn auth_cb(ctx: *mut c_void, req_id: u32, auth_granted: *const FfiAuthGranted) {
+    unsafe {
+        let auth_granted = unwrap!(AuthGranted::clone_from_repr_c(auth_granted));
+
+        let ctx = ctx as *mut Context;
+        (*ctx).req_id = req_id;
+        (*ctx).auth_granted = Some(auth_granted);
+    }
+}
+
+extern "C" fn containers_cb(ctx: *mut c_void, _req_id: u32) {
+    unsafe {
+        let ctx = ctx as *mut Context;
+        (*ctx).unexpected_cb = true;
+    }
+}
+
+extern "C" fn share_mdata_cb(ctx: *mut c_void, _req_id: u32) {
+    unsafe {
+        let ctx = ctx as *mut Context;
+        (*ctx).unexpected_cb = true;
+    }
+}
+
+extern "C" fn revoked_cb(ctx: *mut c_void) {
+    unsafe {
+        let ctx = ctx as *mut Context;
+        (*ctx).unexpected_cb = true;
+    }
+}
+
+extern "C" fn unregistered_cb(
+    ctx: *mut c_void,
+    _req_id: u32,
+    _bootstrap_cfg: *const u8,
+    _bootstrap_cfg_len: usize,
+) {
+    unsafe {
+        let ctx = ctx as *mut Context;
+        (*ctx).unexpected_cb = true;
+    }
+}
+
+extern "C" fn err_cb(ctx: *mut c_void, _res: *const FfiResult, _req_id: u32) {
+    unsafe {
+        let ctx = ctx as *mut Context;
+        (*ctx).unexpected_cb = true;
+    }
+}
+
+extern "C" fn disconnect_cb(_user_data: *mut c_void) {
+    panic!("Disconnect callback")
+}
+
+struct RegisteredAppId(String);
+impl ReprC for RegisteredAppId {
+    type C = *const RegisteredApp;
+    type Error = StringError;
+
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        Ok(RegisteredAppId(from_c_str((*repr_c).app_info.id)?))
+    }
+}
+
+// Reads a file and returns its contents in a string.
+fn read_file_str(fname: &str) -> io::Result<String> {
+    // Open the path in read-only mode
+    let mut file = File::open(fname)?;
+
+    let mut contents = String::new();
+    let _ = file.read_to_string(&mut contents)?;
+
+    Ok(contents)
+}
+
+// Writes a string to a file.
+fn write_file_str(fname: &str, contents: &str) -> io::Result<()> {
+    // Open a file in write-only mode
+    let mut file = File::create(fname)?;
+
+    file.write_all(contents.as_bytes())?;
+
+    Ok(())
+}

--- a/revocation.rs
+++ b/revocation.rs
@@ -1,0 +1,1120 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::utils::{corrupt_container, create_containers_req};
+use config::{self, get_app_revocation_queue, push_to_app_revocation_queue};
+use errors::AuthError;
+use futures::Future;
+use revocation;
+use routing::{AccountInfo, EntryActions, User};
+use safe_core::ipc::{AuthReq, Permission};
+use safe_core::nfs::NfsError;
+use safe_core::{app_container_name, Client, CoreError, MDataInfo};
+use std::collections::HashMap;
+use test_utils::{
+    access_container, create_account_and_login, create_authenticator, create_file, fetch_file,
+    get_container_from_authenticator_entry, rand_app, register_app, register_rand_app, revoke, run,
+    try_access_container, try_revoke,
+};
+use Authenticator;
+
+#[cfg(feature = "use-mock-routing")]
+mod mock_routing {
+    use super::*;
+    use access_container;
+    use app_auth::{app_state, AppState};
+    use client::AuthClient;
+    use config;
+    use ffi::ipc::auth_flush_app_revocation_queue;
+    use ffi_utils::test_utils::call_0;
+    use futures::future;
+    use maidsafe_utilities::SeededRng;
+    use routing::{ClientError, Request, Response};
+    use safe_core::ipc::req::container_perms_into_permission_set;
+    use safe_core::ipc::resp::AccessContainerEntry;
+    use safe_core::ipc::{IpcError, Permission};
+    use safe_core::utils::test_utils::Synchronizer;
+    use safe_core::MockRouting;
+    use safe_core::{Client, FutureExt};
+    use std::collections::HashMap;
+    use std::iter;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use test_utils::{get_container_from_authenticator_entry, register_rand_app, try_revoke};
+    use tiny_keccak::sha3_256;
+    use AuthFuture;
+
+    // Test operation recovery for app revocation
+    //
+    // 1. Create a test app and authenticate it.
+    // 2. Grant access to some of the default containers (e.g. `_video`, `_documents`).
+    // 3. Put several files with a known content in both containers (e.g. `_videos/video.mp4` and
+    //    `_documents/test.doc`).
+    // 4. Revoke the app access from the authenticator.
+    // 5. Simulate network failure during the re-encryption of the `_document` container.
+    // 6. Verify that the `_documents` container is still accessible using the previous `MDataInfo`.
+    // 7. Verify that the `_videos` container is accessible using the new `MDataInfo`
+    //    (it might or might not be still accessible using the old info, depending on whether
+    //    its re-encryption managed to run to completion before the re-encryption of
+    //    `_documents` failed).
+    // 8. Check that the app key is not listed in MaidManagers.
+    // 9. Repeat step 1.4 (restart the revoke operation for the app) and don't interfere with the
+    //    re-encryption process this time. It should pass.
+    // 10. Verify that both the second and first containers aren't accessible using previous
+    //     `MDataInfo`.
+    // 11. Verify that both the second and first containers are accessible using the new
+    //     `MDataInfo`.
+    #[test]
+    fn app_revocation_recovery() {
+        let (auth, locator, password) = create_authenticator();
+
+        // Create a test app and authenticate it.
+        // Grant access to some of the default containers (e.g. `_video`, `_documents`).
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: false,
+            containers: create_containers_req(),
+        };
+        let app_id = auth_req.app.id.clone();
+        let auth_granted = unwrap!(register_app(&auth, &auth_req));
+
+        // Put several files with a known content in both containers
+        let mut ac_entries = access_container(&auth, app_id.clone(), auth_granted.clone());
+        let (videos_md, _) = unwrap!(ac_entries.remove("_videos"));
+        let (docs_md, _) = unwrap!(ac_entries.remove("_documents"));
+
+        unwrap!(create_file(
+            &auth,
+            videos_md.clone(),
+            "video.mp4",
+            vec![1; 10],
+        ));
+        unwrap!(create_file(&auth, docs_md.clone(), "test.doc", vec![2; 10]));
+
+        // After re-encryption of the first container (`_video`) is done, simulate a network failure
+        let docs_name = docs_md.name;
+
+        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+            routing.set_request_hook(move |req| {
+                match *req {
+                    // Simulate a network failure for the request to re-encrypt
+                    // the `_documents` container, so it remains untouched.
+                    Request::MutateMDataEntries { name, msg_id, .. } if name == docs_name => {
+                        Some(Response::MutateMDataEntries {
+                            msg_id,
+                            res: Err(ClientError::LowBalance),
+                        })
+                    }
+                    // Pass-through
+                    _ => None,
+                }
+            });
+            routing
+        };
+        let auth = unwrap!(Authenticator::login_with_hook(
+            locator.clone(),
+            password.clone(),
+            || (),
+            routing_hook,
+        ));
+
+        // Revoke the app.
+        match try_revoke(&auth, &app_id) {
+            Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Verify that the `_documents` container is still accessible using the previous info.
+        let _ = unwrap!(fetch_file(&auth, docs_md.clone(), "test.doc"));
+
+        // The re-encryption of `_videos` may or might not have successfully run
+        // to completion. Try to fetch a file from it using the new info first.
+        let new_videos_md = unwrap!(get_container_from_authenticator_entry(&auth, "_videos"));
+        let success = match fetch_file(&auth, new_videos_md, "video.mp4") {
+            Ok(_) => true,
+            Err(AuthError::NfsError(NfsError::FileNotFound)) => false,
+            x => panic!("Unexpected {:?}", x),
+        };
+
+        // If it failed, it means the `_videos` container re-encryption has not
+        // been successfully completed. Verify that we can still access the file
+        // using the old info.
+        if !success {
+            let _ = unwrap!(fetch_file(&auth, videos_md.clone(), "video.mp4"));
+        }
+
+        // Ensure that the app key has been removed from MaidManagers
+        let auth_keys = run(&auth, move |client| {
+            client
+                .list_auth_keys_and_version()
+                .map(move |(auth_keys, _version)| auth_keys)
+                .map_err(AuthError::from)
+        });
+        assert!(!auth_keys.contains(&auth_granted.app_keys.sign_pk));
+
+        // Login and try to revoke the app again, now without interfering with responses
+        let auth = unwrap!(Authenticator::login(
+            locator.clone(),
+            password.clone(),
+            || (),
+        ));
+
+        // App revocation should succeed
+        revoke(&auth, &app_id);
+
+        // Try to access both files using previous keys - they shouldn't be accessible
+        match fetch_file(&auth, docs_md, "test.doc") {
+            Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+        match fetch_file(&auth, videos_md, "video.mp4") {
+            Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Get the new encryption info from the authenticator entry (as the app entry has been
+        // removed now). Both containers should be accessible with the new keys without any extra
+        // effort
+        let ac_entries = try_access_container(&auth, app_id.clone(), auth_granted.clone());
+        assert!(ac_entries.is_none());
+
+        let new_docs_md = unwrap!(get_container_from_authenticator_entry(&auth, "_documents"));
+        let new_videos_md = unwrap!(get_container_from_authenticator_entry(&auth, "_videos"));
+
+        let _ = unwrap!(fetch_file(&auth, new_docs_md, "test.doc"));
+        let _ = unwrap!(fetch_file(&auth, new_videos_md, "video.mp4"));
+    }
+
+    // Test app cannot be (re)authenticated while it's being revoked.
+    //
+    // 1. Create an app.
+    // 2. Initiate a revocation of the app, but simulate a network failure to prevent it
+    //    from finishing.
+    // 3. Try to re-authenticate the app and assert that it fails (as the app is in the
+    //    middle of its revocation process)
+    // 4. Re-try the revocation with no simulated failures to let it finish successfully.
+    // 5. Try to re-authenticate the app again. This time it will succeed.
+    #[test]
+    fn app_authentication_during_pending_revocation() {
+        // Create account.
+        let (auth, locator, password) = create_authenticator();
+
+        // Authenticate the app.
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: false,
+            containers: create_containers_req(),
+        };
+
+        let app_id = auth_req.app.id.clone();
+        let _ = unwrap!(register_app(&auth, &auth_req));
+
+        // Attempt to revoke it which fails due to simulated network failure.
+        simulate_revocation_failure(&locator, &password, iter::once(&app_id));
+
+        // Attempt to re-authenticate the app fails, because revocation is pending.
+        match register_app(&auth, &auth_req) {
+            Err(_) => (), // TODO: assert expected error variant
+            x => panic!("Unexpected {:?}", x),
+        }
+
+        // Retry the app revocation. This time it succeeds.
+        revoke(&auth, &app_id);
+
+        // Re-authentication now succeeds.
+        let _ = unwrap!(register_app(&auth, &auth_req));
+    }
+
+    // Test flushing the app revocation queue.
+    //
+    // 1. Create two apps
+    // 2. Revoke both of them, but simulate network failure so both revocations would
+    //    fail.
+    // 3. Log in again and flush the revocation queue with no simulated failures.
+    // 4. Verify both apps are successfully revoked.
+    #[test]
+    fn flushing_app_revocation_queue() {
+        // Create account.
+        let (auth, locator, password) = create_authenticator();
+
+        // Authenticate the first app.
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: false,
+            containers: create_containers_req(),
+        };
+
+        let _ = unwrap!(register_app(&auth, &auth_req));
+        let app_id_0 = auth_req.app.id.clone();
+
+        // Authenticate the second app.
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: false,
+            containers: create_containers_req(),
+        };
+
+        let _ = unwrap!(register_app(&auth, &auth_req));
+        let app_id_1 = auth_req.app.id.clone();
+
+        // Simulate failed revocations of both apps.
+        simulate_revocation_failure(&locator, &password, &[&app_id_0, &app_id_1]);
+
+        // Verify the apps are not revoked yet.
+        {
+            let app_id_0 = app_id_0.clone();
+            let app_id_1 = app_id_1.clone();
+
+            run(&auth, |client| {
+                let client = client.clone();
+
+                config::list_apps(&client)
+                    .then(move |res| {
+                        let (_, apps) = unwrap!(res);
+                        let f_0 = app_state(&client, &apps, &app_id_0);
+                        let f_1 = app_state(&client, &apps, &app_id_1);
+
+                        f_0.join(f_1)
+                    })
+                    .then(|res| {
+                        let (state_0, state_1) = unwrap!(res);
+                        assert_eq!(state_0, AppState::Authenticated);
+                        assert_eq!(state_1, AppState::Authenticated);
+
+                        Ok(())
+                    })
+            })
+        }
+
+        // Login again without simulated failures.
+        let auth = unwrap!(Authenticator::login(locator, password, || ()));
+
+        // Flush the revocation queue and verify both apps get revoked.
+        unsafe {
+            unwrap!(call_0(|ud, cb| auth_flush_app_revocation_queue(
+                &auth, ud, cb
+            )))
+        }
+
+        run(&auth, |client| {
+            let c2 = client.clone();
+
+            config::list_apps(client)
+                .then(move |res| {
+                    let (_, apps) = unwrap!(res);
+                    let f_0 = app_state(&c2, &apps, &app_id_0);
+                    let f_1 = app_state(&c2, &apps, &app_id_1);
+
+                    f_0.join(f_1)
+                })
+                .then(move |res| {
+                    let (state_0, state_1) = unwrap!(res);
+                    assert_eq!(state_0, AppState::Revoked);
+                    assert_eq!(state_1, AppState::Revoked);
+
+                    Ok(())
+                })
+        })
+    }
+
+    // Test one app being revoked by multiple authenticator concurrently.
+    #[test]
+    fn concurrent_revocation_of_single_app() {
+        let rng = SeededRng::new();
+
+        // Number of concurrent operations.
+        let concurrency = 2;
+
+        // Create account.
+        let (auth, locator, password) = create_authenticator();
+
+        // Create two apps with dedicated containers + access to one shared container.
+        let mut containers_req = HashMap::new();
+        let _ = containers_req.insert(
+            "_documents".to_owned(),
+            btree_set![
+                Permission::Read,
+                Permission::Insert,
+                Permission::Update,
+                Permission::Delete,
+            ],
+        );
+
+        let (app_id_0, auth_granted_0) =
+            unwrap!(register_rand_app(&auth, true, containers_req.clone()));
+        let (app_id_1, _) = unwrap!(register_rand_app(&auth, true, containers_req));
+
+        let ac_entries_0 = access_container(&auth, app_id_0.clone(), auth_granted_0);
+
+        // Put a file into the shared container.
+        let info = unwrap!(get_container_from_authenticator_entry(&auth, "_documents"));
+        unwrap!(create_file(&auth, info, "shared.txt", vec![0; 10]));
+
+        // Put a file into the dedicated container of each app.
+        for app_id in &[&app_id_0, &app_id_1] {
+            let info = unwrap!(get_container_from_authenticator_entry(
+                &auth,
+                &app_container_name(app_id),
+            ));
+            unwrap!(create_file(&auth, info, "private.txt", vec![0; 10]));
+        }
+
+        // Try to revoke the app concurrently using multiple authenticators (running
+        // in separate threads).
+
+        // This barrier makes sure the revocations are started only after all
+        // the authenticators are fully initialized.
+        let barrier = Arc::new(Barrier::new(concurrency));
+        let sync = Synchronizer::new(rng);
+
+        let join_handles: Vec<_> = (0..concurrency)
+            .map(|_| {
+                let locator = locator.clone();
+                let password = password.clone();
+                let app_id = app_id_0.clone();
+                let barrier = Arc::clone(&barrier);
+                let sync = sync.clone();
+
+                thread::spawn(move || {
+                    let auth = unwrap!(Authenticator::login_with_hook(
+                        locator,
+                        password,
+                        || (),
+                        move |routing| sync.hook(routing),
+                    ));
+
+                    let _ = barrier.wait();
+                    try_revoke(&auth, &app_id)
+                })
+            })
+            // Doing `collect` to prevent short-circuiting.
+            .collect();
+
+        let success =
+            join_handles
+                .into_iter()
+                .fold(false, |success, handle| match unwrap!(handle.join()) {
+                    Ok(_) | Err(AuthError::IpcError(IpcError::UnknownApp)) => true,
+                    _ => success,
+                });
+
+        // If none of the concurrently running revocations succeeded, let's give it
+        // one more try, but this time using only one authenticator.
+        // The idea behind this is that it's OK if revocation fails when run concurrently,
+        // but it should always succeed when run non-concurrently - that is, the
+        // concurrent runs should never leave things in inconsistent state.
+        if !success {
+            unwrap!(try_revoke(&auth, &app_id_0));
+        }
+
+        // Check that the first app is now revoked, but the second app is not.
+        run(&auth, move |client| {
+            let app_0 = verify_app_is_revoked(client, app_id_0, ac_entries_0);
+            let app_1 = verify_app_is_authenticated(client, app_id_1);
+
+            app_0.join(app_1).map(|_| ())
+        });
+    }
+
+    // Test multiple apps being revoked concurrently.
+    #[test]
+    fn concurrent_revocation_of_multiple_apps() {
+        let rng = SeededRng::new();
+
+        // Create account.
+        let (auth, locator, password) = create_authenticator();
+
+        // Create apps with dedicated containers + access to one shared container.
+        let mut containers_req = HashMap::new();
+        let _ = containers_req.insert(
+            "_documents".to_owned(),
+            btree_set![
+                Permission::Read,
+                Permission::Insert,
+                Permission::Update,
+                Permission::Delete,
+            ],
+        );
+
+        let (app_id_0, auth_granted_0) =
+            unwrap!(register_rand_app(&auth, true, containers_req.clone()));
+        let (app_id_1, auth_granted_1) =
+            unwrap!(register_rand_app(&auth, true, containers_req.clone()));
+        let (app_id_2, _) = unwrap!(register_rand_app(&auth, true, containers_req));
+
+        let ac_entries_0 = access_container(&auth, app_id_0.clone(), auth_granted_0);
+        let ac_entries_1 = access_container(&auth, app_id_1.clone(), auth_granted_1);
+
+        // Put a file into the shared container.
+        let info = unwrap!(get_container_from_authenticator_entry(&auth, "_documents"));
+        unwrap!(create_file(&auth, info, "shared.txt", vec![0; 10]));
+
+        // Put a file into the dedicated container of each app.
+        for app_id in &[&app_id_0, &app_id_1, &app_id_2] {
+            let info = unwrap!(get_container_from_authenticator_entry(
+                &auth,
+                &app_container_name(app_id),
+            ));
+            unwrap!(create_file(&auth, info, "private.txt", vec![0; 10]));
+        }
+
+        // Revoke the first two apps, concurrently.
+        let apps_to_revoke = [app_id_0.clone(), app_id_1.clone()];
+
+        // This barrier makes sure the revocations are started only after all
+        // the authenticators are fully initialized.
+        let barrier = Arc::new(Barrier::new(apps_to_revoke.len()));
+        let sync = Synchronizer::new(rng);
+
+        let join_handles: Vec<_> = apps_to_revoke
+            .iter()
+            .map(|app_id| {
+                let locator = locator.clone();
+                let password = password.clone();
+                let app_id = app_id.to_string();
+                let barrier = Arc::clone(&barrier);
+                let sync = sync.clone();
+
+                thread::spawn(move || {
+                    let auth = unwrap!(Authenticator::login_with_hook(
+                        locator,
+                        password,
+                        || (),
+                        move |routing| sync.hook(routing),
+                    ));
+
+                    let _ = barrier.wait();
+                    try_revoke(&auth, &app_id)
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = join_handles
+            .into_iter()
+            .map(|handle| unwrap!(handle.join()))
+            .collect();
+
+        // Retry failed revocations sequentially.
+        for (app_id, result) in apps_to_revoke.iter().zip(results) {
+            if result.is_err() {
+                match try_revoke(&auth, app_id) {
+                    Ok(_) | Err(AuthError::IpcError(IpcError::UnknownApp)) => (),
+                    Err(error) => panic!("Unexpected revocation failure: {:?}", error),
+                }
+            }
+        }
+
+        // Check that the first two apps are now revoked, but the other one is not.
+        run(&auth, move |client| {
+            let app_0 = verify_app_is_revoked(client, app_id_0, ac_entries_0);
+            let app_1 = verify_app_is_revoked(client, app_id_1, ac_entries_1);
+            let app_2 = verify_app_is_authenticated(client, app_id_2);
+
+            app_0.join3(app_1, app_2).map(|_| ())
+        });
+    }
+
+    // Try to revoke apps with the given ids, but simulate network failure so they
+    // would be initiated but not finished.
+    fn simulate_revocation_failure<T, S>(locator: &str, password: &str, app_ids: T)
+    where
+        T: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // First, log in normally to obtain the access contained info.
+        let auth = unwrap!(Authenticator::login(locator, password, || ()));
+        let ac_info = run(&auth, |client| Ok(client.access_container()));
+
+        // Then, log in with a request hook that makes mutation of the access container
+        // fail.
+        let auth = unwrap!(Authenticator::login_with_hook(
+            locator,
+            password,
+            || (),
+            move |mut routing| {
+                let ac_info = ac_info.clone();
+
+                routing.set_request_hook(move |request| match *request {
+                    Request::MutateMDataEntries {
+                        name, tag, msg_id, ..
+                    } => {
+                        if name == ac_info.name && tag == ac_info.type_tag {
+                            Some(Response::MutateMDataEntries {
+                                res: Err(ClientError::LowBalance),
+                                msg_id,
+                            })
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                });
+
+                routing
+            },
+        ));
+
+        // Then attempt to revoke each app from the iterator.
+        for app_id in app_ids {
+            match try_revoke(&auth, app_id.as_ref()) {
+                Err(_) => (),
+                x => panic!("Unexpected {:?}", x),
+            }
+        }
+    }
+
+    fn verify_app_is_revoked(
+        client: &AuthClient,
+        app_id: String,
+        prev_ac_entry: AccessContainerEntry,
+    ) -> Box<AuthFuture<()>> {
+        let c0 = client.clone();
+        let c1 = client.clone();
+
+        config::list_apps(client)
+            .then(move |res| {
+                let (_, apps) = unwrap!(res);
+
+                let auth_keys = c0.list_auth_keys_and_version().map_err(AuthError::from);
+                let state = app_state(&c0, &apps, &app_id);
+
+                let app_hash = sha3_256(app_id.as_bytes());
+                let app_key = unwrap!(apps.get(&app_hash)).keys.sign_pk;
+
+                auth_keys
+                    .join(state)
+                    .map(move |((auth_keys, _), state)| (auth_keys, app_key, state))
+            })
+            .then(move |res| -> Result<_, AuthError> {
+                let (auth_keys, app_key, state) = unwrap!(res);
+
+                // Verify the app is no longer authenticated.
+                assert!(!auth_keys.contains(&app_key));
+
+                // Verify its state is `Revoked` (meaning it has no entry in the
+                // access container)
+                assert_match!(state, AppState::Revoked);
+
+                Ok(app_key)
+            })
+            .then(move |res| {
+                let app_key = unwrap!(res);
+                let futures = prev_ac_entry.into_iter().map(move |(_, (mdata_info, _))| {
+                    // Verify the app has no permissions in the containers.
+                    let perms = c1
+                        .list_mdata_user_permissions(
+                            mdata_info.name,
+                            mdata_info.type_tag,
+                            User::Key(app_key),
+                        )
+                        .then(|res| {
+                            assert_match!(
+                                res,
+                                Err(CoreError::RoutingClientError(ClientError::NoSuchKey))
+                            );
+                            Ok(())
+                        });
+
+                    // Verify the app can't decrypt the content of the containers.
+                    let entries = c1
+                        .list_mdata_entries(mdata_info.name, mdata_info.type_tag)
+                        .then(move |res| {
+                            let entries = unwrap!(res);
+                            for (key, value) in entries {
+                                if value.content.is_empty() {
+                                    continue;
+                                }
+
+                                assert_match!(mdata_info.decrypt(&key), Err(_));
+                                assert_match!(mdata_info.decrypt(&value.content), Err(_));
+                            }
+
+                            Ok(())
+                        });
+
+                    perms.join(entries).map(|_| ())
+                });
+
+                future::join_all(futures).map(|_| ())
+            })
+            .into_box()
+    }
+
+    fn verify_app_is_authenticated(client: &AuthClient, app_id: String) -> Box<AuthFuture<()>> {
+        let c0 = client.clone();
+        let c1 = client.clone();
+        let c2 = client.clone();
+
+        config::list_apps(client)
+            .then(move |res| {
+                let (_, mut apps) = unwrap!(res);
+
+                let app_hash = sha3_256(app_id.as_bytes());
+                let app_keys = unwrap!(apps.remove(&app_hash)).keys;
+
+                c0.list_auth_keys_and_version()
+                    .map_err(AuthError::from)
+                    .map(move |(auth_keys, _)| (auth_keys, app_id, app_keys))
+            })
+            .then(move |res| {
+                let (auth_keys, app_id, app_keys) = unwrap!(res);
+                let app_key = app_keys.sign_pk;
+
+                // Verify the app is authenticated.
+                assert!(auth_keys.contains(&app_key));
+
+                // Fetch the access container entry
+                access_container::fetch_entry(&c1, &app_id, app_keys)
+                    .map(move |(_, entry)| (app_key, entry))
+            })
+            .then(move |res| {
+                let (app_key, ac_entry) = unwrap!(res);
+                let user = User::Key(app_key);
+                let ac_entry = unwrap!(ac_entry);
+
+                let futures = ac_entry
+                    .into_iter()
+                    .map(move |(_, (mdata_info, permissions))| {
+                        // Verify the app has the permissions set according to the access container.
+                        let expected_perms = container_perms_into_permission_set(&permissions);
+                        let perms = c2
+                            .list_mdata_user_permissions(mdata_info.name, mdata_info.type_tag, user)
+                            .then(move |res| {
+                                let perms = unwrap!(res);
+                                assert_eq!(perms, expected_perms);
+                                Ok(())
+                            });
+
+                        // Verify the app can decrypt the content of the containers.
+                        let entries = c2
+                            .list_mdata_entries(mdata_info.name, mdata_info.type_tag)
+                            .then(move |res| {
+                                let entries = unwrap!(res);
+                                for (key, value) in entries {
+                                    if value.content.is_empty() {
+                                        continue;
+                                    }
+
+                                    let _ = unwrap!(mdata_info.decrypt(&key));
+                                    let _ = unwrap!(mdata_info.decrypt(&value.content));
+                                }
+
+                                Ok(())
+                            });
+
+                        perms.join(entries).map(|_| ())
+                    });
+
+                future::join_all(futures).map(|_| ())
+            })
+            .into_box()
+    }
+}
+
+// The app revocation and re-authorisation workflow.
+#[test]
+fn app_revocation() {
+    let authenticator = create_account_and_login();
+
+    // Create and authorise two apps.
+    let auth_req1 = AuthReq {
+        app: rand_app(),
+        app_container: false,
+        containers: create_containers_req(),
+    };
+    let app_id1 = auth_req1.app.id.clone();
+    let auth_granted1 = unwrap!(register_app(&authenticator, &auth_req1));
+
+    let auth_req2 = AuthReq {
+        app: rand_app(),
+        app_container: true,
+        containers: create_containers_req(),
+    };
+    let app_id2 = auth_req2.app.id.clone();
+    let auth_granted2 = unwrap!(register_app(&authenticator, &auth_req2));
+
+    // Put one file by each app into a shared container.
+    let mut ac_entries = access_container(&authenticator, app_id1.clone(), auth_granted1.clone());
+    let (videos_md1, _) = unwrap!(ac_entries.remove("_videos"));
+    unwrap!(create_file(
+        &authenticator,
+        videos_md1.clone(),
+        "1.mp4",
+        vec![1; 10],
+    ));
+
+    let mut ac_entries = access_container(&authenticator, app_id2.clone(), auth_granted2.clone());
+    let (videos_md2, _) = unwrap!(ac_entries.remove("_videos"));
+    unwrap!(create_file(
+        &authenticator,
+        videos_md2.clone(),
+        "2.mp4",
+        vec![1; 10],
+    ));
+
+    let app_container_name = app_container_name(&app_id2);
+    let (app_container_md, _) = unwrap!(ac_entries.remove(&app_container_name));
+    unwrap!(create_file(
+        &authenticator,
+        app_container_md.clone(),
+        "3.mp4",
+        vec![1; 10],
+    ));
+
+    // There should be 2 entries.
+    assert_eq!(count_mdata_entries(&authenticator, videos_md1.clone()), 2);
+
+    // Both apps can access both files.
+    let _ = unwrap!(fetch_file(&authenticator, videos_md1.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md1.clone(), "2.mp4"));
+
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "2.mp4"));
+
+    // Revoke the first app.
+    revoke(&authenticator, &app_id1);
+
+    // There should now be 4 entries - 2 deleted previous entries, 2 new,
+    // re-encrypted entries.
+    assert_eq!(count_mdata_entries(&authenticator, videos_md1.clone()), 4);
+
+    // The first app is no longer in the access container.
+    let ac = try_access_container(&authenticator, app_id1.clone(), auth_granted1.clone());
+    assert!(ac.is_none());
+
+    // Container permissions include only the second app.
+    let (name, tag) = (videos_md2.name, videos_md2.type_tag);
+    let perms = run(&authenticator, move |client| {
+        client.list_mdata_permissions(name, tag).map_err(From::from)
+    });
+    assert!(!perms.contains_key(&User::Key(auth_granted1.app_keys.sign_pk)));
+    assert!(perms.contains_key(&User::Key(auth_granted2.app_keys.sign_pk)));
+
+    // The first app can no longer access the files.
+    match fetch_file(&authenticator, videos_md1.clone(), "1.mp4") {
+        Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    match fetch_file(&authenticator, videos_md1.clone(), "2.mp4") {
+        Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    // The second app can still access both files after re-fetching the access container.
+    let mut ac_entries = access_container(&authenticator, app_id2.clone(), auth_granted2.clone());
+    let (videos_md2, _) = unwrap!(ac_entries.remove("_videos"));
+
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "2.mp4"));
+
+    // Re-authorise the first app.
+    let auth_granted1 = unwrap!(register_app(&authenticator, &auth_req1));
+    let mut ac_entries = access_container(&authenticator, app_id1.clone(), auth_granted1.clone());
+    let (videos_md1, _) = unwrap!(ac_entries.remove("_videos"));
+
+    // The first app can access the files again.
+    let _ = unwrap!(fetch_file(&authenticator, videos_md1.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md1.clone(), "2.mp4"));
+
+    // The second app as well.
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "2.mp4"));
+
+    // Revoke the first app again. Only the second app can access the files.
+    revoke(&authenticator, &app_id1);
+
+    // There should now be 6 entries (4 deleted, 2 new).
+    assert_eq!(count_mdata_entries(&authenticator, videos_md1.clone()), 6);
+
+    match fetch_file(&authenticator, videos_md1.clone(), "1.mp4") {
+        Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    match fetch_file(&authenticator, videos_md1.clone(), "2.mp4") {
+        Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    let mut ac_entries = access_container(&authenticator, app_id2.clone(), auth_granted2.clone());
+    let (videos_md2, _) = unwrap!(ac_entries.remove("_videos"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "1.mp4"));
+    let _ = unwrap!(fetch_file(&authenticator, videos_md2.clone(), "2.mp4"));
+
+    // Revoke the second app that has created its own app container.
+    revoke(&authenticator, &app_id2);
+
+    match fetch_file(&authenticator, videos_md2.clone(), "1.mp4") {
+        Err(AuthError::NfsError(NfsError::CoreError(CoreError::EncodeDecodeError(..)))) => (),
+        x => panic!("Unexpected {:?}", x),
+    }
+
+    // Try to reauthorise and revoke the second app again - as it should have reused its
+    // app container, the subsequent reauthorisation + revocation should work correctly too.
+    let auth_granted2 = unwrap!(register_app(&authenticator, &auth_req2));
+
+    // The second app should be able to access data from its own container,
+    let mut ac_entries = access_container(&authenticator, app_id2.clone(), auth_granted2.clone());
+    let (app_container_md, _) = unwrap!(ac_entries.remove(&app_container_name));
+
+    assert_eq!(
+        count_mdata_entries(&authenticator, app_container_md.clone()),
+        2
+    );
+    let _ = unwrap!(fetch_file(
+        &authenticator,
+        app_container_md.clone(),
+        "3.mp4",
+    ));
+
+    revoke(&authenticator, &app_id2);
+}
+
+// Test that corrupting an app's entry before trying to revoke it results in a
+// `SymmetricDecipherFailure` error and immediate return, without revoking more apps.
+#[test]
+fn revocation_symmetric_decipher_failure() {
+    let authenticator = create_account_and_login();
+
+    // Create a containers request for the entry to be corrupted
+    let mut corrupt_containers = HashMap::new();
+    let _ = corrupt_containers.insert(
+        "_downloads".to_owned(),
+        btree_set![Permission::Read, Permission::Insert],
+    );
+
+    // Create and authorise three apps, which we will put on the revocation queue.
+    let auth_req1 = AuthReq {
+        app: rand_app(),
+        app_container: false,
+        containers: create_containers_req(),
+    };
+    let app_id1 = auth_req1.app.id.clone();
+    debug!("Registering app 1 with ID {}...", app_id1);
+    let auth_granted1 = unwrap!(register_app(&authenticator, &auth_req1));
+
+    let auth_req2 = AuthReq {
+        app: rand_app(),
+        app_container: true,
+        containers: corrupt_containers,
+    };
+    let app_id2 = auth_req2.app.id.clone();
+    debug!("Registering app 2 with ID {}...", app_id2);
+    let auth_granted2 = unwrap!(register_app(&authenticator, &auth_req2));
+
+    let auth_req3 = AuthReq {
+        app: rand_app(),
+        app_container: false,
+        containers: create_containers_req(),
+    };
+    let app_id3 = auth_req3.app.id.clone();
+    debug!("Registering app 3 with ID {}...", app_id3);
+    let auth_granted3 = unwrap!(register_app(&authenticator, &auth_req3));
+
+    // Put a file into the _downloads container.
+    let mut ac_entries = access_container(&authenticator, app_id2.clone(), auth_granted2.clone());
+    let (downloads_md, _) = unwrap!(ac_entries.remove("_downloads"));
+
+    unwrap!(create_file(
+        &authenticator,
+        downloads_md.clone(),
+        "video.mp4",
+        vec![1; 10],
+    ));
+
+    // Push apps 1 and 2 to the revocation queue.
+    {
+        let app_id1 = app_id1.clone();
+        let app_id2 = app_id2.clone();
+        let app_id2_clone = app_id2.clone();
+
+        run(&authenticator, move |client| {
+            let c2 = client.clone();
+            let c3 = client.clone();
+            let c4 = client.clone();
+            let c5 = client.clone();
+
+            get_app_revocation_queue(client)
+                .map(move |(version, queue)| {
+                    let _ = push_to_app_revocation_queue(
+                        &c2,
+                        queue,
+                        config::next_version(version),
+                        &app_id1,
+                    );
+                })
+                .and_then(move |_| {
+                    get_app_revocation_queue(&c3).map(move |(version, queue)| {
+                        let _ = push_to_app_revocation_queue(
+                            &c4,
+                            queue,
+                            config::next_version(version),
+                            &app_id2_clone,
+                        );
+                    })
+                })
+                .and_then(move |_| corrupt_container(&c5, "_downloads"))
+        });
+    }
+
+    // Try to revoke app3.
+    match try_revoke(&authenticator, &app_id3) {
+        Ok(_) => panic!("Revocation succeeded with corrupted encryption key!"),
+        Err(AuthError::CoreError(CoreError::SymmetricDecipherFailure)) => (),
+        Err(x) => panic!("An unexpected error occurred: {:?}", x),
+    }
+
+    let queue = run(&authenticator, move |client| {
+        get_app_revocation_queue(client).map(|(_, queue)| queue)
+    });
+
+    // Verify app1 was revoked, app2 is not in the revocation queue,
+    // app3 is still in the revocation queue.
+    let ac = try_access_container(&authenticator, app_id1.clone(), auth_granted1.clone());
+    assert!(ac.is_none());
+    assert!(!queue.contains(&app_id1));
+    assert!(!queue.contains(&app_id2));
+    assert!(queue.contains(&app_id3));
+
+    // Try to revoke app3 again.
+    match try_revoke(&authenticator, &app_id3) {
+        Ok(_) => (),
+        Err(x) => panic!("An unexpected error occurred: {:?}", x),
+    }
+
+    let queue = run(&authenticator, move |client| {
+        get_app_revocation_queue(client).map(|(_, queue)| queue)
+    });
+
+    // Verify app3 was revoked this time.
+    let ac = try_access_container(&authenticator, app_id3.clone(), auth_granted3.clone());
+    assert!(ac.is_none());
+    assert!(!queue.contains(&app_id3));
+}
+
+// Test that flushing app revocation queue that is empty does not cause any
+// mutation requests to be sent and subsequently does not charge the account
+// balance.
+#[test]
+fn flushing_empty_app_revocation_queue_does_not_mutate_network() {
+    // Create account.
+    let (auth, ..) = create_authenticator();
+    let account_info_0 = get_account_info(&auth);
+
+    // There are no apps, so the queue is empty.
+    run(&auth, |client| {
+        revocation::flush_app_revocation_queue(client)
+    });
+
+    let account_info_1 = get_account_info(&auth);
+    assert_eq!(account_info_0, account_info_1);
+
+    // Now create an app and revoke it. Then flush the queue again and observe
+    // the account balance did not change.
+    let auth_req = AuthReq {
+        app: rand_app(),
+        app_container: false,
+        containers: create_containers_req(),
+    };
+    let _ = unwrap!(register_app(&auth, &auth_req));
+    let app_id = auth_req.app.id;
+
+    revoke(&auth, &app_id);
+
+    let account_info_2 = get_account_info(&auth);
+
+    // The queue is empty again.
+    run(&auth, |client| {
+        revocation::flush_app_revocation_queue(client)
+    });
+
+    let account_info_3 = get_account_info(&auth);
+    assert_eq!(account_info_2, account_info_3);
+}
+
+#[test]
+fn revocation_with_unencrypted_container_entries() {
+    let (auth, ..) = create_authenticator();
+
+    let mut containers_req = HashMap::new();
+    let _ = containers_req.insert(
+        "_documents".to_owned(),
+        btree_set![Permission::Read, Permission::Insert,],
+    );
+
+    let (app_id, _) = unwrap!(register_rand_app(&auth, true, containers_req));
+
+    let shared_info = unwrap!(get_container_from_authenticator_entry(&auth, "_documents"));
+    let shared_info2 = shared_info.clone();
+    let shared_key = b"shared-key".to_vec();
+    let shared_content = b"shared-value".to_vec();
+    let shared_actions = EntryActions::new()
+        .ins(shared_key.clone(), shared_content.clone(), 0)
+        .into();
+
+    let dedicated_info = unwrap!(get_container_from_authenticator_entry(
+        &auth,
+        &app_container_name(&app_id),
+    ));
+    let dedicated_info2 = dedicated_info.clone();
+    let dedicated_key = b"dedicated-key".to_vec();
+    let dedicated_content = b"dedicated-value".to_vec();
+    let dedicated_actions = EntryActions::new()
+        .ins(dedicated_key.clone(), dedicated_content.clone(), 0)
+        .into();
+
+    // Insert unencrypted stuff into the shared container and the dedicated container.
+    run(&auth, move |client| {
+        let f0 =
+            client.mutate_mdata_entries(shared_info.name, shared_info.type_tag, shared_actions);
+        let f1 = client.mutate_mdata_entries(
+            dedicated_info.name,
+            dedicated_info.type_tag,
+            dedicated_actions,
+        );
+
+        f0.join(f1).map(|_| ()).map_err(AuthError::from)
+    });
+
+    // Revoke the app.
+    revoke(&auth, &app_id);
+
+    // Verify that the unencrypted entries remain unencrypted after the revocation.
+    run(&auth, move |client| {
+        let f0 = client.get_mdata_value(shared_info2.name, shared_info2.type_tag, shared_key);
+        let f1 = client.get_mdata_value(
+            dedicated_info2.name,
+            dedicated_info2.type_tag,
+            dedicated_key,
+        );
+
+        f0.join(f1).then(move |res| {
+            let (shared_value, dedicated_value) = unwrap!(res);
+            assert_eq!(shared_value.content, shared_content);
+            assert_eq!(dedicated_value.content, dedicated_content);
+
+            Ok(())
+        })
+    })
+}
+
+fn count_mdata_entries(authenticator: &Authenticator, info: MDataInfo) -> usize {
+    run(authenticator, move |client| {
+        client
+            .list_mdata_entries(info.name, info.type_tag)
+            .map(|entries| entries.len())
+            .map_err(From::from)
+    })
+}
+
+fn get_account_info(authenticator: &Authenticator) -> AccountInfo {
+    run(authenticator, |client| {
+        client.get_account_info().map_err(AuthError::from)
+    })
+}

--- a/test_utils.rs
+++ b/test_utils.rs
@@ -1,0 +1,149 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#![allow(unsafe_code)]
+
+use errors::AppError;
+use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, ReprC, FFI_RESULT_OK};
+use safe_core::ffi::ipc::req::AuthReq;
+use safe_core::ipc::req::AuthReq as NativeAuthReq;
+use std::os::raw::{c_char, c_void};
+use test_utils::{create_app_by_req, create_auth_req};
+use App;
+
+/// Creates a random app instance for testing.
+#[no_mangle]
+pub unsafe extern "C" fn test_create_app(
+    app_id: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let app_id = from_c_str(app_id)?;
+        let auth_req = create_auth_req(Some(app_id), None);
+        match create_app_by_req(&auth_req) {
+            Ok(app) => {
+                o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
+            }
+            res @ Err(..) => {
+                call_result_cb!(res, user_data, o_cb);
+            }
+        }
+        Ok(())
+    })
+}
+
+/// Create a random app instance for testing, with access to containers.
+#[no_mangle]
+pub unsafe extern "C" fn test_create_app_with_access(
+    auth_req: *const AuthReq,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, o_app: *mut App),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+        let auth_req = NativeAuthReq::clone_from_repr_c(auth_req)?;
+        match create_app_by_req(&auth_req) {
+            Ok(app) => {
+                o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
+            }
+            res @ Err(..) => {
+                call_result_cb!(res, user_data, o_cb);
+            }
+        }
+        Ok(())
+    })
+}
+
+/// Simulate a network disconnect when testing.
+#[cfg(feature = "use-mock-routing")]
+#[no_mangle]
+pub unsafe extern "C" fn test_simulate_network_disconnect(
+    app: *mut App,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    use ffi::helper::send_sync;
+    use safe_core::Client;
+
+    catch_unwind_cb(user_data, o_cb, || {
+        send_sync(app, user_data, o_cb, |client, _| {
+            client.simulate_network_disconnect();
+            Ok(())
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_create_app_with_access;
+    use ffi_utils::test_utils::call_1;
+    use ffi_utils::ErrorCode;
+    use safe_authenticator::test_utils::rand_app;
+    use safe_core::ipc::req::AuthReq;
+    use safe_core::ipc::Permission;
+    use std::collections::HashMap;
+    use {App, AppError};
+
+    #[test]
+    fn create_app_with_invalid_access() {
+        let mut containers = HashMap::new();
+        let _ = containers.insert("_app".to_owned(), btree_set![Permission::Insert]);
+
+        let auth_req = AuthReq {
+            app: rand_app(),
+            app_container: false,
+            containers,
+        };
+        let auth_req = unwrap!(auth_req.into_repr_c());
+
+        let result: Result<*mut App, i32> =
+            unsafe { call_1(|ud, cb| test_create_app_with_access(&auth_req, ud, cb)) };
+        match result {
+            Err(error) if error == AppError::NoSuchContainer("_app".into()).error_code() => (),
+            x => panic!("Unexpected {:?}", x),
+        }
+    }
+
+    // Test simulating network disconnects.
+    #[cfg(feature = "use-mock-routing")]
+    #[test]
+    fn simulate_network_disconnect() {
+        use super::test_simulate_network_disconnect;
+        use ffi_utils::test_utils::call_0;
+        use safe_authenticator::test_utils as authenticator;
+        use safe_core::utils;
+        use std::sync::mpsc;
+        use std::time::Duration;
+        use test_utils::create_auth_req;
+
+        let app_id = unwrap!(utils::generate_random_string(10));
+        let auth_req = create_auth_req(Some(app_id), None);
+        let auth = authenticator::create_account_and_login();
+        let auth_granted = unwrap!(authenticator::register_app(&auth, &auth_req));
+
+        // Use `sync_channel` as `App::registered` requires `Send`.
+        let (tx, rx) = mpsc::sync_channel::<()>(0);
+
+        let mut app = unwrap!(App::registered(
+            auth_req.app.id.clone(),
+            auth_granted,
+            move || {
+                unwrap!(tx.send(()));
+            },
+        ));
+
+        unsafe {
+            unwrap!(call_0(|ud, cb| test_simulate_network_disconnect(
+                &mut app, ud, cb
+            )));
+        }
+
+        unwrap!(rx.recv_timeout(Duration::from_secs(10)));
+    }
+}

--- a/tests.rs
+++ b/tests.rs
@@ -1,0 +1,604 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use errors::{ERR_ACCESS_DENIED, ERR_INVALID_SUCCESSOR, ERR_NO_SUCH_ENTRY, ERR_NO_SUCH_KEY};
+use ffi::mdata_info::*;
+use ffi::mutable_data::entries::*;
+use ffi::mutable_data::entry_actions::*;
+use ffi::mutable_data::permissions::*;
+use ffi::mutable_data::*;
+use ffi::object_cache::MDataPermissionsHandle;
+use ffi_utils::test_utils::{
+    call_0, call_1, call_vec, call_vec_u8, send_via_user_data, sender_as_user_data,
+};
+use ffi_utils::{vec_clone_from_raw_parts, FfiResult};
+use permissions::UserPermissionSet;
+use routing::{Action, PermissionSet as NativePermissionSet};
+use safe_core::ffi::ipc::req::PermissionSet as FfiPermissionSet;
+use safe_core::ipc::req::{permission_set_clone_from_repr_c, permission_set_into_repr_c};
+use safe_core::ipc::resp::{MDataKey, MDataValue};
+use safe_core::MDataInfo as NativeMDataInfo;
+use std::sync::mpsc;
+use test_utils::create_app;
+
+// The usual test to insert, update, delete and list all permissions from the FFI point of view.
+#[test]
+fn permissions_crud_ffi() {
+    let app = create_app();
+
+    // Create a permissions set
+    let perm_set = NativePermissionSet::new()
+        .allow(Action::Insert)
+        .allow(Action::ManagePermissions);
+
+    // Create permissions
+    let perms_h: MDataPermissionsHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_permissions_new(&app, ud, cb))) };
+
+    {
+        let ffi_perm_set = permission_set_into_repr_c(perm_set);
+        assert!(ffi_perm_set.insert);
+
+        // Create permissions for anyone
+        let len: usize = unsafe {
+            unwrap!(call_0(|ud, cb| mdata_permissions_insert(
+                &app,
+                perms_h,
+                USER_ANYONE,
+                &ffi_perm_set,
+                ud,
+                cb
+            )));
+            unwrap!(call_1(|ud, cb| mdata_permissions_len(
+                &app, perms_h, ud, cb
+            )))
+        };
+        assert_eq!(len, 1);
+
+        let perm_set2: FfiPermissionSet = unsafe {
+            unwrap!(call_1(|ud, cb| mdata_permissions_get(
+                &app,
+                perms_h,
+                USER_ANYONE,
+                ud,
+                cb
+            )))
+        };
+        assert!(perm_set2.insert);
+        let perm_set2 = unwrap!(permission_set_clone_from_repr_c(perm_set2));
+
+        assert_eq!(Some(true), perm_set2.is_allowed(Action::Insert));
+        assert_eq!(None, perm_set2.is_allowed(Action::Update));
+
+        let result: Vec<UserPermissionSet> = unsafe {
+            unwrap!(call_vec(|ud, cb| mdata_list_permission_sets(
+                &app, perms_h, ud, cb
+            )))
+        };
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].user_h, USER_ANYONE);
+        assert_eq!(result[0].perm_set, perm_set);
+    }
+
+    // Try to create an empty public MD
+    let md_info_pub: NativeMDataInfo =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_info_random_public(10_000, ud, cb))) };
+    let md_info_pub = md_info_pub.into_repr_c();
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_put(
+            &app,
+            &md_info_pub,
+            perms_h,
+            ENTRIES_EMPTY,
+            ud,
+            cb
+        )))
+    };
+
+    {
+        let read_perm_set: FfiPermissionSet = unsafe {
+            unwrap!(call_1(|ud, cb| mdata_list_user_permissions(
+                &app,
+                &md_info_pub,
+                USER_ANYONE,
+                ud,
+                cb
+            )))
+        };
+        let read_perm_set = unwrap!(permission_set_clone_from_repr_c(read_perm_set));
+        assert_eq!(Some(true), read_perm_set.is_allowed(Action::Insert));
+        assert_eq!(
+            Some(true),
+            read_perm_set.is_allowed(Action::ManagePermissions)
+        );
+        assert_eq!(None, read_perm_set.is_allowed(Action::Update));
+
+        // Create a new permissions set
+        let perm_set_new = NativePermissionSet::new().allow(Action::ManagePermissions);
+
+        let result = unsafe {
+            // Should fail due to invalid version
+            call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    &md_info_pub,
+                    USER_ANYONE,
+                    &permission_set_into_repr_c(perm_set_new),
+                    0,
+                    ud,
+                    cb,
+                );
+            })
+        };
+
+        match result {
+            Err(ERR_INVALID_SUCCESSOR) => (),
+            _ => panic!("Invalid version specified has succeeded"),
+        };
+
+        let result = unsafe {
+            // Should succeed
+            unwrap!(call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    &md_info_pub,
+                    USER_ANYONE,
+                    &permission_set_into_repr_c(perm_set_new),
+                    1,
+                    ud,
+                    cb,
+                );
+            }));
+
+            // Delete the permission set - should succeed
+            unwrap!(call_0(|ud, cb| {
+                mdata_del_user_permissions(&app, &md_info_pub, USER_ANYONE, 2, ud, cb);
+            }));
+
+            // Try to change permissions - should fail
+            call_0(|ud, cb| {
+                mdata_set_user_permissions(
+                    &app,
+                    &md_info_pub,
+                    USER_ANYONE,
+                    &permission_set_into_repr_c(perm_set_new),
+                    3,
+                    ud,
+                    cb,
+                );
+            })
+        };
+
+        match result {
+            Err(ERR_ACCESS_DENIED) => (),
+            _ => panic!("Changed permissions without permission"),
+        };
+
+        let result: Result<FfiPermissionSet, i32> = unsafe {
+            call_1(|ud, cb| mdata_list_user_permissions(&app, &md_info_pub, USER_ANYONE, ud, cb))
+        };
+
+        match result {
+            Err(ERR_NO_SUCH_KEY) => (),
+            _ => panic!("User permissions listed without key"),
+        }
+    }
+}
+
+//  The usual test to insert, update, delete and list all entry-keys/values from the FFI point of
+//  view.
+#[test]
+fn entries_crud_ffi() {
+    let app = create_app();
+
+    const KEY: &[u8] = b"hello";
+    const VALUE: &[u8] = b"world";
+
+    // Create a permissions set
+    let perm_set = NativePermissionSet::new().allow(Action::Insert);
+
+    // Create permissions
+    let perms_h: MDataPermissionsHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_permissions_new(&app, ud, cb))) };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_permissions_insert(
+            &app,
+            perms_h,
+            USER_ANYONE,
+            &permission_set_into_repr_c(perm_set),
+            ud,
+            cb,
+        )))
+    }
+
+    // Try to create an empty public MD
+    let md_info_pub: NativeMDataInfo =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_info_random_public(10_000, ud, cb))) };
+    let md_info_pub = md_info_pub.into_repr_c();
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_put(
+            &app,
+            &md_info_pub,
+            perms_h,
+            ENTRIES_EMPTY,
+            ud,
+            cb
+        )))
+    };
+
+    // Try to create a MD instance using the same name & type tag - it should fail.
+    let res =
+        unsafe { call_0(|ud, cb| mdata_put(&app, &md_info_pub, perms_h, ENTRIES_EMPTY, ud, cb)) };
+    match res {
+        Err(_) => (),
+        x => panic!("Failed test: unexpected {:?}, expected error", x),
+    }
+
+    // Try to create a MD instance using the same name & a different type tag - it should pass.
+    let xor_name = md_info_pub.name;
+    let md_info_pub_2 = MDataInfo {
+        name: xor_name,
+        type_tag: 10_001,
+        has_enc_info: false,
+        enc_key: Default::default(),
+        enc_nonce: Default::default(),
+        has_new_enc_info: false,
+        new_enc_key: Default::default(),
+        new_enc_nonce: Default::default(),
+    };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_put(
+            &app,
+            &md_info_pub_2,
+            perms_h,
+            ENTRIES_EMPTY,
+            ud,
+            cb
+        )))
+    };
+
+    // Try to add entries to a public MD
+    let actions_h: MDataEntryActionsHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_entry_actions_new(&app, ud, cb))) };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_entry_actions_insert(
+            &app,
+            actions_h,
+            KEY.as_ptr(),
+            KEY.len(),
+            VALUE.as_ptr(),
+            VALUE.len(),
+            ud,
+            cb,
+        )))
+    };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_mutate_entries(
+            &app,
+            &md_info_pub,
+            actions_h,
+            ud,
+            cb
+        )))
+    }
+
+    // Retrieve added entry
+    {
+        let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
+        let mut ud = Default::default();
+
+        unsafe {
+            mdata_get_value(
+                &app,
+                &md_info_pub,
+                KEY.as_ptr(),
+                KEY.len(),
+                sender_as_user_data(&tx, &mut ud),
+                get_value_cb,
+            )
+        };
+
+        let result = unwrap!(rx.recv());
+        assert_eq!(&unwrap!(result), &VALUE, "got back invalid value");
+    }
+
+    // Check the version of a public MD
+    let ver: u64 = unsafe {
+        unwrap!(call_1(|ud, cb| mdata_get_version(
+            &app,
+            &md_info_pub,
+            ud,
+            cb
+        )))
+    };
+    assert_eq!(ver, 0);
+
+    // Check that permissions on the public MD haven't changed
+    let read_perm_set: FfiPermissionSet = unsafe {
+        unwrap!(call_1(|ud, cb| mdata_list_user_permissions(
+            &app,
+            &md_info_pub,
+            USER_ANYONE,
+            ud,
+            cb
+        )))
+    };
+    let read_perm_set = unwrap!(permission_set_clone_from_repr_c(read_perm_set));
+
+    assert_eq!(Some(true), read_perm_set.is_allowed(Action::Insert));
+    assert_eq!(None, read_perm_set.is_allowed(Action::Update));
+
+    // Try to create a private MD
+    let md_info_priv: NativeMDataInfo =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_info_random_private(10_001, ud, cb))) };
+    let md_info_priv = md_info_priv.into_repr_c();
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_put(
+            &app,
+            &md_info_priv,
+            perms_h,
+            ENTRIES_EMPTY,
+            ud,
+            cb
+        )))
+    };
+
+    // Check the version of a private MD
+    let ver: u64 = unsafe {
+        unwrap!(call_1(|ud, cb| mdata_get_version(
+            &app,
+            &md_info_priv,
+            ud,
+            cb
+        )))
+    };
+    assert_eq!(ver, 0);
+
+    // Try to add entries to a private MD
+    let key_enc = unsafe {
+        unwrap!(call_vec_u8(|ud, cb| mdata_info_encrypt_entry_key(
+            &md_info_priv,
+            KEY.as_ptr(),
+            KEY.len(),
+            ud,
+            cb
+        )))
+    };
+    let value_enc = unsafe {
+        unwrap!(call_vec_u8(|ud, cb| mdata_info_encrypt_entry_value(
+            &md_info_priv,
+            VALUE.as_ptr(),
+            VALUE.len(),
+            ud,
+            cb
+        )))
+    };
+
+    let actions_priv_h: MDataEntryActionsHandle =
+        unsafe { unwrap!(call_1(|ud, cb| mdata_entry_actions_new(&app, ud, cb))) };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_entry_actions_insert(
+            &app,
+            actions_priv_h,
+            key_enc.as_ptr(),
+            key_enc.len(),
+            value_enc.as_ptr(),
+            value_enc.len(),
+            ud,
+            cb,
+        )))
+    };
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_mutate_entries(
+            &app,
+            &md_info_priv,
+            actions_priv_h,
+            ud,
+            cb
+        )))
+    }
+
+    // Try to fetch the serialised size of MD
+    {
+        let size: u64 = unsafe {
+            unwrap!(call_1(|ud, cb| mdata_serialised_size(
+                &app,
+                &md_info_priv,
+                ud,
+                cb
+            )))
+        };
+        assert!(size > 0);
+
+        let size: u64 = unsafe {
+            unwrap!(call_1(|ud, cb| mdata_serialised_size(
+                &app,
+                &md_info_pub,
+                ud,
+                cb
+            )))
+        };
+        assert!(size > 0);
+    }
+
+    // Retrieve added entry from private MD
+    {
+        let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
+        let mut ud = Default::default();
+
+        unsafe {
+            mdata_get_value(
+                &app,
+                &md_info_priv,
+                key_enc.as_ptr(),
+                key_enc.len(),
+                sender_as_user_data(&tx, &mut ud),
+                get_value_cb,
+            )
+        };
+
+        let result = unwrap!(rx.recv());
+        let got_value_enc = unwrap!(result);
+        assert_eq!(&got_value_enc, &value_enc, "got back invalid value");
+
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| mdata_info_decrypt(
+                &md_info_priv,
+                got_value_enc.as_ptr(),
+                got_value_enc.len(),
+                ud,
+                cb,
+            )))
+        };
+        assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
+    }
+
+    // Check mdata_entries
+    {
+        let entries_h =
+            unsafe { unwrap!(call_1(|ud, cb| mdata_entries(&app, &md_info_priv, ud, cb))) };
+
+        // Try with a fake entry key, expect error.
+        let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
+        let mut ud = Default::default();
+
+        let fake_key = vec![0];
+        unsafe {
+            mdata_entries_get(
+                &app,
+                entries_h,
+                fake_key.as_ptr(),
+                fake_key.len(),
+                sender_as_user_data(&tx, &mut ud),
+                get_value_cb,
+            )
+        };
+
+        let result = unwrap!(rx.recv());
+        match result {
+            Err(ERR_NO_SUCH_ENTRY) => (),
+            _ => panic!("Got mdata entry with a fake entry key"),
+        };
+
+        // Try with the real encrypted entry key.
+        let (tx, rx) = mpsc::channel::<Result<Vec<u8>, i32>>();
+        let mut ud = Default::default();
+
+        unsafe {
+            mdata_entries_get(
+                &app,
+                entries_h,
+                key_enc.as_ptr(),
+                key_enc.len(),
+                sender_as_user_data(&tx, &mut ud),
+                get_value_cb,
+            )
+        };
+
+        let result = unwrap!(rx.recv());
+        let got_value_enc = unwrap!(result);
+        assert_eq!(&got_value_enc, &value_enc, "got back invalid value");
+
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| mdata_info_decrypt(
+                &md_info_priv,
+                got_value_enc.as_ptr(),
+                got_value_enc.len(),
+                ud,
+                cb,
+            )))
+        };
+        assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
+
+        unsafe { unwrap!(call_0(|ud, cb| mdata_entries_free(&app, entries_h, ud, cb))) }
+    }
+
+    // Check mdata_list_keys
+    {
+        let keys_list: Vec<MDataKey> = unsafe {
+            unwrap!(call_vec(|ud, cb| mdata_list_keys(
+                &app,
+                &md_info_priv,
+                ud,
+                cb
+            )))
+        };
+        assert_eq!(keys_list.len(), 1);
+
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| mdata_info_decrypt(
+                &md_info_priv,
+                keys_list[0].0.as_ptr(),
+                keys_list[0].0.len(),
+                ud,
+                cb,
+            )))
+        };
+        assert_eq!(&decrypted, &KEY, "decrypted invalid key");
+    }
+
+    // Check mdata_list_values
+    {
+        let vals_list: Vec<MDataValue> = unsafe {
+            unwrap!(call_vec(|ud, cb| mdata_list_values(
+                &app,
+                &md_info_priv,
+                ud,
+                cb
+            )))
+        };
+        assert_eq!(vals_list.len(), 1);
+
+        let decrypted = unsafe {
+            unwrap!(call_vec_u8(|ud, cb| mdata_info_decrypt(
+                &md_info_priv,
+                vals_list[0].content.as_ptr(),
+                vals_list[0].content.len(),
+                ud,
+                cb,
+            )))
+        };
+        assert_eq!(&decrypted, &VALUE, "decrypted invalid value");
+    }
+
+    // Free everything.
+    unsafe {
+        unwrap!(call_0(|ud, cb| mdata_permissions_free(
+            &app, perms_h, ud, cb
+        )));
+    }
+
+    extern "C" fn get_value_cb(
+        user_data: *mut c_void,
+        res: *const FfiResult,
+        val: *const u8,
+        len: usize,
+        _version: u64,
+    ) {
+        unsafe {
+            let result: Result<Vec<u8>, i32> = if (*res).error_code == 0 {
+                Ok(vec_clone_from_raw_parts(val, len))
+            } else {
+                Err((*res).error_code)
+            };
+
+            send_via_user_data(user_data, result);
+        }
+    }
+}


### PR DESCRIPTION
There are many instances of ,) in the code, for example:

            let permission_set = *try_cb!(
                permissions
                    .get(&user,)
                    .ok_or(AppError::InvalidSignPubKeyHandle,),
                user_data,
                o_cb
            );
source

It seems like this was introduced in this commit when we ran rustfmt-nightly. Running the latest version of rustfmt Stable doesn't fix this.

The fix is simply to do a search-replace for ,) throughout the project, followed by running cargo fmt for good measure.