### PR TITLE
refactor/ffi: rework MDataKey and MDataValue to use FFI conventions

### DIFF
--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -152,7 +152,7 @@ impl AppClient {
 }
 
 impl Client for AppClient {
-    type MsgType = AppContext;
+    type Context = AppContext;
 
     fn full_id(&self) -> Option<FullId> {
         let app_inner = self.app_inner.borrow();
@@ -169,7 +169,7 @@ impl Client for AppClient {
         app_inner.cm_addr
     }
 
-    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::MsgType>>> {
+    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::Context>>> {
         self.inner.clone()
     }
 

--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -256,10 +256,11 @@ pub unsafe extern "C" fn mdata_list_keys(
                 .then(move |result| {
                     match result {
                         Ok(keys) => {
-                            let keys: Vec<_> =
-                                keys.into_iter().map(NativeMDataKey::from_routing).collect();
-                            let repr_c: Vec<_> =
-                                keys.iter().map(NativeMDataKey::as_repr_c).collect();
+                            let repr_c: Vec<_> = keys
+                                .into_iter()
+                                .map(|vec| NativeMDataKey::from_bytes(&vec))
+                                .map(NativeMDataKey::into_repr_c)
+                                .collect();
 
                             o_cb(
                                 user_data.0,
@@ -305,12 +306,11 @@ pub unsafe extern "C" fn mdata_list_values(
                 .then(move |result| {
                     match result {
                         Ok(values) => {
-                            let values: Vec<_> = values
+                            let repr_c: Vec<_> = values
                                 .into_iter()
                                 .map(NativeMDataValue::from_routing)
+                                .map(NativeMDataValue::into_repr_c)
                                 .collect();
-                            let repr_c: Vec<_> =
-                                values.iter().map(NativeMDataValue::as_repr_c).collect();
 
                             o_cb(
                                 user_data.0,

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -469,7 +469,7 @@ where {
 }
 
 impl Client for AuthClient {
-    type MsgType = ();
+    type Context = ();
 
     fn full_id(&self) -> Option<FullId> {
         let auth_inner = self.auth_inner.borrow();
@@ -485,7 +485,7 @@ impl Client for AuthClient {
         Some(auth_inner.cm_addr)
     }
 
-    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::MsgType>>> {
+    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::Context>>> {
         self.inner.clone()
     }
 

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -22,17 +22,16 @@ use safe_core::ipc::resp::AppAccess as NativeAppAccess;
 use safe_core::FutureExt;
 use std::os::raw::{c_char, c_void};
 
-/// Application registered in the authenticator
+/// Application registered in the authenticator.
 #[repr(C)]
 pub struct RegisteredApp {
-    /// Unique application identifier
+    /// Unique application identifier.
     pub app_info: AppExchangeInfo,
-    /// List of containers that this application has access to
+    /// List of containers that this application has access to.
     pub containers: *const ContainerPermissions,
-    /// Length of the containers array
+    /// Length of the containers array.
     pub containers_len: usize,
-    /// Capacity of the containers array. Internal data required
-    /// for the Rust allocator.
+    /// Capacity of the containers array. Internal data required for the Rust allocator.
     pub containers_cap: usize,
 }
 

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -91,7 +91,7 @@ pub fn create_account_and_login() -> Authenticator {
     unwrap!(Authenticator::login(locator, password, || ()))
 }
 
-/// Revoke an app, returning an error on failure
+/// Revoke an app, returning an error on failure.
 pub fn try_revoke(authenticator: &Authenticator, app_id: &str) -> Result<(), AuthError> {
     let app_id = app_id.to_string();
 
@@ -100,7 +100,7 @@ pub fn try_revoke(authenticator: &Authenticator, app_id: &str) -> Result<(), Aut
     })
 }
 
-/// Revoke an app, panicking on failure
+/// Revoke an app, panicking on failure.
 pub fn revoke(authenticator: &Authenticator, app_id: &str) {
     match try_revoke(authenticator, app_id) {
         Ok(_) => (),
@@ -124,7 +124,7 @@ where
     ))
 }
 
-/// Returns `AppInfo` iff the app is listed in the authenticator config.
+/// Return `AppInfo` iff the app is listed in the authenticator config.
 pub fn get_app_or_err(
     authenticator: &Authenticator,
     app_id: &str,
@@ -136,7 +136,7 @@ pub fn get_app_or_err(
     })
 }
 
-/// Registers a mock application using a given `AuthReq`.
+/// Register a mock application using a given `AuthReq`.
 pub fn register_app(
     authenticator: &Authenticator,
     auth_req: &AuthReq,

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -183,7 +183,7 @@ impl CoreClient {
 }
 
 impl Client for CoreClient {
-    type MsgType = ();
+    type Context = ();
 
     fn full_id(&self) -> Option<FullId> {
         None
@@ -197,7 +197,7 @@ impl Client for CoreClient {
         Some(self.cm_addr)
     }
 
-    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::MsgType>>> {
+    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::Context>>> {
         self.inner.clone()
     }
 

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -77,8 +77,8 @@ pub fn unlimited_muts(config: &Config) -> bool {
     }
 }
 
-/// Mock routing implementation that mirrors the behaviour
-/// of the real network but is not connected to it
+/// Mock routing implementation that mirrors the behaviour of the real network but is not connected
+/// to it.
 pub struct Routing {
     vault: Arc<Mutex<Vault>>,
     sender: Sender<Event>,
@@ -91,8 +91,7 @@ pub struct Routing {
 }
 
 impl Routing {
-    /// Initialises mock routing.
-    /// The function signature mirrors `routing::Client`.
+    /// Initialise mock routing. The function signature mirrors `routing::Client`.
     pub fn new(
         sender: Sender<Event>,
         id: Option<FullId>,
@@ -430,7 +429,7 @@ impl Routing {
         )
     }
 
-    /// Fetches a list of values in MutableData.
+    /// Fetch a list of values in MutableData.
     pub fn list_mdata_values(
         &mut self,
         dst: Authority<XorName>,
@@ -453,7 +452,7 @@ impl Routing {
         )
     }
 
-    /// Fetches a single value from MutableData
+    /// Fetch a single value from MutableData.
     pub fn get_mdata_value(
         &mut self,
         dst: Authority<XorName>,
@@ -556,8 +555,7 @@ impl Routing {
         )
     }
 
-    /// Updates or inserts a list of permissions for a particular User in the given
-    /// MutableData.
+    /// Update or insert a list of permissions for a particular User in the given MutableData.
     pub fn set_mdata_user_permissions(
         &mut self,
         dst: Authority<XorName>,
@@ -690,7 +688,7 @@ impl Routing {
         )
     }
 
-    /// Fetches a list of authorised keys and version in MaidManager
+    /// Fetch a list of authorised keys and version in MaidManager.
     pub fn list_auth_keys_and_version(
         &mut self,
         dst: Authority<XorName>,
@@ -734,7 +732,7 @@ impl Routing {
         Ok(())
     }
 
-    /// Adds a new authorised key to MaidManager
+    /// Add a new authorised key to MaidManager.
     pub fn ins_auth_key(
         &mut self,
         dst: Authority<XorName>,
@@ -780,7 +778,7 @@ impl Routing {
         Ok(())
     }
 
-    /// Removes an authorised key from MaidManager
+    /// Remove an authorised key from MaidManager.
     pub fn del_auth_key(
         &mut self,
         dst: Authority<XorName>,
@@ -1023,7 +1021,7 @@ impl Routing {
         Ok(BootstrapConfig::default())
     }
 
-    /// Returns the config settings.
+    /// Return the config settings.
     pub fn config(&self) -> Config {
         let vault = self.lock_vault(false);
         vault.config()

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -96,7 +96,7 @@ pub fn bootstrap_config() -> Result<BootstrapConfig, CoreError> {
 /// abstraction from the futures-rs crate.
 pub trait Client: Clone + 'static {
     /// Associated message type.
-    type MsgType;
+    type Context;
 
     /// Return the client's ID.
     fn full_id(&self) -> Option<FullId>;
@@ -109,7 +109,7 @@ pub trait Client: Clone + 'static {
 
     /// Return an associated `ClientInner` type which is expected to contain fields associated with
     /// the implementing type.
-    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::MsgType>>>;
+    fn inner(&self) -> Rc<RefCell<ClientInner<Self, Self::Context>>>;
 
     /// Return the public encryption key.
     fn public_encryption_key(&self) -> Option<box_::PublicKey>;

--- a/safe_core/src/client/routing_event_loop.rs
+++ b/safe_core/src/client/routing_event_loop.rs
@@ -49,6 +49,7 @@ pub fn run<C: Client, T>(
     }
 }
 
+// Translate a Routing response to a (MessageId, CoreEvent).
 fn get_core_event(res: Response) -> Result<(MessageId, CoreEvent), CoreError> {
     Ok(match res {
         Response::ChangeMDataOwner { res, msg_id }

--- a/safe_core/src/ffi/ipc/req.rs
+++ b/safe_core/src/ffi/ipc/req.rs
@@ -98,23 +98,21 @@ impl Drop for ContainerPermissions {
     }
 }
 
-/// Represents an authorisation request
+/// Represents an authorisation request.
 #[repr(C)]
 pub struct AuthReq {
-    /// The application identifier for this request
+    /// The application identifier for this request.
     pub app: AppExchangeInfo,
-    /// `true` if the app wants dedicated container for itself. `false`
-    /// otherwise.
+    /// `true` if the app wants dedicated container for itself. `false` otherwise.
     pub app_container: bool,
 
-    /// Array of `ContainerPermissions`
+    /// Array of `ContainerPermissions`.
     pub containers: *const ContainerPermissions,
 
-    /// Size of container permissions array
+    /// Size of container permissions array.
     pub containers_len: usize,
 
-    /// Capacity of container permissions array. Internal field
-    /// required for the Rust allocator.
+    /// Capacity of container permissions array. Internal field required for the Rust allocator.
     pub containers_cap: usize,
 }
 
@@ -134,14 +132,13 @@ impl Drop for AuthReq {
 /// Containers request.
 #[repr(C)]
 pub struct ContainersReq {
-    /// Exchange info
+    /// Exchange info.
     pub app: AppExchangeInfo,
-    /// Requested containers
+    /// Requested containers.
     pub containers: *const ContainerPermissions,
-    /// Size of requested containers array
+    /// Size of requested containers array.
     pub containers_len: usize,
-    /// Capacity of requested containers array. Internal field
-    /// required for the Rust allocator.
+    /// Capacity of requested containers array. Internal field required for the Rust allocator.
     pub containers_cap: usize,
 }
 

--- a/safe_core/src/ffi/ipc/resp.rs
+++ b/safe_core/src/ffi/ipc/resp.rs
@@ -100,7 +100,7 @@ pub struct AuthGranted {
     pub access_container_entry: AccessContainerEntry,
 
     /// Crust's bootstrap config
-    pub bootstrap_config: *mut u8,
+    pub bootstrap_config: *const u8,
     /// `bootstrap_config`'s length
     pub bootstrap_config_len: usize,
     /// Used by Rust memory allocator
@@ -111,7 +111,7 @@ impl Drop for AuthGranted {
     fn drop(&mut self) {
         unsafe {
             let _ = Vec::from_raw_parts(
-                self.bootstrap_config,
+                self.bootstrap_config as *mut u8,
                 self.bootstrap_config_len,
                 self.bootstrap_config_cap,
             );
@@ -197,22 +197,43 @@ impl Drop for MetadataResponse {
 #[repr(C)]
 #[derive(Debug)]
 pub struct MDataKey {
-    /// Key value pointer.
+    /// Pointer to the key.
     pub key: *const u8,
-    /// Key length.
+    /// Size of the key.
     pub key_len: usize,
+    /// Capacity of the key. Internal field required for the Rust allocator.
+    pub key_cap: usize,
+}
+
+impl Drop for MDataKey {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        let _ = unsafe { Vec::from_raw_parts(self.key as *mut u8, self.key_len, self.key_cap) };
+    }
 }
 
 /// Represents the FFI-safe mutable data value.
 #[repr(C)]
 #[derive(Debug)]
 pub struct MDataValue {
-    /// Content pointer.
+    /// Pointer to the content.
     pub content: *const u8,
-    /// Content length.
+    /// Size of the content.
     pub content_len: usize,
+    /// Capacity of the content. Internal field required for the Rust allocator.
+    pub content_cap: usize,
+
     /// Entry version.
     pub entry_version: u64,
+}
+
+impl Drop for MDataValue {
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        let _ = unsafe {
+            Vec::from_raw_parts(self.content as *mut u8, self.content_len, self.content_cap)
+        };
+    }
 }
 
 /// Represents an FFI-safe mutable data (key, value) entry.

--- a/safe_core/src/ffi/mod.rs
+++ b/safe_core/src/ffi/mod.rs
@@ -52,8 +52,7 @@ pub struct MDataInfo {
     /// Type tag of the mutable data.
     pub type_tag: u64,
 
-    /// Flag indicating whether the encryption info (`enc_key` and `enc_nonce`).
-    /// is set.
+    /// Flag indicating whether the encryption info (`enc_key` and `enc_nonce`) is set.
     pub has_enc_info: bool,
     /// Encryption key. Meaningful only if `has_enc_info` is `true`.
     pub enc_key: SymSecretKey,

--- a/safe_core/src/ffi/nfs.rs
+++ b/safe_core/src/ffi/nfs.rs
@@ -22,10 +22,10 @@ pub struct File {
     /// Modification time (nanoseconds part).
     pub modified_nsec: u32,
     /// Pointer to the user metadata.
-    pub user_metadata_ptr: *mut u8,
+    pub user_metadata: *const u8,
     /// Size of the user metadata.
     pub user_metadata_len: usize,
-    /// Capacity of the user metadata (internal field).
+    /// Capacity of user metadata. Internal field required for the Rust allocator.
     pub user_metadata_cap: usize,
     /// Name of the `ImmutableData` containing the content of this file.
     pub data_map_name: XorNameArray,
@@ -36,7 +36,7 @@ impl Drop for File {
     fn drop(&mut self) {
         let _ = unsafe {
             Vec::from_raw_parts(
-                self.user_metadata_ptr,
+                self.user_metadata as *mut u8,
                 self.user_metadata_len,
                 self.user_metadata_cap,
             )

--- a/safe_core/src/ipc/resp.rs
+++ b/safe_core/src/ipc/resp.rs
@@ -432,6 +432,43 @@ impl ReprC for UserMetadata {
     }
 }
 
+/// Mutable data key.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub struct MDataKey(
+    /// Key value.
+    pub Vec<u8>,
+);
+
+impl MDataKey {
+    /// Create the key from bytes.
+    pub fn from_bytes(key: &[u8]) -> Self {
+        MDataKey(key.into())
+    }
+
+    /// Construct FFI wrapper for the native Rust object, consuming self.
+    pub fn into_repr_c(self) -> ffi::MDataKey {
+        let (key, key_len, key_cap) = vec_into_raw_parts(self.0);
+
+        ffi::MDataKey {
+            key,
+            key_len,
+            key_cap,
+        }
+    }
+}
+
+impl ReprC for MDataKey {
+    type C = *const ffi::MDataKey;
+    type Error = ();
+
+    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
+        let ffi::MDataKey { key, key_len, .. } = *repr_c;
+        let key = slice::from_raw_parts(key, key_len).to_vec();
+
+        Ok(MDataKey(key))
+    }
+}
+
 /// Redefine the Value from routing so that we can `impl ReprC`.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
 pub struct MDataValue {
@@ -444,17 +481,20 @@ pub struct MDataValue {
 impl MDataValue {
     /// Convert routing representation to `MDataValue`.
     pub fn from_routing(value: Value) -> Self {
-        MDataValue {
+        Self {
             content: value.content,
             entry_version: value.entry_version,
         }
     }
 
     /// Returns FFI counterpart without consuming the object.
-    pub fn as_repr_c(&self) -> ffi::MDataValue {
+    pub fn into_repr_c(self) -> ffi::MDataValue {
+        let (content, content_len, content_cap) = vec_into_raw_parts(self.content);
+
         ffi::MDataValue {
-            content: self.content.as_ptr(),
-            content_len: self.content.len(),
+            content,
+            content_len,
+            content_cap,
             entry_version: self.entry_version,
         }
     }
@@ -469,45 +509,14 @@ impl ReprC for MDataValue {
             content,
             content_len,
             entry_version,
+            ..
         } = *repr_c;
+        let content = slice::from_raw_parts(content, content_len).to_vec();
 
         Ok(Self {
-            content: slice::from_raw_parts(content, content_len).to_vec(),
+            content,
             entry_version,
         })
-    }
-}
-
-/// Mutable data key.
-#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
-pub struct MDataKey(
-    /// Key value.
-    pub Vec<u8>,
-);
-
-impl MDataKey {
-    /// Convert routing representation to `MDataKey`.
-    pub fn from_routing(key: Vec<u8>) -> Self {
-        MDataKey(key)
-    }
-
-    /// Returns FFI counterpart without consuming the object.
-    pub fn as_repr_c(&self) -> ffi::MDataKey {
-        ffi::MDataKey {
-            key: self.0.as_ptr(),
-            key_len: self.0.len(),
-        }
-    }
-}
-
-impl ReprC for MDataKey {
-    type C = *const ffi::MDataKey;
-    type Error = ();
-
-    unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
-        let ffi::MDataKey { key, key_len } = *repr_c;
-
-        Ok(MDataKey(slice::from_raw_parts(key, key_len).to_vec()))
     }
 }
 
@@ -521,11 +530,11 @@ pub struct MDataEntry {
 }
 
 impl MDataEntry {
-    /// Returns FFI counterpart without consuming the object.
-    pub fn as_repr_c(&self) -> ffi::MDataEntry {
+    /// Construct FFI wrapper for the native Rust object, consuming self.
+    pub fn into_repr_c(self) -> ffi::MDataEntry {
         ffi::MDataEntry {
-            key: self.key.as_repr_c(),
-            value: self.value.as_repr_c(),
+            key: self.key.into_repr_c(),
+            value: self.value.into_repr_c(),
         }
     }
 }

--- a/safe_core/src/nfs/file.rs
+++ b/safe_core/src/nfs/file.rs
@@ -40,7 +40,7 @@ impl File {
     pub fn into_repr_c(self) -> FfiFile {
         // TODO: move the metadata, not clone.
         let user_metadata = self.user_metadata().to_vec();
-        let (user_metadata_ptr, user_metadata_len, user_metadata_cap) =
+        let (user_metadata, user_metadata_len, user_metadata_cap) =
             vec_into_raw_parts(user_metadata);
 
         FfiFile {
@@ -49,7 +49,7 @@ impl File {
             created_nsec: self.created_time().timestamp_subsec_nanos(),
             modified_sec: self.modified_time().timestamp(),
             modified_nsec: self.modified_time().timestamp_subsec_nanos(),
-            user_metadata_ptr,
+            user_metadata,
             user_metadata_len,
             user_metadata_cap,
             data_map_name: self.data_map_name().0,
@@ -114,8 +114,7 @@ impl ReprC for File {
     #[allow(unsafe_code)]
     unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
         let user_metadata =
-            slice::from_raw_parts((*repr_c).user_metadata_ptr, (*repr_c).user_metadata_len)
-                .to_vec();
+            slice::from_raw_parts((*repr_c).user_metadata, (*repr_c).user_metadata_len).to_vec();
 
         let created = convert_date_time((*repr_c).created_sec, (*repr_c).created_nsec)?;
         let modified = convert_date_time((*repr_c).modified_sec, (*repr_c).modified_nsec)?;


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->

Also:

+ make miscellaneous doc fixes
+ clean up FFI documentation

Closes #770 