### PR TITLE
chore/ci: perform rebuild for windows deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,6 +72,7 @@ test_script:
 before_deploy:
   - PowerShell .\scripts\package.ps1
   - ps: $root = Resolve-Path .\target\deploy; [IO.Directory]::GetFiles($root.Path, '*.zip') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) }
+  - ps: $root = Resolve-Path .\target\deploy; [IO.Directory]::GetFiles($root.Path, '*.tar.gz') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) }
 
 deploy:
   provider: S3
@@ -81,6 +82,6 @@ deploy:
   bucket: safe-client-libs
   region: eu-west-2
   set_public: true
-  artifact: /.*\.zip/
+  artifact: /.*\.zip/,/.*\.tar.gz/
   on:
     branch: master

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -5,16 +5,16 @@ Invoke-WebRequest $url -OutFile "cargo-script.exe"
 New-Item -Path ".\target\deploy" -ItemType directory
 $COMMIT_MESSAGE = "$env:APPVEYOR_REPO_COMMIT_MESSAGE $env:APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED"
 if ($COMMIT_MESSAGE -match "[Vv]ersion change.*safe_authenticator to ([^;]+)") {
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --mock --strip
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --strip
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --mock --strip --rebuild
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --strip --rebuild
 } else {
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --mock --commit --strip
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --commit --strip
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --mock --commit --strip --rebuild
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_app -d target\deploy --commit --strip --rebuild
 }
 if ($COMMIT_MESSAGE -match "[Vv]ersion change.*safe_app to ([^;]+)") {
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --mock --strip
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --strip
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --mock --strip --rebuild
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --strip --rebuild
 } else {
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --mock --commit --strip
-  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --commit --strip
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --mock --commit --strip --rebuild
+  & $cargo_script_path script -- .\scripts\package.rs --lib --name safe_authenticator -d target\deploy --commit --strip --rebuild
 }


### PR DESCRIPTION
This setting was never enabled in the packaging script, so I think these
deployments have been broken for a while, as rebuilding has explicitly
been controlled with a switch I introduced some time ago.

This also extends the deployment to look for any .tar.gz files produced.