### PR TITLE
refactor/feature: rename the `use-mock-routing` feature to `mock-network`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,9 +65,9 @@ after_build:
 
 test_script:
   - |-
-    cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml
-    cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml
-    cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml
+    cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+    cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+    cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
 
 before_deploy:
   - PowerShell .\scripts\package.ps1

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -54,7 +54,7 @@ safe_bindgen = "~0.12.0"
 unwrap = "~1.2.0"
 
 [features]
-use-mock-routing = ["testing", "safe_core/use-mock-routing", "safe_authenticator/use-mock-routing"]
+mock-network = ["testing", "safe_core/mock-network", "safe_authenticator/mock-network"]
 testing = ["safe_core/testing", "safe_authenticator/testing"]
 bindings = []
 

--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(not(feature = "use-mock-routing"))]
+#[cfg(not(feature = "mock-network"))]
 use routing::Client as Routing;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting as Routing;
 
 use crate::errors::AppError;
@@ -83,8 +83,8 @@ impl AppClient {
 
     /// Allows customising the mock Routing client before logging in using client keys.
     #[cfg(any(
-        all(test, feature = "use-mock-routing"),
-        all(feature = "testing", feature = "use-mock-routing")
+        all(test, feature = "mock-network"),
+        all(feature = "testing", feature = "mock-network")
     ))]
     pub(crate) fn from_keys_with_hook<F>(
         keys: ClientKeys,

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -249,5 +249,5 @@ pub unsafe extern "C" fn app_container_name(
 /// Returns true if this crate was compiled against mock-routing.
 #[no_mangle]
 pub extern "C" fn app_is_mock() -> bool {
-    cfg!(feature = "use-mock-routing")
+    cfg!(feature = "mock-network")
 }

--- a/safe_app/src/ffi/test_utils.rs
+++ b/safe_app/src/ffi/test_utils.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn test_create_app_with_access(
 }
 
 /// Simulate a network disconnect when testing.
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 #[no_mangle]
 pub unsafe extern "C" fn test_simulate_network_disconnect(
     app: *mut App,
@@ -111,7 +111,7 @@ mod tests {
     }
 
     // Test simulating network disconnects.
-    #[cfg(feature = "use-mock-routing")]
+    #[cfg(feature = "mock-network")]
     #[test]
     fn simulate_network_disconnect() {
         use super::test_simulate_network_disconnect;

--- a/safe_app/src/ffi/tests/mod.rs
+++ b/safe_app/src/ffi/tests/mod.rs
@@ -45,14 +45,14 @@ fn create_containers_req() -> HashMap<String, ContainerPermissions> {
 }
 // Test mock detection when compiled against mock-routing.
 #[test]
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 fn test_mock_build() {
     assert_eq!(app_is_mock(), true);
 }
 
 // Test mock detection when not compiled against mock-routing.
 #[test]
-#[cfg(not(feature = "use-mock-routing"))]
+#[cfg(not(feature = "mock-network"))]
 fn test_not_mock_build() {
     assert_eq!(app_is_mock(), false);
 }
@@ -86,7 +86,7 @@ fn account_info() {
 }
 
 // Test disconnection and reconnection with apps.
-#[cfg(all(test, feature = "use-mock-routing"))]
+#[cfg(all(test, feature = "mock-network"))]
 #[test]
 fn network_status_callback() {
     use ffi_utils::test_utils::{call_0, call_1_with_custom, send_via_user_data_custom, UserData};

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -145,7 +145,7 @@ use maidsafe_utilities::thread::{self, Joiner};
 use safe_core::crypto::shared_secretbox;
 use safe_core::ipc::resp::{access_container_enc_key, AccessContainerEntry};
 use safe_core::ipc::{AccessContInfo, AppKeys, AuthGranted, BootstrapConfig};
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting as Routing;
 use safe_core::{event_loop, CoreMsg, CoreMsgTx, NetworkEvent, NetworkTx};
 use std::cell::RefCell;
@@ -259,7 +259,7 @@ impl App {
     }
 
     /// Allows customising the mock Routing client before registering a new account.
-    #[cfg(feature = "use-mock-routing")]
+    #[cfg(feature = "mock-network")]
     pub fn registered_with_hook<N, F>(
         app_id: String,
         auth_granted: AuthGranted,

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -15,7 +15,7 @@ use crate::test_utils::{create_app_by_req, create_auth_req, create_auth_req_with
 use crate::{run, App};
 use ffi_utils::test_utils::call_1;
 use futures::Future;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use routing::{ClientError, Request, Response};
 use safe_authenticator::test_utils as authenticator;
 use safe_authenticator::test_utils::revoke;
@@ -23,7 +23,7 @@ use safe_authenticator::Authenticator;
 use safe_core::ffi::AccountInfo;
 use safe_core::ipc::req::{AppExchangeInfo, AuthReq};
 use safe_core::ipc::Permission;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -97,7 +97,7 @@ fn get_access_info() {
 }
 
 // Make sure we can login to a registered app with low balance.
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 #[test]
 pub fn login_registered_with_low_balance() {
     // Register a hook prohibiting mutations and login

--- a/safe_app_jni/Cargo.toml
+++ b/safe_app_jni/Cargo.toml
@@ -27,5 +27,5 @@ features = ["bindings"]
 crate_type = ["cdylib"]
 
 [features]
-use-mock-routing = ["testing", "safe_core/use-mock-routing", "safe_app/use-mock-routing"]
+mock-network = ["testing", "safe_core/mock-network", "safe_app/mock-network"]
 testing = ["safe_core/testing", "safe_app/testing"]

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -44,7 +44,7 @@ safe_bindgen = "~0.12.0"
 unwrap = "~1.2.0"
 
 [features]
-use-mock-routing = ["testing", "safe_core/use-mock-routing"]
+mock-network = ["testing", "safe_core/mock-network"]
 testing = ["safe_core/testing"]
 bindings = []
 

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(not(feature = "use-mock-routing"))]
+#[cfg(not(feature = "mock-network"))]
 use routing::Client as Routing;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting as Routing;
 
 use crate::errors::AuthError;
@@ -98,7 +98,7 @@ where {
         )
     }
 
-    #[cfg(all(feature = "use-mock-routing", any(test, feature = "testing")))]
+    #[cfg(all(feature = "mock-network", any(test, feature = "testing")))]
     /// Allows customising the mock Routing client before registering a new account
     pub fn registered_with_hook<F>(
         acc_locator: &str,
@@ -250,7 +250,7 @@ where {
         })
     }
 
-    #[cfg(all(feature = "use-mock-routing", any(test, feature = "testing")))]
+    #[cfg(all(feature = "mock-network", any(test, feature = "testing")))]
     /// Allows customising the mock Routing client before logging into the network.
     pub fn login_with_hook<F>(
         acc_locator: &str,
@@ -753,7 +753,7 @@ mod tests {
     }
 
     // Test restarting routing after a network disconnect.
-    #[cfg(feature = "use-mock-routing")]
+    #[cfg(feature = "mock-network")]
     #[test]
     fn restart_routing() {
         use crate::test_utils::random_client_with_net_obs;
@@ -788,7 +788,7 @@ mod tests {
     }
 
     // Test that a `RequestTimeout` error is returned on network timeout.
-    #[cfg(feature = "use-mock-routing")]
+    #[cfg(feature = "mock-network")]
     #[test]
     fn timeout() {
         use crate::test_utils::random_client;

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn auth_free(auth: *mut Authenticator) {
 /// Returns true if this crate was compiled against mock-routing.
 #[no_mangle]
 pub extern "C" fn auth_is_mock() -> bool {
-    cfg!(feature = "use-mock-routing")
+    cfg!(feature = "mock-network")
 }
 
 #[cfg(test)]
@@ -222,14 +222,14 @@ mod tests {
 
     // Test mock detection when compiled against mock-routing.
     #[test]
-    #[cfg(feature = "use-mock-routing")]
+    #[cfg(feature = "mock-network")]
     fn test_mock_build() {
         assert_eq!(auth_is_mock(), true);
     }
 
     // Test mock detection when not compiled against mock-routing.
     #[test]
-    #[cfg(not(feature = "use-mock-routing"))]
+    #[cfg(not(feature = "mock-network"))]
     fn test_not_mock_build() {
         assert_eq!(auth_is_mock(), false);
     }
@@ -276,7 +276,7 @@ mod tests {
     }
 
     // Test disconnection and reconnection with the authenticator.
-    #[cfg(all(test, feature = "use-mock-routing"))]
+    #[cfg(all(test, feature = "mock-network"))]
     #[test]
     fn network_status_callback() {
         use ffi_utils::test_utils::{

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -114,7 +114,7 @@ use futures::stream::Stream;
 use futures::sync::mpsc;
 use futures::{Future, IntoFuture};
 use maidsafe_utilities::thread::{self, Joiner};
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting;
 use safe_core::{event_loop, CoreMsg, CoreMsgTx, FutureExt, NetworkEvent, NetworkTx};
 use std::sync::mpsc as std_mpsc;
@@ -391,7 +391,7 @@ impl Authenticator {
     }
 }
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 impl Authenticator {
     #[allow(unused)]
     fn create_acc_with_hook<F, S, N>(

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -34,7 +34,7 @@ use safe_core::ipc::{
 use safe_core::nfs::file_helper::{self, Version};
 use safe_core::nfs::{File, Mode};
 use safe_core::utils::test_utils::setup_client_with_net_obs;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting;
 use safe_core::{utils, MDataInfo, NetworkEvent};
 use std::collections::HashMap;
@@ -110,7 +110,7 @@ pub fn revoke(authenticator: &Authenticator, app_id: &str) {
 
 /// Create a random authenticator and login using the same credentials.
 /// Attaches a hook to the Routing to override responses.
-#[cfg(all(any(test, feature = "testing"), feature = "use-mock-routing"))]
+#[cfg(all(any(test, feature = "testing"), feature = "mock-network"))]
 pub fn create_account_and_login_with_hook<F>(hook: F) -> Authenticator
 where
     F: Fn(MockRouting) -> MockRouting + Send + 'static,

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -35,7 +35,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 use tiny_keccak::sha3_256;
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 mod mock_routing {
     use super::utils;
     use crate::access_container as access_container_tools;

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -23,7 +23,7 @@ use safe_core::nfs::NfsError;
 use safe_core::{app_container_name, Client, CoreError, MDataInfo};
 use std::collections::HashMap;
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 mod mock_routing {
     use super::*;
     use crate::access_container;

--- a/safe_authenticator/src/tests/serialisation.rs
+++ b/safe_authenticator/src/tests/serialisation.rs
@@ -8,7 +8,7 @@
 
 //! These tests ensure binary compatibility between different versions of `safe_client_libs`.
 
-#![cfg(feature = "use-mock-routing")]
+#![cfg(feature = "mock-network")]
 
 use crate::app_auth::{self, AppState};
 use crate::client::AuthClient;

--- a/safe_authenticator_jni/Cargo.toml
+++ b/safe_authenticator_jni/Cargo.toml
@@ -27,5 +27,5 @@ features = ["bindings"]
 crate_type = ["cdylib"]
 
 [features]
-use-mock-routing = ["testing", "safe_core/use-mock-routing", "safe_authenticator/use-mock-routing"]
+mock-network = ["testing", "safe_core/mock-network", "safe_authenticator/mock-network"]
 testing = ["safe_core/testing", "safe_authenticator/testing"]

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -36,5 +36,5 @@ unwrap = "~1.2.0"
 serde_json = "~1.0.9"
 
 [features]
-use-mock-routing = []
+mock-network = []
 testing = []

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use crate::client::mock::Routing;
-#[cfg(not(feature = "use-mock-routing"))]
+#[cfg(not(feature = "mock-network"))]
 use routing::Client as Routing;
 
 use crate::client::account::{Account as ClientAccount, ClientKeys};

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -16,20 +16,20 @@ pub mod mdata_info;
 /// Operations with recovery.
 pub mod recovery;
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 mod mock;
 mod routing_event_loop;
 
 pub use self::account::ClientKeys;
 pub use self::mdata_info::MDataInfo;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 pub use self::mock::vault::mock_vault_path;
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 pub use self::mock::Routing as MockRouting;
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 use self::mock::Routing;
-#[cfg(not(feature = "use-mock-routing"))]
+#[cfg(not(feature = "mock-network"))]
 use routing::Client as Routing;
 
 use crate::crypto::{shared_box, shared_secretbox, shared_sign};
@@ -450,8 +450,8 @@ pub trait Client: Clone + 'static {
     }
 
     #[cfg(any(
-        all(test, feature = "use-mock-routing"),
-        all(feature = "testing", feature = "use-mock-routing")
+        all(test, feature = "mock-network"),
+        all(feature = "testing", feature = "mock-network")
     ))]
     #[doc(hidden)]
     fn set_network_limits(&self, max_ops_count: Option<u64>) {
@@ -460,8 +460,8 @@ pub trait Client: Clone + 'static {
     }
 
     #[cfg(any(
-        all(test, feature = "use-mock-routing"),
-        all(feature = "testing", feature = "use-mock-routing")
+        all(test, feature = "mock-network"),
+        all(feature = "testing", feature = "mock-network")
     ))]
     #[doc(hidden)]
     fn simulate_network_disconnect(&self) {
@@ -470,8 +470,8 @@ pub trait Client: Clone + 'static {
     }
 
     #[cfg(any(
-        all(test, feature = "use-mock-routing"),
-        all(feature = "testing", feature = "use-mock-routing")
+        all(test, feature = "mock-network"),
+        all(feature = "testing", feature = "mock-network")
     ))]
     #[doc(hidden)]
     fn set_simulate_timeout(&self, enabled: bool) {

--- a/safe_core/src/client/recovery.rs
+++ b/safe_core/src/client/recovery.rs
@@ -462,7 +462,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "use-mock-routing"))]
+#[cfg(all(test, feature = "mock-network"))]
 mod tests_with_mock_routing {
     use super::*;
     use crate::utils::test_utils::random_client;

--- a/safe_core/src/ipc/mod.rs
+++ b/safe_core/src/ipc/mod.rs
@@ -60,7 +60,7 @@ pub enum IpcMsg {
 pub fn encode_msg(msg: &IpcMsg) -> Result<String, IpcError> {
     // We also add a multicodec compatible prefix. For more details please follow
     // https://github.com/multiformats/multicodec/blob/master/table.csv
-    let msg = (msg, cfg!(feature = "use-mock-routing"));
+    let msg = (msg, cfg!(feature = "mock-network"));
     Ok(format!("b{}", BASE32_NOPAD.encode(&serialise(&msg)?)))
 }
 
@@ -85,7 +85,7 @@ pub fn decode_msg(encoded: &str) -> Result<IpcMsg, IpcError> {
     };
 
     let (msg, mock): (IpcMsg, bool) = deserialise(&decoded)?;
-    if mock != cfg!(feature = "use-mock-routing") {
+    if mock != cfg!(feature = "mock-network") {
         return Err(IpcError::IncompatibleMockStatus);
     }
 

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -77,7 +77,7 @@
     allow(clippy::implicit_hasher, clippy::too_many_arguments, clippy::use_debug)
 )]
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -122,7 +122,7 @@ mod errors;
 mod event;
 
 pub use self::client::{mdata_info, recovery, Client, ClientKeys, MDataInfo};
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 pub use self::client::{mock_vault_path, MockRouting};
 pub use self::errors::CoreError;
 pub use self::event::{CoreEvent, NetworkEvent, NetworkRx, NetworkTx};

--- a/safe_core/src/utils/test_utils/mod.rs
+++ b/safe_core/src/utils/test_utils/mod.rs
@@ -6,10 +6,10 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 mod sync;
 
-#[cfg(feature = "use-mock-routing")]
+#[cfg(feature = "mock-network")]
 pub use self::sync::Synchronizer;
 use crate::client::core_client::CoreClient;
 use crate::client::Client;

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -4,7 +4,7 @@ set -e -x
 
 echo "--- Building the binary compatibility test ---"
 
-cargo test --verbose --release --no-run --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml
+cargo test --verbose --release --no-run --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
 
 # Find the file to run.
 TEST_FILE=$(find target/release -maxdepth 1 -type f -executable -name "safe_authenticator-*" -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ")

--- a/scripts/build-mock
+++ b/scripts/build-mock
@@ -2,8 +2,8 @@
 
 set -e -x
 
-cargo build --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml
-cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml
-cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
-cargo build --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo build --verbose --features=mock-network --release --manifest-path=safe_core/Cargo.toml
+cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml
+cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml
 cargo build --verbose --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-mock
+++ b/scripts/check-mock
@@ -2,7 +2,7 @@
 
 set -x;
 
-cargo check --verbose --features=use-mock-routing --release --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
-cargo check --verbose --features="testing use-mock-routing" --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo check --verbose --features=mock-network --release --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml &&
+cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml &&
+cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml

--- a/scripts/clippy-mock
+++ b/scripts/clippy-mock
@@ -2,6 +2,6 @@
 
 set -x;
 
-cd safe_core && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
-cd safe_authenticator && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd .. &&
-cd safe_app && cargo clippy --verbose --features="use-mock-routing" --release --profile=test && cd ..
+cd safe_core && cargo clippy --verbose --features="mock-network" --release --profile=test && cd .. &&
+cd safe_authenticator && cargo clippy --verbose --features="mock-network" --release --profile=test && cd .. &&
+cd safe_app && cargo clippy --verbose --features="mock-network" --release --profile=test && cd ..

--- a/scripts/package.rs
+++ b/scripts/package.rs
@@ -227,7 +227,7 @@ fn main() {
     // Gather features.
     let mut features = vec![];
     if mock {
-        features.push("use-mock-routing");
+        features.push("mock-network");
         features.push("testing");
     }
     if matches.is_present("BINDINGS") {

--- a/scripts/test-binary
+++ b/scripts/test-binary
@@ -14,11 +14,11 @@ if [[ -f "$COMPAT_TESTS" ]]; then
     export SAFE_MOCK_VAULT_PATH=$HOME/tmp
     mkdir -p "$SAFE_MOCK_VAULT_PATH"
 
-    cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation_write_data -- --ignored
+    cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_write_data -- --ignored
 
     chmod +x "$COMPAT_TESTS"
     "$COMPAT_TESTS" serialisation_read_data --ignored
     "$COMPAT_TESTS" serialisation_write_data --ignored
 
-    cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml serialisation_read_data -- --ignored
+    cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_read_data -- --ignored
 fi

--- a/scripts/test-integration
+++ b/scripts/test-integration
@@ -2,4 +2,4 @@
 
 set -e -x
 
-cargo test --verbose --features="use-mock-routing" --release --manifest-path=tests/Cargo.toml
+cargo test --verbose --features="mock-network" --release --manifest-path=tests/Cargo.toml

--- a/scripts/test-mock
+++ b/scripts/test-mock
@@ -2,8 +2,8 @@
 
 set -e -x
 
-cargo test config_mock_vault_path --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml
+cargo test config_mock_vault_path --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
 export SAFE_MOCK_IN_MEMORY_STORAGE=1 &&
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_core/Cargo.toml
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_authenticator/Cargo.toml
-cargo test --verbose --release --features=use-mock-routing --manifest-path=safe_app/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,10 +31,10 @@ version = "~0.32.1"
 features = ["testing"]
 
 [features]
-use-mock-routing = [
+mock-network = [
 "testing",
-"safe_core/use-mock-routing",
-"safe_authenticator/use-mock-routing",
-"safe_app/use-mock-routing",
+"safe_core/mock-network",
+"safe_authenticator/mock-network",
+"safe_app/mock-network",
 ]
 testing = ["safe_core/testing", "safe_authenticator/testing", "safe_app/testing"]


### PR DESCRIPTION
closes #793 