### PR TITLE
feat/safe_app: expose run helper

### DIFF
--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -124,6 +124,7 @@ mod tests {
     use ffi::access_container::*;
     use ffi_utils::test_utils::{call_0, call_1, call_vec};
     use ffi_utils::{from_c_str, ReprC};
+    use run;
     use safe_core::ffi::ipc::req::ContainerPermissions as FfiContainerPermissions;
     use safe_core::ipc::req::ContainerPermissions;
     use safe_core::ipc::req::{container_perms_from_repr_c, Permission};
@@ -131,7 +132,7 @@ mod tests {
     use std::collections::HashMap;
     use std::ffi::CString;
     use std::rc::Rc;
-    use test_utils::{create_app_by_req, create_auth_req_with_access, run};
+    use test_utils::{create_app_by_req, create_auth_req_with_access};
 
     // Test refreshing access info by fetching it from the network.
     #[test]
@@ -147,11 +148,11 @@ mod tests {
             container_permissions.clone()
         ),));
 
-        run(&app, move |_client, context| {
+        unwrap!(run(&app, move |_client, context| {
             let reg = Rc::clone(unwrap!(context.as_registered()));
             assert!(reg.access_info.borrow().is_empty());
             Ok(())
-        });
+        }));
 
         unsafe {
             unwrap!(call_0(|ud, cb| access_container_refresh_access_info(
@@ -159,7 +160,7 @@ mod tests {
             ),))
         }
 
-        run(&app, move |_client, context| {
+        unwrap!(run(&app, move |_client, context| {
             let reg = Rc::clone(unwrap!(context.as_registered()));
             assert!(!reg.access_info.borrow().is_empty());
 
@@ -170,7 +171,7 @@ mod tests {
             );
 
             Ok(())
-        });
+        }));
     }
 
     // Test getting info about access containers and their mutable data.

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -233,11 +233,12 @@ mod tests {
     };
     use ffi_utils::vec_clone_from_raw_parts;
     use routing::{Action, PermissionSet, Value};
+    use run;
     use safe_core::ipc::resp::{MDataEntry, MDataKey, MDataValue};
     use safe_core::utils;
     use std::os::raw::c_void;
     use std::sync::mpsc;
-    use test_utils::{create_app, run_now};
+    use test_utils::create_app;
 
     // Test mdata entries operations.
     #[test]
@@ -261,9 +262,9 @@ mod tests {
         let entries = btree_map![key0.clone() => value0.clone(),
                                  key1.clone() => value1.clone()];
 
-        let handle0 = run_now(&app, move |_, context| {
-            context.object_cache().insert_mdata_entries(entries)
-        });
+        let handle0 = unwrap!(run(&app, move |_, context| {
+            Ok(context.object_cache().insert_mdata_entries(entries))
+        }));
 
         let len1: usize =
             unsafe { unwrap!(call_1(|ud, cb| mdata_entries_len(&app, handle0, ud, cb))) };

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -17,11 +17,11 @@ use safe_core::ffi::nfs::File;
 use safe_core::ffi::MDataInfo;
 use safe_core::ipc::Permission;
 use safe_core::nfs::{File as NativeFile, NfsError};
-use std;
 use std::collections::HashMap;
 use std::ffi::CString;
-use test_utils::{create_app_by_req, create_auth_req_with_access, run};
+use test_utils::{create_app_by_req, create_auth_req_with_access};
 use App;
+use {run, std};
 
 fn setup() -> (App, MDataInfo) {
     let mut container_permissions = HashMap::new();
@@ -39,12 +39,12 @@ fn setup() -> (App, MDataInfo) {
         container_permissions
     ),));
 
-    let container_info = run(&app, move |client, context| {
+    let container_info = unwrap!(run(&app, move |client, context| {
         context.get_access_info(client).then(move |res| {
             let mut access_info = unwrap!(res);
             Ok(unwrap!(access_info.remove("_videos")).0)
         })
-    });
+    }));
     let container_info = container_info.into_repr_c();
 
     (app, container_info)

--- a/safe_app/src/test_utils.rs
+++ b/safe_app/src/test_utils.rs
@@ -7,16 +7,13 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{App, AppContext, AppError};
-use client::AppClient;
-use futures::{Future, IntoFuture};
+use super::{App, AppError};
 use safe_authenticator::test_utils as authenticator;
 use safe_authenticator::AuthError;
 use safe_core::ipc::req::{AuthReq as NativeAuthReq, ContainerPermissions};
 use safe_core::ipc::AppExchangeInfo;
-use safe_core::{utils, FutureExt};
+use safe_core::utils;
 use std::collections::HashMap;
-use std::sync::mpsc;
 
 /// Generates an `AppExchangeInfo` structure for a mock application.
 pub fn gen_app_exchange_info() -> AppExchangeInfo {
@@ -26,49 +23,6 @@ pub fn gen_app_exchange_info() -> AppExchangeInfo {
         name: unwrap!(utils::generate_random_string(10)),
         vendor: unwrap!(utils::generate_random_string(10)),
     }
-}
-
-/// Run the given closure inside the app's event loop. The return value of
-/// the closure is returned immediately.
-pub fn run_now<F, R>(app: &App, f: F) -> R
-where
-    F: FnOnce(&AppClient, &AppContext) -> R + Send + 'static,
-    R: Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-
-    unwrap!(app.send(move |client, context| {
-        unwrap!(tx.send(f(client, context)));
-        None
-    }));
-
-    unwrap!(rx.recv())
-}
-
-/// Run the given closure inside the app event loop. The closure should
-/// return a future which will then be driven to completion and its result
-/// returned.
-pub fn run<F, I, T>(app: &App, f: F) -> T
-where
-    F: FnOnce(&AppClient, &AppContext) -> I + Send + 'static,
-    I: IntoFuture<Item = T, Error = AppError> + 'static,
-    T: Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-
-    unwrap!(app.send(move |client, app| {
-        let future = f(client, app)
-            .into_future()
-            .then(move |result| {
-                unwrap!(tx.send(result));
-                Ok(())
-            })
-            .into_box();
-
-        Some(future)
-    }));
-
-    unwrap!(unwrap!(rx.recv()))
 }
 
 /// Create a random app.

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -25,8 +25,8 @@ use safe_core::MockRouting;
 use std::collections::HashMap;
 use std::rc::Rc;
 use test_utils::gen_app_exchange_info;
-use test_utils::{create_app_by_req, create_auth_req, create_auth_req_with_access, run};
-use App;
+use test_utils::{create_app_by_req, create_auth_req, create_auth_req_with_access};
+use {run, App};
 
 // Test refreshing access info by fetching it from the network.
 #[test]
@@ -42,7 +42,7 @@ fn refresh_access_info() {
         container_permissions.clone()
     ),));
 
-    run(&app, move |client, context| {
+    unwrap!(run(&app, move |client, context| {
         let reg = Rc::clone(unwrap!(context.as_registered()));
         assert!(reg.access_info.borrow().is_empty());
 
@@ -56,7 +56,7 @@ fn refresh_access_info() {
 
             Ok(())
         })
-    });
+    }));
 }
 
 // Test fetching containers that an app has access to.
@@ -78,7 +78,7 @@ fn get_access_info() {
         ),))
     };
 
-    run(unsafe { &*app }, move |client, context| {
+    unwrap!(run(unsafe { &*app }, move |client, context| {
         context.get_access_info(client).then(move |res| {
             let info = unwrap!(res);
             assert!(info.contains_key(&"_videos".to_string()));
@@ -93,7 +93,7 @@ fn get_access_info() {
 
             Ok(())
         })
-    });
+    }));
 }
 
 // Make sure we can login to a registered app with low balance.
@@ -192,12 +192,12 @@ fn authorise_app(
 
 // Get the number of containers for `app`
 fn num_containers(app: &App) -> usize {
-    run(app, move |client, context| {
+    unwrap!(run(app, move |client, context| {
         context.get_access_info(client).then(move |res| {
             let info = unwrap!(res);
             Ok(info.len())
         })
-    })
+    }))
 }
 
 // Test app container creation under the following circumstances:

--- a/safe_app/src/tests/mutable_data.rs
+++ b/safe_app/src/tests/mutable_data.rs
@@ -14,13 +14,14 @@ use futures::Future;
 use maidsafe_utilities::thread;
 use rand::{OsRng, Rng};
 use routing::{Action, ClientError, EntryAction, MutableData, PermissionSet, User, Value, XorName};
+use run;
 use rust_sodium::crypto::sign;
 use safe_core::utils::test_utils::random_client;
 use safe_core::{utils, Client, CoreError, FutureExt, DIR_TAG};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::CString;
 use std::sync::mpsc;
-use test_utils::{create_app, run};
+use test_utils::create_app;
 
 // MD created by App. App lists its own sign_pk in owners field: Put should fail - Rejected by
 // MaidManagers. Should pass when it lists the owner's sign_pk instead.
@@ -34,7 +35,7 @@ fn md_created_by_app_1() {
     let app: *mut App =
         unsafe { unwrap!(call_1(|ud, cb| test_create_app(app_id.as_ptr(), ud, cb))) };
 
-    run(unsafe { &*app }, |client: &AppClient, _app_context| {
+    unwrap!(run(unsafe { &*app }, |client: &AppClient, _app_context| {
         let mut rng = unwrap!(OsRng::new());
 
         let owners = btree_set![unwrap!(client.public_signing_key())];
@@ -67,7 +68,7 @@ fn md_created_by_app_1() {
                 cl2.put_mdata(mdata)
             })
             .map_err(|e| panic!("{:?}", e))
-    });
+    }));
 }
 
 // MD created by App properly: Should pass. App tries to change ownership - Should Fail by
@@ -536,7 +537,7 @@ fn multiple_apps() {
 #[test]
 fn permissions_and_version() {
     let app = create_app();
-    run(&app, |client: &AppClient, _app_context| {
+    unwrap!(run(&app, |client: &AppClient, _app_context| {
         let mut rng = unwrap!(OsRng::new());
         let sign_pk = unwrap!(client.public_signing_key());
         let (random_key, _) = sign::gen_keypair();
@@ -652,7 +653,7 @@ fn permissions_and_version() {
                 );
             })
             .map_err(|e| panic!("{:?}", e))
-    });
+    }));
 }
 
 // The usual test to insert, update, delete and list all permissions. Put in some permissions, fetch
@@ -662,7 +663,7 @@ fn permissions_and_version() {
 #[test]
 fn permissions_crud() {
     let app = create_app();
-    run(&app, |client: &AppClient, _app_context| {
+    unwrap!(run(&app, |client: &AppClient, _app_context| {
         let mut rng = unwrap!(OsRng::new());
         let sign_pk = unwrap!(client.public_signing_key());
         let (random_key_a, _) = sign::gen_keypair();
@@ -954,7 +955,7 @@ fn permissions_crud() {
                 Ok(())
             })
             .map_err(|e| panic!("{:?}", e))
-    });
+    }));
 }
 
 // The usual test to insert, update, delete and list all entry-keys/values. Same thing from
@@ -964,7 +965,7 @@ fn permissions_crud() {
 #[test]
 fn entries_crud() {
     let app = create_app();
-    run(&app, |client: &AppClient, _app_context| {
+    unwrap!(run(&app, |client: &AppClient, _app_context| {
         let mut rng = unwrap!(OsRng::new());
         let sign_pk = unwrap!(client.public_signing_key());
 
@@ -1109,5 +1110,5 @@ fn entries_crud() {
                 Ok(())
             })
             .map_err(|e| panic!("{:?}", e))
-    });
+    }));
 }

--- a/safe_authenticator/src/std_dirs.rs
+++ b/safe_authenticator/src/std_dirs.rs
@@ -162,14 +162,15 @@ pub fn create_std_dirs(
 mod tests {
     use super::*;
     use futures::Future;
-    use test_utils::{create_account_and_login, run};
+    use run;
+    use test_utils::create_account_and_login;
 
     // Test creation of default dirs.
     #[test]
     fn creates_default_dirs() {
         let auth = create_account_and_login();
 
-        run(&auth, |client| {
+        unwrap!(run(&auth, |client| {
             let client = client.clone();
 
             create_std_dirs(
@@ -201,6 +202,6 @@ mod tests {
 
                 Ok(())
             })
-        });
+        }));
     }
 }

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -14,6 +14,7 @@ use futures::Future;
 use maidsafe_utilities::serialisation::serialise;
 use rand;
 use routing::{Action, MutableData, PermissionSet, User, Value};
+use run;
 use rust_sodium::crypto::sign;
 use safe_core::ipc::req::AppExchangeInfo;
 use safe_core::ipc::resp::{AppAccess, UserMetadata, METADATA_KEY};
@@ -60,9 +61,9 @@ fn share_zero_mdatas() {
 fn share_some_mdatas() {
     let authenticator = test_utils::create_account_and_login();
 
-    let user = test_utils::run(&authenticator, move |client| {
+    let user = unwrap!(run(&authenticator, move |client| {
         ok!(unwrap!(client.public_signing_key()))
-    });
+    }));
 
     const NUM_MDATAS: usize = 3;
 
@@ -83,9 +84,9 @@ fn share_some_mdatas() {
             ))
         };
 
-        test_utils::run(&authenticator, move |client| {
+        unwrap!(run(&authenticator, move |client| {
             client.put_mdata(mdata).map_err(AuthError::CoreError)
-        });
+        }));
 
         mdatas.push(ShareMData {
             type_tag: tag,
@@ -172,9 +173,9 @@ fn share_some_mdatas_with_valid_metadata() {
     let app_auth = unwrap!(test_utils::register_app(&authenticator, &auth_req));
     let app_key = app_auth.app_keys.sign_pk;
 
-    let user = test_utils::run(&authenticator, move |client| {
+    let user = unwrap!(run(&authenticator, move |client| {
         ok!(unwrap!(client.public_signing_key()))
-    });
+    }));
 
     const NUM_MDATAS: usize = 3;
 
@@ -205,9 +206,9 @@ fn share_some_mdatas_with_valid_metadata() {
             ))
         };
 
-        test_utils::run(&authenticator, move |client| {
+        unwrap!(run(&authenticator, move |client| {
             client.put_mdata(mdata).map_err(AuthError::CoreError)
-        });
+        }));
 
         mdatas.push(ShareMData {
             type_tag: tag,
@@ -262,11 +263,11 @@ fn share_some_mdatas_with_valid_metadata() {
     for share_mdata in &mdatas {
         let name = share_mdata.name;
         let type_tag = share_mdata.type_tag;
-        let mdata = test_utils::run(&authenticator, move |client| {
+        let mdata = unwrap!(run(&authenticator, move |client| {
             client
                 .get_mdata(name, type_tag)
                 .map_err(AuthError::CoreError)
-        });
+        }));
         let permissions = unwrap!(mdata.user_permissions(&User::Key(app_key)));
         assert_eq!(permissions, &perms);
     }
@@ -277,9 +278,9 @@ fn share_some_mdatas_with_valid_metadata() {
 fn share_some_mdatas_with_ownership_error() {
     let authenticator = test_utils::create_account_and_login();
 
-    let user = test_utils::run(&authenticator, move |client| {
+    let user = unwrap!(run(&authenticator, move |client| {
         ok!(unwrap!(client.public_signing_key()))
-    });
+    }));
 
     let (someone_else, _) = sign::gen_keypair();
 
@@ -303,9 +304,9 @@ fn share_some_mdatas_with_ownership_error() {
             ))
         };
 
-        test_utils::run(&authenticator, move |client| {
+        unwrap!(run(&authenticator, move |client| {
             client.put_mdata(mdata).map_err(AuthError::CoreError)
-        });
+        }));
 
         mdatas.push(ShareMData {
             type_tag: 0,
@@ -373,9 +374,9 @@ fn share_some_mdatas_with_ownership_error() {
 fn auth_apps_accessing_mdatas() {
     let authenticator = test_utils::create_account_and_login();
 
-    let user = test_utils::run(&authenticator, move |client| {
+    let user = unwrap!(run(&authenticator, move |client| {
         ok!(unwrap!(client.public_signing_key()))
-    });
+    }));
 
     const NUM_MDATAS: usize = 3;
     const NUM_MDATAS_NO_META: usize = 3;
@@ -423,9 +424,9 @@ fn auth_apps_accessing_mdatas() {
             ))
         };
 
-        test_utils::run(&authenticator, move |client| {
+        unwrap!(run(&authenticator, move |client| {
             client.put_mdata(mdata).map_err(AuthError::CoreError)
-        });
+        }));
 
         mdatas.push(ShareMData {
             type_tag: tag,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -76,8 +76,7 @@ extern crate unwrap;
 mod real_network;
 
 use futures::future::Future;
-use safe_app::test_utils::run_now;
-use safe_app::{App, Client, ImmutableData};
+use safe_app::{run, App, Client, ImmutableData};
 use safe_core::utils;
 use safe_core::utils::test_utils::random_client;
 
@@ -96,9 +95,10 @@ fn unregistered_client() {
 
     // Unregistered Client should be able to retrieve the data.
     let app = unwrap!(App::unregistered(|| (), None));
-    run_now(&app, move |client, _context| {
+    unwrap!(run(&app, move |client, _context| {
         let _ = client.get_idata(*orig_data.name()).map(move |data| {
             assert_eq!(data, orig_data);
         });
-    });
+        Ok(())
+    }));
 }


### PR DESCRIPTION
- expose run helper function to execute futures by blocking the thread until the result arrives
- refactor the existing run helper in test_utils to call this function

closes #776 
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
