### PR TITLE
Improvements to mock MutableData implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -140,9 +140,19 @@ name = "bincode"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bincode"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,7 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.7"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -206,7 +216,7 @@ name = "bytes"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -264,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -296,7 +306,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -310,7 +320,7 @@ dependencies = [
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -399,10 +409,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crust"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -415,7 +425,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -495,7 +505,7 @@ dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -537,7 +547,7 @@ dependencies = [
  "jni 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -876,7 +886,7 @@ dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -917,7 +927,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1208,7 +1218,7 @@ name = "pairing"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1498,7 +1508,7 @@ version = "0.36.0"
 source = "git+https://github.com/lionel1704/routing?branch=patch#70cbaf5d2e222ee3d9897b3d5eba3aed83cb4e36"
 dependencies = [
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crust 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crust 0.32.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake_clock 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1510,7 +1520,7 @@ dependencies = [
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource_proof 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1526,7 +1536,7 @@ dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium-sys 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1578,7 +1588,7 @@ dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1598,15 +1608,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions#7f907bcaff7b4e7004fa31ff28c3ee9bdcac0d04"
+source = "git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions#c86ae5151c769e1b07dc3c29f0ff048be3220fd0"
 dependencies = [
- "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1628,7 +1637,7 @@ dependencies = [
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1666,7 +1675,7 @@ dependencies = [
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1724,7 +1733,7 @@ dependencies = [
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions)",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1797,7 +1806,7 @@ dependencies = [
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,7 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1830,7 +1839,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1850,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1860,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1940,7 +1949,7 @@ version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1952,7 +1961,7 @@ name = "syntex_pos"
 version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1964,7 +1973,7 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2025,7 +2034,7 @@ dependencies = [
  "safe_app 0.9.1",
  "safe_authenticator 0.9.1",
  "safe_core 0.32.1",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2052,7 +2061,7 @@ name = "threshold_crypto"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2063,7 +2072,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand04_compat 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2274,7 +2283,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2282,7 +2291,7 @@ name = "toml"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2458,7 +2467,7 @@ name = "ws"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2542,6 +2551,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
+"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -2550,7 +2560,7 @@ dependencies = [
 "checksum brotli-decompressor 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4014f0cb706cc3a33fe90c3ddf6364366c1995c9f77f2bb6173f63b68860855a"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
@@ -2574,7 +2584,7 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
-"checksum crust 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ce7a713c1d97f75199d62ba284cae3a8be287f9b6ef245c997676ddcc22b959"
+"checksum crust 0.32.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689e1866709c0da0db68c631f312df4fb4137d5a96f1d779c0bee34f303de8c2"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
@@ -2721,7 +2731,7 @@ dependencies = [
 "checksum self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a30463a6a1328f3e3d2a09fa64f85df7925f0af82410b352cf840eb2de5d0d50"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
+"checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions#c86ae5151c769e1b07dc3c29f0ff048be3220fd0"
+source = "git+https://github.com/maidsafe/safe-nd#99a1d8508e7a756d026df6a87b1368e52d6fd85b"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1731,7 +1731,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions)",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2719,7 +2719,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions)" = "<none>"
+"checksum safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)" = "<none>"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/lionel1704/safe-nd?branch=mdata-improv#78ccbf61f6752bb17e9120d4c3423d28c2e8f6a8"
+source = "git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions#7f907bcaff7b4e7004fa31ff28c3ee9bdcac0d04"
 dependencies = [
  "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
@@ -1722,7 +1722,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata-improv)",
+ "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions)",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2709,7 +2709,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata-improv)" = "<none>"
+"checksum safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=more-mdata-functions)" = "<none>"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,8 +1598,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/lionel1704/safe-nd?branch=mdata#b4c5c5387f86ba6fb13031f219291b0b618e3f2f"
+source = "git+https://github.com/lionel1704/safe-nd?branch=mdata-improv#78ccbf61f6752bb17e9120d4c3423d28c2e8f6a8"
 dependencies = [
+ "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1721,7 +1722,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "routing 0.36.0 (git+https://github.com/lionel1704/routing?branch=patch)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata)",
+ "safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata-improv)",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2708,7 +2709,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata)" = "<none>"
+"checksum safe-nd 0.1.0 (git+https://github.com/lionel1704/safe-nd?branch=mdata-improv)" = "<none>"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ else
 endif
 
 package-build-artifacts:
+ifndef SCL_BRANCH
+	@echo "A branch or PR reference must be provided."
+	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@exit 1
+endif
 ifndef SCL_BUILD_NUMBER
 	@echo "A build number must be supplied for build artifact packaging."
 	@echo "Please set SCL_BUILD_NUMBER to a valid build number."
@@ -68,9 +73,9 @@ ifndef SCL_BUILD_OS
 	@exit 1
 endif
 ifeq ($(SCL_BUILD_MOCK),true)
-	$(eval ARCHIVE_NAME := ${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
 else
-	$(eval ARCHIVE_NAME := ${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
 endif
 	tar -C artifacts -zcvf ${ARCHIVE_NAME} .
 	rm artifacts/**
@@ -84,6 +89,11 @@ package-deploy-artifacts:
 		scripts/package-runner-container
 
 retrieve-build-artifacts:
+ifndef SCL_BRANCH
+	@echo "A branch or PR reference must be provided."
+	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@exit 1
+endif
 ifndef SCL_BUILD_NUMBER
 	@echo "A valid build number must be supplied for the artifacts to be retrieved."
 	@echo "Please set SCL_BUILD_NUMBER to a valid build number."
@@ -100,9 +110,9 @@ ifndef SCL_BUILD_OS
 	@exit 1
 endif
 ifeq ($(SCL_BUILD_MOCK),true)
-	$(eval ARCHIVE_NAME := ${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
 else
-	$(eval ARCHIVE_NAME := ${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
 endif
 	aws s3 cp \
 		--no-sign-request \
@@ -125,6 +135,11 @@ endif
 	rm ${ARCHIVE_NAME}
 
 retrieve-all-build-artifacts:
+ifndef SCL_BRANCH
+	@echo "A branch or PR reference must be provided."
+	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@exit 1
+endif
 ifndef SCL_BUILD_NUMBER
 	@echo "A valid build number must be supplied for the artifacts to be retrieved."
 	@echo "Please set SCL_BUILD_NUMBER to a valid build number."
@@ -137,24 +152,24 @@ endif
 	mkdir -p artifacts/win/mock/release
 	mkdir -p artifacts/osx/real/release
 	mkdir -p artifacts/osx/mock/release
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz .
-	tar -C artifacts/linux/real/release -xvf ${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
-	tar -C artifacts/linux/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
-	tar -C artifacts/win/real/release -xvf ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
-	tar -C artifacts/win/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
-	tar -C artifacts/osx/real/release -xvf ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
-	tar -C artifacts/osx/mock/release -xvf ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
-	rm ${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz .
+	tar -C artifacts/linux/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
+	tar -C artifacts/linux/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
+	tar -C artifacts/win/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
+	tar -C artifacts/win/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	tar -C artifacts/osx/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	tar -C artifacts/osx/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
 
 test-artifacts-mock:
 ifeq ($(UNAME_S),Linux)

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -33,7 +33,7 @@ threshold_crypto = "0.3.1"
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
-safe-nd = { git = "https://github.com/lionel1704/safe-nd", branch = "mdata" }
+safe-nd = { git = "https://github.com/lionel1704/safe-nd", branch = "mdata-improv" }
 
 [dev-dependencies]
 serde_json = "~1.0.9"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -33,7 +33,8 @@ threshold_crypto = "0.3.1"
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
-safe-nd = { git = "https://github.com/lionel1704/safe-nd", branch = "mdata-improv" }
+safe-nd = { git = "https://github.com/lionel1704/safe-nd", branch = "more-mdata-functions" }
+# safe-nd = { path = "../../safe-nd" }
 
 [dev-dependencies]
 serde_json = "~1.0.9"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -33,8 +33,7 @@ threshold_crypto = "0.3.1"
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
-safe-nd = { git = "https://github.com/lionel1704/safe-nd", branch = "more-mdata-functions" }
-# safe-nd = { path = "../../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 
 [dev-dependencies]
 serde_json = "~1.0.9"

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -148,7 +148,9 @@ impl Routing {
                 // Also make this better
                 let message_id = match resp {
                     RpcResponse::GetUnseqMData { msg_id, .. }
-                    | RpcResponse::PutUnseqMData { msg_id, .. } => msg_id,
+                    | RpcResponse::GetSeqMData { msg_id, .. }
+                    | RpcResponse::PutUnseqMData { msg_id, .. }
+                    | RpcResponse::PutSeqMData { msg_id, .. } => msg_id,
                     _ => {
                         // Return random msg_id for now
                         // Other responses should be handled with their data types

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -10,6 +10,7 @@
 
 use super::vault::{self, Data, Vault, VaultGuard};
 use super::DataId;
+use crate::client::MsgIdConverter;
 use crate::config_handler::{get_config, Config};
 use maidsafe_utilities::serialisation::deserialise;
 use maidsafe_utilities::thread;
@@ -21,7 +22,6 @@ use routing::{
 };
 use rust_sodium::crypto::sign;
 use safe_nd::response::Response as RpcResponse;
-use safe_nd::MessageId as SndMessageId;
 use std;
 use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
@@ -150,7 +150,8 @@ impl Routing {
                     RpcResponse::GetUnseqMData { msg_id, .. }
                     | RpcResponse::GetSeqMData { msg_id, .. }
                     | RpcResponse::PutUnseqMData { msg_id, .. }
-                    | RpcResponse::GetMDataShell { msg_id, .. }
+                    | RpcResponse::GetSeqMDataShell { msg_id, .. }
+                    | RpcResponse::GetUnseqMDataShell { msg_id, .. }
                     | RpcResponse::GetMDataVersion { msg_id, .. }
                     | RpcResponse::ListUnseqMDataEntries { msg_id, .. }
                     | RpcResponse::ListSeqMDataEntries { msg_id, .. }
@@ -161,12 +162,12 @@ impl Routing {
                     _ => {
                         // Return random msg_id for now
                         // Other responses should be handled with their data types
-                        SndMessageId::from(MessageId::new())
+                        MessageId::new().to_new()
                     }
                 };
                 let response = Response::RpcResponse {
                     res: Ok(payload.to_vec()),
-                    msg_id: SndMessageId::into(message_id),
+                    msg_id: MessageId::from_new(message_id),
                 };
                 self.send_response(DEFAULT_DELAY_MS, src, dst, response);
                 None

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -22,7 +22,7 @@ use routing::{
     TYPE_TAG_SESSION_PACKET,
 };
 use rust_sodium::crypto::sign;
-use safe_nd::mutable_data::{MutableData as SndMutableData, MutableDataKind, MutableDataRef};
+use safe_nd::mutable_data::{MutableDataRef, UnseqMutableData};
 use safe_nd::request::Request as RpcRequest;
 use safe_nd::response::Response as RpcResponse;
 use safe_nd::MessageId as SndMessageId;
@@ -1031,12 +1031,10 @@ fn unpub_md() {
     let name = rand::random();
     let tag = 15001;
 
-    let data = SndMutableData::new(
+    let data = UnseqMutableData::new(
         name,
         tag,
-        MutableDataKind::Unsequenced {
-            data: Default::default(),
-        },
+        Default::default(),
         Default::default(),
         full_id.bls_key().public_key(),
     );
@@ -1069,9 +1067,9 @@ fn unpub_md() {
     let rpc_response: RpcResponse<ClientError> = unwrap!(deserialise(&response2));
     match rpc_response {
         RpcResponse::GetUnseqMData { res, .. } => {
-            let unpub_mdata: SndMutableData = unwrap!(res);
+            let unpub_mdata: UnseqMutableData = unwrap!(res);
             println!("{:?} :: {}", unpub_mdata.name(), unpub_mdata.tag());
-            assert_eq!(unpub_mdata.name(), name);
+            assert_eq!(*unpub_mdata.name(), name);
             assert_eq!(unpub_mdata.tag(), tag);
         }
         _ => panic!("Unexpected response"),

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -12,6 +12,7 @@
 use super::routing::Routing;
 use super::DEFAULT_MAX_MUTATIONS;
 use crate::client::mock::vault::Vault;
+use crate::client::MsgIdConverter;
 use crate::config_handler::{Config, DevConfig};
 use crate::utils;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
@@ -22,10 +23,9 @@ use routing::{
     TYPE_TAG_SESSION_PACKET,
 };
 use rust_sodium::crypto::sign;
-use safe_nd::mutable_data::{MutableDataRef, UnseqMutableData};
+use safe_nd::mutable_data::{MutableData as NewMutableData, MutableDataRef, UnseqMutableData};
 use safe_nd::request::Request as RpcRequest;
 use safe_nd::response::Response as RpcResponse;
-use safe_nd::MessageId as SndMessageId;
 use std::sync::mpsc::{self, Receiver};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -1031,7 +1031,7 @@ fn unpub_md() {
     let name = rand::random();
     let tag = 15001;
 
-    let data = UnseqMutableData::new(
+    let data = UnseqMutableData::new_with_data(
         name,
         tag,
         Default::default(),
@@ -1044,7 +1044,7 @@ fn unpub_md() {
     let put_request = RpcRequest::PutUnseqMData {
         data: data.clone(),
         requester: owner_key,
-        message_id: SndMessageId::from(message_id),
+        message_id: message_id.to_new(),
     };
 
     let put_req_buffer = unwrap!(serialise(&put_request));
@@ -1055,7 +1055,7 @@ fn unpub_md() {
     let get_request = RpcRequest::GetUnseqMData {
         address: MutableDataRef::new(name, tag),
         requester: full_id.bls_key().public_key(),
-        message_id: SndMessageId::from(message_id2),
+        message_id: message_id2.to_new(),
     };
     let get_req_buffer = unwrap!(serialise(&get_request));
     unwrap!(routing.send(

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -235,7 +235,6 @@ impl Vault {
         payload: Vec<u8>,
     ) -> Result<(Authority<XorName>, Vec<u8>), ClientError> {
         let request: Request = unwrap!(deserialise(&payload));
-        dbg!(request.clone());
         match request {
             Request::PutUnseqMData {
                 data,

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -337,7 +337,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::GetSeqMData { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -412,7 +411,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::GetSeqMDataShell { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -450,7 +448,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::GetUnseqMDataShell { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -488,7 +485,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::GetMDataVersion { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -556,7 +552,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::ListUnseqMDataEntries { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -598,7 +593,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::ListSeqMDataEntries { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -647,7 +641,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::ListMDataKeys { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -685,7 +678,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::ListSeqMDataValues { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),
@@ -723,7 +715,6 @@ pub trait Client: Clone + 'static {
             };
             let result_buffer = unwrap!(res);
             let res: Response<ClientError> = unwrap!(deserialise(&result_buffer));
-            dbg!(res.clone());
             match res {
                 Response::ListUnseqMDataValues { res, .. } => res.map_err(CoreError::from),
                 _ => Err(CoreError::ReceivedUnexpectedEvent),

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -52,7 +52,7 @@ use rust_sodium::crypto::{box_, sign};
 use safe_nd::mutable_data::{
     MutableData as NewMutableData, MutableDataRef, SeqMutableData, UnseqMutableData, Value as Val,
 };
-use safe_nd::request::Request;
+use safe_nd::request::{Request, Requester};
 use safe_nd::response::Response;
 use safe_nd::MessageId as NewMessageId;
 use std::cell::RefCell;
@@ -239,7 +239,7 @@ pub trait Client: Clone + 'static {
     fn put_unseq_mutable_data(&self, data: UnseqMutableData) -> Box<CoreFuture<()>> {
         trace!("Put Unsequenced MData at {:?}", data.name());
 
-        let requester = some_or_err!(self.public_signing_key());
+        let requester = some_or_err!(self.public_bls_key());
         let client = Authority::Client {
             client_id: *some_or_err!(self.full_id()).public_id(),
             proxy_node_name: rand::random(),
@@ -247,7 +247,7 @@ pub trait Client: Clone + 'static {
         send_mutation(self, move |routing, dst, message_id| {
             let request = Request::PutUnseqMData {
                 data: data.clone(),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: message_id.to_new(),
             };
             routing.send(client, dst, &unwrap!(serialise(&request)))
@@ -258,7 +258,7 @@ pub trait Client: Clone + 'static {
     fn put_seq_mutable_data(&self, data: SeqMutableData) -> Box<CoreFuture<()>> {
         trace!("Put Sequenced MData at {:?}", data.name());
 
-        let requester = some_or_err!(self.public_signing_key());
+        let requester = some_or_err!(self.public_bls_key());
         let client = Authority::Client {
             client_id: *some_or_err!(self.full_id()).public_id(),
             proxy_node_name: rand::random(),
@@ -266,7 +266,7 @@ pub trait Client: Clone + 'static {
         send_mutation(self, move |routing, dst, message_id| {
             let request = Request::PutSeqMData {
                 data: data.clone(),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: message_id.to_new(),
             };
             routing.send(client, dst, &unwrap!(serialise(&request)))
@@ -285,7 +285,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::GetUnseqMData {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
             routing.send(
@@ -321,7 +321,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::GetSeqMData {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
             routing.send(
@@ -395,7 +395,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::GetSeqMDataShell {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -433,7 +433,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::GetUnseqMDataShell {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -471,7 +471,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::GetMDataVersion {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -539,7 +539,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::ListUnseqMDataEntries {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -581,7 +581,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::ListSeqMDataEntries {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -630,7 +630,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::ListMDataKeys {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -668,7 +668,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::ListSeqMDataValues {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 
@@ -706,7 +706,7 @@ pub trait Client: Clone + 'static {
         send(self, move |routing, msg_id| {
             let request = Request::ListUnseqMDataValues {
                 address: MutableDataRef::new(name.0, tag),
-                requester,
+                requester: Requester::Key(requester),
                 message_id: msg_id.to_new(),
             };
 

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM rust:1.29.2
+FROM rust:1.34.1
 
 RUN addgroup --gid 1000 maidsafe && \
     adduser --uid 1000 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -6,17 +6,7 @@ properties([
 ])
 
 stage('build') {
-    parallel real_linux: {
-        node('docker') {
-            checkout(scm)
-            clean()
-            build_safe_client_libs('real')
-            strip_build_artifacts()
-            package_build_artifacts('real', 'linux')
-            upload_build_artifacts()
-        }
-    },
-    mock_linux: {
+    parallel mock_linux: {
         node('docker') {
             checkout(scm)
             clean()
@@ -27,30 +17,12 @@ stage('build') {
             upload_binary_compatibility_test()
         }
     },
-    real_windows: {
-        node('windows') {
-            checkout(scm)
-            build_safe_client_libs('real')
-            strip_build_artifacts()
-            package_build_artifacts('real', 'windows')
-            upload_build_artifacts()
-        }
-    },
     mock_windows: {
         node('windows') {
             checkout(scm)
             build_safe_client_libs('mock')
             strip_build_artifacts()
             package_build_artifacts('mock', 'windows')
-            upload_build_artifacts()
-        }
-    },
-    real_osx: {
-        node('osx') {
-            checkout(scm)
-            build_safe_client_libs('real')
-            strip_build_artifacts()
-            package_build_artifacts('real', 'osx')
             upload_build_artifacts()
         }
     },
@@ -92,13 +64,6 @@ stage('test') {
             checkout(scm)
             retrieve_build_artifacts('mock', 'linux')
             run_tests('integration')
-        }
-    },
-    binary_linux: {
-        node('docker') {
-            checkout(scm)
-            retrieve_build_artifacts('mock', 'linux')
-            run_binary_compatibility_tests()
         }
     }
 }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -68,30 +68,35 @@ stage('build') {
 stage('test') {
     parallel mocked_linux: {
         node('docker') {
+            checkout(scm)
             retrieve_build_artifacts('mock', 'linux')
             run_tests('mock')
         }
     },
     mocked_windows: {
         node('windows') {
+            checkout(scm)
             retrieve_build_artifacts('mock', 'windows')
             run_tests('mock')
         }
     },
     mocked_macos: {
         node('osx') {
+            checkout(scm)
             retrieve_build_artifacts('mock', 'osx')
             run_tests('mock')
         }
     },
     integration_linux: {
         node('docker') {
+            checkout(scm)
             retrieve_build_artifacts('mock', 'linux')
             run_tests('integration')
         }
     },
     binary_linux: {
         node('docker') {
+            checkout(scm)
             run_binary_compatibility_tests()
         }
     }
@@ -99,6 +104,7 @@ stage('test') {
 
 stage('deployment') {
     node('docker') {
+        checkout(scm)
         package_deploy_artifacts()
         withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
             def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,3 +1,10 @@
+properties([
+    parameters([
+        string(name: 'ARTIFACTS_BUCKET', defaultValue: 'safe-client-libs-jenkins'),
+        string(name: 'DEPLOY_BUCKET', defaultValue: 'safe-client-libs')
+    ])
+])
+
 stage('build') {
     parallel real_linux: {
         node('docker') {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -97,6 +97,7 @@ stage('test') {
     binary_linux: {
         node('docker') {
             checkout(scm)
+            retrieve_build_artifacts('mock', 'linux')
             run_binary_compatibility_tests()
         }
     }
@@ -140,7 +141,13 @@ def get_container_name(mode, type, app='') {
 }
 
 def package_build_artifacts(mode, os) {
-    command = "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
+    command = ""
+    if (env.CHANGE_ID?.trim()) {
+        command += "SCL_BRANCH=${env.CHANGE_ID} "
+    } else {
+        command += "SCL_BRANCH=${env.BRANCH_NAME} "
+    }
+    command += "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
     command += "SCL_BUILD_OS=${os} "
     if (mode == 'mock') {
         command += "SCL_BUILD_MOCK=true "
@@ -152,7 +159,13 @@ def package_build_artifacts(mode, os) {
 }
 
 def package_deploy_artifacts() {
-    command = "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
+    command = ""
+    if (env.CHANGE_ID?.trim()) {
+        command += "SCL_BRANCH=${env.CHANGE_ID} "
+    } else {
+        command += "SCL_BRANCH=${env.BRANCH_NAME} "
+    }
+    command += "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
     command += "make retrieve-all-build-artifacts"
     sh(command)
     sh("make package-deploy-artifacts")
@@ -201,7 +214,13 @@ def upload_binary_compatibility_test() {
 }
 
 def retrieve_build_artifacts(mode, os) {
-    command = "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
+    command = ""
+    if (env.CHANGE_ID?.trim()) {
+        command += "SCL_BRANCH=${env.CHANGE_ID} "
+    } else {
+        command += "SCL_BRANCH=${env.BRANCH_NAME} "
+    }
+    command += "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
     command += "SCL_BUILD_OS=${os} "
     if (mode == 'mock') {
         command += "SCL_BUILD_MOCK=true "

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -105,17 +105,21 @@ stage('test') {
 
 stage('deployment') {
     node('docker') {
-        checkout(scm)
-        package_deploy_artifacts()
-        withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
-            def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")
-            for (artifact in artifacts) {
-                s3Upload(
-                    bucket: "${params.DEPLOY_BUCKET}",
-                    file: artifact,
-                    workingDir: "${env.WORKSPACE}/deploy",
-                    acl: 'PublicRead')
+        if (env.BRANCH_NAME == "master") {
+            checkout(scm)
+            package_deploy_artifacts()
+            withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
+                def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")
+                for (artifact in artifacts) {
+                    s3Upload(
+                        bucket: "${params.DEPLOY_BUCKET}",
+                        file: artifact,
+                        workingDir: "${env.WORKSPACE}/deploy",
+                        acl: 'PublicRead')
+                }
             }
+        } else {
+            echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
         }
     }
 }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -104,7 +104,7 @@ stage('deployment') {
             def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")
             for (artifact in artifacts) {
                 s3Upload(
-                    bucket: "${env.DEPLOY_BUCKET}",
+                    bucket: "${params.DEPLOY_BUCKET}",
                     file: artifact,
                     workingDir: "${env.WORKSPACE}/deploy",
                     acl: 'PublicRead')
@@ -169,7 +169,7 @@ def upload_build_artifacts() {
         def artifacts = sh(returnStdout: true, script: 'ls -1 artifacts').trim().split("\\r?\\n")
         for (artifact in artifacts) {
             s3Upload(
-                bucket: "${env.ARTIFACTS_BUCKET}",
+                bucket: "${params.ARTIFACTS_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/artifacts",
                 acl: 'PublicRead')
@@ -186,7 +186,7 @@ def upload_binary_compatibility_test() {
     sh("rm -rf target/release")
     withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
         s3Upload(
-            bucket: "${env.ARTIFACTS_BUCKET}",
+            bucket: "${params.ARTIFACTS_BUCKET}",
             file: "bct/${env.BUILD_NUMBER}/tests",
             path: "bct/${env.BUILD_NUMBER}/tests",
             workingDir: "${env.WORKSPACE}",
@@ -215,7 +215,7 @@ def run_binary_compatibility_tests() {
         withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
             s3Download(
                 file: "${bct_test_path}",
-                bucket: "${env.ARTIFACTS_BUCKET}",
+                bucket: "${params.ARTIFACTS_BUCKET}",
                 path: "bct/${build_number}/tests",
                 force: true)
         }


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
- Improve mock impl. for MData by introducing a local enum in the mock vault impl.
- Add MsgIdConverter trait
- Add functions to the `Client` trait for other mutable data operations
with relevant tests