### PR TITLE
Adapt to the API changes in safe-nd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1009,7 +1009,7 @@ dependencies = [
  "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.1.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1524,16 +1524,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-nd#22840fa2967c770b1582c401fb4aaf3953a582e4"
+source = "git+https://github.com/maidsafe/safe-nd#8b7217d01f61256a54c698d17f491b3f06c21c45"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
+ "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "safe-nd"
+version = "0.1.0"
+dependencies = [
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
  "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1554,7 +1568,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.1.0",
  "safe_authenticator 0.9.1",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
@@ -1597,7 +1611,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.1.0",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1634,7 +1648,7 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1658,7 +1672,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.1.0",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1774,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1861,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.35"
+version = "0.15.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1876,7 +1890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1938,7 +1952,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1992,6 +2006,25 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "threshold_crypto"
+version = "0.3.1"
+source = "git+https://github.com/poanetwork/threshold_crypto.git#594bfdaa309c129dcff0df0e837beb17488756e6"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memsec 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand04_compat 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2613,7 +2646,7 @@ dependencies = [
 "checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1d4c517ad3d421a390cad0afa1108a507be2b86ea1f11afb12809e57a2f0c9"
 "checksum rust_sodium-sys 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3b72937549b078804565bef0276087cb9a5bc6e63677553188d85dd0c735d8"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
@@ -2646,7 +2679,7 @@ dependencies = [
 "checksum strings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa481ee1bc42fc3df8195f91f7cb43cf8f2b71b48bac40bf5381cfaf7e481f3c"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
-"checksum syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)" = "641e117d55514d6d918490e47102f7e08d096fdde360247e4a10f7a91a8478d3"
+"checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum syntex_errors 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3133289179676c9f5c5b2845bf5a2e127769f4889fcbada43035ef6bd662605e"
 "checksum syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30ab669fa003d208c681f874bbc76d91cc3d32550d16b5d9d2087cf477316470"
@@ -2658,6 +2691,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)" = "<none>"
+"checksum threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)" = "<none>"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dbbdebb0b801c7fa4260b6b9ac5a15980276d7d7bcc2dc2959a7c4dc8b426a1a"
 "checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
  "safe-nd 0.1.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
+ "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
  "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1524,22 +1524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-nd#8b7217d01f61256a54c698d17f491b3f06c21c45"
-dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
- "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "safe-nd"
-version = "0.1.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1576,7 +1560,7 @@ dependencies = [
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
+ "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
  "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1617,7 +1601,7 @@ dependencies = [
  "safe_core 0.32.1",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
+ "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
  "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1678,7 +1662,7 @@ dependencies = [
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)",
+ "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
  "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1983,7 +1967,7 @@ version = "0.1.0"
 dependencies = [
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.1.0",
  "safe_app 0.9.1",
  "safe_authenticator 0.9.1",
  "safe_core 0.32.1",
@@ -2013,25 +1997,6 @@ dependencies = [
 name = "threshold_crypto"
 version = "0.3.1"
 source = "git+https://github.com/poanetwork/threshold_crypto.git#594bfdaa309c129dcff0df0e837beb17488756e6"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memsec 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand04_compat 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "threshold_crypto"
-version = "0.3.1"
-source = "git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy#0f41fe7348ca6aa6f9c6492036ee9720032e1727"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2654,7 +2619,6 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-"checksum safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)" = "<none>"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
@@ -2691,7 +2655,6 @@ dependencies = [
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum threshold_crypto 0.3.1 (git+https://github.com/nbaksalyar/threshold_crypto.git?branch=pks-copy)" = "<none>"
 "checksum threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)" = "<none>"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dbbdebb0b801c7fa4260b6b9ac5a15980276d7d7bcc2dc2959a7c4dc8b426a1a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
 name = "safe_app"
 version = "0.9.1"
 dependencies = [
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,7 +1009,7 @@ dependencies = [
  "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.1 (git+https://github.com/poanetwork/threshold_crypto.git)",
@@ -1524,6 +1524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
+source = "git+https://github.com/maidsafe/safe-nd#a38aaa7271f67dbf7d59c9d8837fc8f216772aee"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1553,7 +1554,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "safe_authenticator 0.9.1",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
@@ -1596,7 +1597,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1657,7 +1658,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "self_encryption 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1967,7 +1968,7 @@ version = "0.1.0"
 dependencies = [
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.1.0",
+ "safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)",
  "safe_app 0.9.1",
  "safe_authenticator 0.9.1",
  "safe_core 0.32.1",
@@ -2619,6 +2620,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+"checksum safe-nd 0.1.0 (git+https://github.com/maidsafe/safe-nd)" = "<none>"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"

--- a/mock_routing/Cargo.toml
+++ b/mock_routing/Cargo.toml
@@ -11,8 +11,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-safe-nd = { path = "../../safe-nd" }
-# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 maidsafe_utilities = "~0.18.0"
 rust_sodium = "~0.10.2"
 rand = "~0.3.18"

--- a/mock_routing/Cargo.toml
+++ b/mock_routing/Cargo.toml
@@ -18,5 +18,5 @@ rust_sodium = "~0.10.2"
 rand = "~0.3.18"
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
-threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tiny-keccak = "~1.4.3"

--- a/mock_routing/Cargo.toml
+++ b/mock_routing/Cargo.toml
@@ -11,7 +11,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { path = "../../safe-nd" }
+# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 maidsafe_utilities = "~0.18.0"
 rust_sodium = "~0.10.2"
 rand = "~0.3.18"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -29,8 +29,7 @@ serde = "~1.0.27"
 serde_derive = "~1.0.27"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.9.1", optional = true }
 safe_core = { path = "../safe_core", version = "~0.32.1" }
-# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
-safe-nd = { path = "../../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 self_encryption = "~0.14.0"
 # threshold_crypto = "0.3.1"
 threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
+bincode = "~1.1.4"
 config_file_handler = "~0.11.0"
 ffi_utils = "~0.12.0"
 futures = "~0.1.17"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -28,7 +28,8 @@ serde = "~1.0.27"
 serde_derive = "~1.0.27"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.9.1", optional = true }
 safe_core = { path = "../safe_core", version = "~0.32.1" }
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { path = "../../safe-nd" }
 self_encryption = "~0.14.0"
 # threshold_crypto = "0.3.1"
 threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -33,7 +33,7 @@ safe_core = { path = "../safe_core", version = "~0.32.1" }
 safe-nd = { path = "../../safe-nd" }
 self_encryption = "~0.14.0"
 # threshold_crypto = "0.3.1"
-threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tiny-keccak = "~1.4.0"
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"

--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -25,6 +25,7 @@ use safe_core::{Client, ClientKeys, NetworkTx};
 use safe_nd::{
     request::{Request, Requester},
     Message, MessageId, PublicKey,
+    AppFullId
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -51,7 +52,7 @@ impl AppClient {
     ) -> Result<Self, AppError> {
         trace!("Creating unregistered client.");
 
-        let (routing, routing_rx) = setup_routing(None, config.clone())?;
+        let (routing, routing_rx) = setup_routing(None, None, config.clone())?;
         let joiner = spawn_routing_thread(routing_rx, core_tx.clone(), net_tx.clone());
 
         Ok(Self {
@@ -126,7 +127,7 @@ impl AppClient {
     {
         trace!("Attempting to log into an acc using client keys.");
         let (mut routing, routing_rx) =
-            setup_routing(Some(keys.clone().into()), Some(config.clone()))?;
+            setup_routing(Some(keys.clone().into()), Some(FullIdentity::App(AppFullId::with_keys(keys.bls_sk.clone(), owner))), Some(config.clone()))?;
         routing = routing_wrapper_fn(routing);
         let joiner = spawn_routing_thread(routing_rx, core_tx.clone(), net_tx.clone());
 

--- a/safe_app/src/tests/coins.rs
+++ b/safe_app/src/tests/coins.rs
@@ -14,7 +14,7 @@ use crate::{run, AppError};
 use futures::Future;
 use routing::XorName;
 use safe_core::{Client, CoreError};
-use safe_nd::{response::Transaction, AppPermissions, Coins, Error, PublicKey};
+use safe_nd::{AppPermissions, Coins, Error, PublicKey, Transaction};
 use std::str::FromStr;
 
 // Apps should not be able to request the coin balance if they don't have

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -26,7 +26,8 @@ new_rand = { package = "rand", version = "0.6" }
 routing = { package = "mock_routing", path = "../mock_routing" }
 rust_sodium = "~0.10.2"
 safe_core = { path = "../safe_core", version = "~0.32.1" }
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { path = "../../safe-nd" }
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
 # threshold_crypto = "0.3.1"

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -26,8 +26,7 @@ new_rand = { package = "rand", version = "0.6" }
 routing = { package = "mock_routing", path = "../mock_routing" }
 rust_sodium = "~0.10.2"
 safe_core = { path = "../safe_core", version = "~0.32.1" }
-# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
-safe-nd = { path = "../../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
 # threshold_crypto = "0.3.1"

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -31,7 +31,7 @@ safe-nd = { path = "../../safe-nd" }
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
 # threshold_crypto = "0.3.1"
-threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tiny-keccak = "~1.4.0"
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"

--- a/safe_authenticator/src/apps.rs
+++ b/safe_authenticator/src/apps.rs
@@ -208,7 +208,7 @@ pub fn apps_accessing_mutable_data(
             let mut app_access_vec: Vec<AppAccess> = Vec::new();
             for (user, perm_set) in permissions {
                 if let Key(public_key) = user {
-                    let app_access = match apps.get(&PublicKey::from(public_key)) {
+                    let app_access = match apps.get(&public_key) {
                         Some(app_info) => AppAccess {
                             sign_key: public_key,
                             permissions: perm_set,

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -9,6 +9,8 @@
 #[cfg(not(feature = "mock-network"))]
 use routing::Client as Routing;
 #[cfg(feature = "mock-network")]
+use safe_core::client::NewFullId;
+#[cfg(feature = "mock-network")]
 use safe_core::MockRouting as Routing;
 
 use crate::errors::AuthError;
@@ -31,7 +33,7 @@ use safe_core::crypto::{shared_box, shared_secretbox, shared_sign};
 #[cfg(any(test, feature = "testing"))]
 use safe_core::utils::seed::{divide_seed, SEED_SUBPARTS};
 use safe_core::{utils, Client, ClientKeys, CoreError, FutureExt, MDataInfo, NetworkTx};
-use safe_nd::{FullIdentity, Message, MessageId, PublicKey, Request};
+use safe_nd::{Message, MessageId, PublicKey, Request};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
@@ -153,7 +155,7 @@ where {
 
         let (mut routing, routing_rx) = setup_routing(
             full_id,
-            Some(FullIdentity::Client(maid_keys.clone().into())),
+            Some(NewFullId::Client(maid_keys.clone().into())),
             None,
         )?;
         routing = routing_wrapper_fn(routing);
@@ -337,7 +339,7 @@ where {
         trace!("Creating an actual routing...");
         let (mut routing, routing_rx) = setup_routing(
             Some(id_packet),
-            Some(FullIdentity::Client(acc.maid_keys.clone().into())),
+            Some(NewFullId::Client(acc.maid_keys.clone().into())),
             None,
         )?;
         routing = routing_wrapper_fn(routing);
@@ -483,9 +485,9 @@ impl Client for AuthClient {
         Some(auth_inner.acc.maid_keys.clone().into())
     }
 
-    fn full_id_new(&self) -> Option<FullIdentity> {
+    fn full_id_new(&self) -> Option<NewFullId> {
         let auth_inner = self.auth_inner.borrow();
-        Some(FullIdentity::Client(ClientKeys::into(
+        Some(NewFullId::Client(ClientKeys::into(
             auth_inner.acc.maid_keys.clone(),
         )))
     }

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -34,6 +34,7 @@ use safe_core::{utils, Client, ClientKeys, CoreError, FutureExt, MDataInfo, Netw
 use safe_nd::{
     request::{Request, Requester},
     Message, MessageId, PublicKey,
+    FullIdentity
 };
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -154,7 +155,7 @@ where {
         let pub_key = PublicKey::from(maid_keys.bls_pk);
         let full_id = Some(maid_keys.clone().into());
 
-        let (mut routing, routing_rx) = setup_routing(full_id, None)?;
+        let (mut routing, routing_rx) = setup_routing(full_id, Some(FullIdentity::Client(maid_keys.clone().into())), None)?;
         routing = routing_wrapper_fn(routing);
 
         let acc = Account::new(maid_keys)?;
@@ -298,7 +299,7 @@ where {
 
         let (acc_content, acc_version) = {
             trace!("Creating throw-away routing getter for account packet.");
-            let (mut routing, routing_rx) = setup_routing(None, None)?;
+            let (mut routing, routing_rx) = setup_routing(None, None, None)?;
             routing = routing_wrapper_fn(routing);
 
             let msg_id = MessageId::new();
@@ -334,7 +335,7 @@ where {
         let cm_addr = Authority::ClientManager(XorName::from(pub_key));
 
         trace!("Creating an actual routing...");
-        let (mut routing, routing_rx) = setup_routing(Some(id_packet), None)?;
+        let (mut routing, routing_rx) = setup_routing(Some(id_packet), Some(FullIdentity::Client(acc.maid_keys.clone().into())), None)?;
         routing = routing_wrapper_fn(routing);
 
         let joiner = spawn_routing_thread(routing_rx, core_tx.clone(), net_tx.clone());

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -37,8 +37,7 @@ threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git",
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
-# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
-safe-nd = { path = "../../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 
 [dev-dependencies]
 serde_json = "~1.0.9"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -37,7 +37,8 @@ threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git",
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { path = "../../safe-nd" }
 
 [dev-dependencies]
 serde_json = "~1.0.9"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -33,7 +33,7 @@ serde = "~1.0.27"
 serde_derive = "~1.0.27"
 tiny-keccak = "~1.4.0"
 # threshold_crypto = "0.3.1"
-threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tokio = "=0.1.8"
 tokio-core = "~0.1.17"
 unwrap = "~1.2.0"

--- a/safe_core/src/client/account.rs
+++ b/safe_core/src/client/account.rs
@@ -14,7 +14,7 @@ use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::FullId;
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, pwhash, secretbox, sign};
-use safe_nd::{XorName, XOR_NAME_LEN};
+use safe_nd::{ClientFullId, XorName, XOR_NAME_LEN};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use threshold_crypto::serde_impl::SerdeSecret;
 use tiny_keccak::sha3_256;
@@ -186,6 +186,14 @@ impl Into<FullId> for ClientKeys {
         let sign_sk = (*self.sign_sk).clone();
 
         FullId::with_keys((self.enc_pk, enc_sk), (self.sign_pk, sign_sk), self.bls_sk)
+    }
+}
+
+impl Into<ClientFullId> for ClientKeys {
+    fn into(self) -> ClientFullId {
+        let bls_sk = (self.bls_sk).clone();
+
+        ClientFullId::with_bls_key(bls_sk)
     }
 }
 

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -29,8 +29,7 @@ use routing::{
 };
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, sign};
-use safe_nd::request::{Request, Requester};
-use safe_nd::{Message, MessageId, PublicKey, XorName};
+use safe_nd::{Message, MessageId, PublicKey, Request, Signature, XorName};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -235,15 +234,16 @@ impl Client for CoreClient {
     fn compose_message(&self, request: Request) -> Message {
         let message_id = MessageId::new();
 
-        let sig = self
-            .keys
-            .bls_sk
-            .sign(&unwrap!(bincode::serialize(&(&request, message_id))));
+        let signature = Some(Signature::from(
+            self.keys
+                .bls_sk
+                .sign(&unwrap!(bincode::serialize(&(&request, message_id)))),
+        ));
 
         Message::Request {
             request,
             message_id,
-            requester: Requester::Owner(sig),
+            signature,
         }
     }
 }

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -29,7 +29,7 @@ use routing::{
 };
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, sign};
-use safe_nd::{Message, MessageId, PublicKey, Request, Signature, XorName};
+use safe_nd::{FullIdentity, Message, MessageId, PublicKey, Request, Signature, XorName};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -120,7 +120,11 @@ impl CoreClient {
         let pub_key = PublicKey::Bls(maid_keys.bls_pk);
         let full_id = Some(maid_keys.clone().into());
 
-        let (mut routing, routing_rx) = setup_routing(full_id, None)?;
+        let (mut routing, routing_rx) = setup_routing(
+            full_id,
+            Some(FullIdentity::Client(maid_keys.clone().into())),
+            None,
+        )?;
         routing = routing_wrapper_fn(routing);
 
         let acc = ClientAccount::new(maid_keys.clone())?;
@@ -185,6 +189,10 @@ impl Client for CoreClient {
 
     fn full_id(&self) -> Option<FullId> {
         Some(ClientKeys::into(self.keys.clone()))
+    }
+
+    fn full_id_new(&self) -> Option<FullIdentity> {
+        Some(FullIdentity::Client(ClientKeys::into(self.keys.clone())))
     }
 
     fn config(&self) -> Option<BootstrapConfig> {

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -12,6 +12,7 @@ use crate::client::mock::Routing;
 use routing::Client as Routing;
 
 use crate::client::account::{Account as ClientAccount, ClientKeys};
+use crate::client::NewFullId;
 use crate::client::{
     setup_routing, spawn_routing_thread, Client, ClientInner, IMMUT_DATA_CACHE_SIZE,
     REQUEST_TIMEOUT_SECS,
@@ -29,7 +30,7 @@ use routing::{
 };
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, sign};
-use safe_nd::{FullIdentity, Message, MessageId, PublicKey, Request, Signature, XorName};
+use safe_nd::{Message, MessageId, PublicKey, Request, Signature, XorName};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -122,7 +123,7 @@ impl CoreClient {
 
         let (mut routing, routing_rx) = setup_routing(
             full_id,
-            Some(FullIdentity::Client(maid_keys.clone().into())),
+            Some(NewFullId::Client(maid_keys.clone().into())),
             None,
         )?;
         routing = routing_wrapper_fn(routing);
@@ -191,8 +192,8 @@ impl Client for CoreClient {
         Some(ClientKeys::into(self.keys.clone()))
     }
 
-    fn full_id_new(&self) -> Option<FullIdentity> {
-        Some(FullIdentity::Client(ClientKeys::into(self.keys.clone())))
+    fn full_id_new(&self) -> Option<NewFullId> {
+        Some(NewFullId::Client(ClientKeys::into(self.keys.clone())))
     }
 
     fn config(&self) -> Option<BootstrapConfig> {

--- a/safe_core/src/client/mock/mod.rs
+++ b/safe_core/src/client/mock/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 pub mod vault;
 
 pub use self::account::{Account, CoinBalance, DEFAULT_MAX_MUTATIONS};
-pub use self::routing::{RequestHookFn, Routing};
+pub use self::routing::{NewFullId, RequestHookFn, Routing};
 use ::routing::XorName;
 
 /// Identifier of immutable data

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -80,8 +80,10 @@ pub fn unlimited_muts(config: &Config) -> bool {
 pub struct Routing {
     vault: Arc<Mutex<Vault>>,
     sender: Sender<Event>,
+    /// old
     pub full_id: FullId,
-    full_id_new: FullIdentity,
+    /// new
+    pub full_id_new: FullIdentity,
     client_auth: Authority<XorName>,
     max_ops_countdown: Option<Cell<u64>>,
     timeout_simulation: bool,

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -80,9 +80,9 @@ pub fn unlimited_muts(config: &Config) -> bool {
 pub struct Routing {
     vault: Arc<Mutex<Vault>>,
     sender: Sender<Event>,
-    /// old
+    /// mock_routing::FullId for old types
     pub full_id: FullId,
-    /// new
+    /// safe_nd::FullIdentity for new types
     pub full_id_new: FullIdentity,
     client_auth: Authority<XorName>,
     max_ops_countdown: Option<Cell<u64>>,

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -599,26 +599,23 @@ pub trait Client: Clone + 'static {
     }
 
     /// Get a current version of `MutableData` from the network.
-    fn get_mdata_version_new(&self, name: XorName, tag: u64) -> Box<CoreFuture<u64>> {
-        trace!("GetMDataVersion for {:?}", name);
+    fn get_mdata_version_new(&self, address: MDataAddress) -> Box<CoreFuture<u64>> {
+        // trace!("GetMDataVersion for {:?}", address);
 
-        send_new(
-            self,
-            Request::GetMDataVersion(MDataAddress::new_seq(name, tag)),
-        )
-        .and_then(|event| {
-            let res = match event {
-                CoreEvent::RpcResponse(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            };
-            let result_buffer = unwrap!(res);
-            let res: Response = unwrap!(deserialise(&result_buffer));
-            match res {
-                Response::GetMDataVersion(res) => res.map_err(CoreError::from),
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            }
-        })
-        .into_box()
+        send_new(self, Request::GetMDataVersion(address))
+            .and_then(|event| {
+                let res = match event {
+                    CoreEvent::RpcResponse(res) => res,
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                };
+                let result_buffer = unwrap!(res);
+                let res: Response = unwrap!(deserialise(&result_buffer));
+                match res {
+                    Response::GetMDataVersion(res) => res.map_err(CoreError::from),
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                }
+            })
+            .into_box()
     }
 
     /// Get a current version of `MutableData` from the network.
@@ -705,7 +702,7 @@ pub trait Client: Clone + 'static {
 
     /// Return a list of keys in `MutableData` stored on the network.
     fn list_mdata_keys(&self, name: XorName, tag: u64) -> Box<CoreFuture<BTreeSet<Vec<u8>>>> {
-        trace!("ListMDataKeys for {:?}", name);
+        // trace!("ListMDataKeys for {:?}", name);
 
         let msg_id = MessageId::new();
         send(self, msg_id, move |routing| {
@@ -716,26 +713,23 @@ pub trait Client: Clone + 'static {
     }
 
     /// Return a list of keys in `MutableData` stored on the network.
-    fn list_mdata_keys_new(&self, name: XorName, tag: u64) -> Box<CoreFuture<BTreeSet<Vec<u8>>>> {
-        trace!("ListMDataKeys for {:?}", name);
+    fn list_mdata_keys_new(&self, address: MDataAddress) -> Box<CoreFuture<BTreeSet<Vec<u8>>>> {
+        // trace!("ListMDataKeys for {:?}", name);
 
-        send_new(
-            self,
-            Request::ListMDataKeys(MDataAddress::new_seq(name, tag)),
-        )
-        .and_then(|event| {
-            let res = match event {
-                CoreEvent::RpcResponse(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            };
-            let result_buffer = unwrap!(res);
-            let res: Response = unwrap!(deserialise(&result_buffer));
-            match res {
-                Response::ListMDataKeys(res) => res.map_err(CoreError::from),
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            }
-        })
-        .into_box()
+        send_new(self, Request::ListMDataKeys(address))
+            .and_then(|event| {
+                let res = match event {
+                    CoreEvent::RpcResponse(res) => res,
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                };
+                let result_buffer = unwrap!(res);
+                let res: Response = unwrap!(deserialise(&result_buffer));
+                match res {
+                    Response::ListMDataKeys(res) => res.map_err(CoreError::from),
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                }
+            })
+            .into_box()
     }
 
     /// Return a list of values in a Sequenced Mutable Data
@@ -764,32 +758,25 @@ pub trait Client: Clone + 'static {
     /// Return the permissions set for a particular user
     fn list_mdata_user_permissions_new(
         &self,
-        name: XorName,
-        tag: u64,
+        address: MDataAddress,
         user: PublicKey,
     ) -> Box<CoreFuture<NewPermissionSet>> {
-        trace!("GetMDataUserPermissions for {:?}", name);
+        // trace!("GetMDataUserPermissions for {:?}", name);
 
-        send_new(
-            self,
-            Request::ListMDataUserPermissions {
-                address: MDataAddress::new_seq(name, tag),
-                user,
-            },
-        )
-        .and_then(|event| {
-            let res = match event {
-                CoreEvent::RpcResponse(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            };
-            let result_buffer = unwrap!(res);
-            let res: Response = unwrap!(deserialise(&result_buffer));
-            match res {
-                Response::ListMDataUserPermissions(res) => res.map_err(CoreError::from),
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            }
-        })
-        .into_box()
+        send_new(self, Request::ListMDataUserPermissions { address, user })
+            .and_then(|event| {
+                let res = match event {
+                    CoreEvent::RpcResponse(res) => res,
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                };
+                let result_buffer = unwrap!(res);
+                let res: Response = unwrap!(deserialise(&result_buffer));
+                match res {
+                    Response::ListMDataUserPermissions(res) => res.map_err(CoreError::from),
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                }
+            })
+            .into_box()
     }
 
     /// Returns a list of values in an Unsequenced Mutable Data
@@ -871,28 +858,24 @@ pub trait Client: Clone + 'static {
     /// Return a list of permissions in `MutableData` stored on the network.
     fn list_mdata_permissions_new(
         &self,
-        name: XorName,
-        tag: u64,
+        address: MDataAddress,
     ) -> Box<CoreFuture<BTreeMap<PublicKey, NewPermissionSet>>> {
-        trace!("List MDataPermissions for {:?}", name);
+        // trace!("List MDataPermissions for {:?}", name);
 
-        send_new(
-            self,
-            Request::ListMDataPermissions(MDataAddress::new_seq(name, tag)),
-        )
-        .and_then(|event| {
-            let res = match event {
-                CoreEvent::RpcResponse(res) => res,
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            };
-            let result_buffer = unwrap!(res);
-            let res: Response = unwrap!(deserialise(&result_buffer));
-            match res {
-                Response::ListMDataPermissions(res) => res.map_err(CoreError::from),
-                _ => Err(CoreError::ReceivedUnexpectedEvent),
-            }
-        })
-        .into_box()
+        send_new(self, Request::ListMDataPermissions(address))
+            .and_then(|event| {
+                let res = match event {
+                    CoreEvent::RpcResponse(res) => res,
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                };
+                let result_buffer = unwrap!(res);
+                let res: Response = unwrap!(deserialise(&result_buffer));
+                match res {
+                    Response::ListMDataPermissions(res) => res.map_err(CoreError::from),
+                    _ => Err(CoreError::ReceivedUnexpectedEvent),
+                }
+            })
+            .into_box()
     }
 
     /// Return a list of permissions for a particular User in MutableData.
@@ -943,18 +926,17 @@ pub trait Client: Clone + 'static {
     /// Updates or inserts a permissions set for a user
     fn set_mdata_user_permissions_new(
         &self,
-        name: XorName,
-        tag: u64,
+        address: MDataAddress,
         user: PublicKey,
         permissions: NewPermissionSet,
         version: u64,
     ) -> Box<CoreFuture<()>> {
-        trace!("SetMDataUserPermissions for {:?}", name);
+        // trace!("SetMDataUserPermissions for {:?}", name);
 
         send_mutation_new(
             self,
             Request::SetMDataUserPermissions {
-                address: MDataAddress::new_seq(name, tag),
+                address,
                 user,
                 permissions: permissions.clone(),
                 version,
@@ -965,17 +947,16 @@ pub trait Client: Clone + 'static {
     /// Updates or inserts a permissions set for a user
     fn del_mdata_user_permissions_new(
         &self,
-        name: XorName,
-        tag: u64,
+        address: MDataAddress,
         user: PublicKey,
         version: u64,
     ) -> Box<CoreFuture<()>> {
-        trace!("DelMDataUserPermissions for {:?}", name);
+        // trace!("DelMDataUserPermissions for {:?}", name);
 
         send_mutation_new(
             self,
             Request::DelMDataUserPermissions {
-                address: MDataAddress::new_seq(name, tag),
+                address,
                 user,
                 version,
             },
@@ -1495,7 +1476,7 @@ mod tests {
                     println!("Put unseq. MData successfully");
 
                     client3
-                        .get_mdata_version_new(name, tag)
+                        .get_mdata_version_new(MDataAddress::new_unseq(name, tag))
                         .map(move |version| assert_eq!(version, 0))
                 })
                 .and_then(move |_| {
@@ -1507,7 +1488,7 @@ mod tests {
                 })
                 .and_then(move |_| {
                     client5
-                        .list_mdata_keys_new(name, tag)
+                        .list_mdata_keys_new(MDataAddress::new_unseq(name, tag))
                         .map(move |keys| assert_eq!(keys, entries_keys))
                 })
                 .and_then(move |_| {
@@ -1581,7 +1562,7 @@ mod tests {
                 })
                 .and_then(move |_| {
                     client5
-                        .list_mdata_keys_new(name, tag)
+                        .list_mdata_keys_new(MDataAddress::new_seq(name, tag))
                         .map(move |keys| assert_eq!(keys, entries_keys))
                 })
                 .and_then(move |_| {
@@ -1850,14 +1831,19 @@ mod tests {
                         .allow(MDataAction::ManagePermissions)
                         .allow(MDataAction::Read);
                     client2
-                        .set_mdata_user_permissions_new(name, tag, user, new_perm_set, 1)
+                        .set_mdata_user_permissions_new(
+                            MDataAddress::new_seq(name, tag),
+                            user,
+                            new_perm_set,
+                            1,
+                        )
                         .and_then(|_| Ok(()))
                 })
                 .and_then(move |_| {
                     println!("Modified user permissions");
 
                     client3
-                        .list_mdata_user_permissions_new(name, tag, user2)
+                        .list_mdata_user_permissions_new(MDataAddress::new_seq(name, tag), user2)
                         .and_then(|permissions| {
                             assert!(!permissions.is_allowed(MDataAction::Insert));
                             assert!(permissions.is_allowed(MDataAction::Read));
@@ -1869,13 +1855,17 @@ mod tests {
                 })
                 .and_then(move |_| {
                     client4
-                        .del_mdata_user_permissions_new(name, tag, random_user, 2)
+                        .del_mdata_user_permissions_new(
+                            MDataAddress::new_seq(name, tag),
+                            random_user,
+                            2,
+                        )
                         .and_then(|_| Ok(()))
                 })
                 .and_then(move |_| {
                     println!("Deleted permissions");
                     client5
-                        .list_mdata_permissions_new(name, tag)
+                        .list_mdata_permissions_new(MDataAddress::new_seq(name, tag))
                         .and_then(|permissions| {
                             assert_eq!(permissions.len(), 1);
                             println!("Permission set verified");

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -463,10 +463,10 @@ pub trait Client: Clone + 'static {
     }
 
     /// Delete MData from network
-    fn delete_mdata(&self, mdataref: MDataAddress) -> Box<CoreFuture<()>> {
-        trace!("Delete entire Mutable Data");
+    fn delete_mdata(&self, address: MDataAddress) -> Box<CoreFuture<()>> {
+        trace!("Delete entire Mutable Data at {:?}", address);
 
-        send_mutation_new(self, Request::DeleteMData(mdataref))
+        send_mutation_new(self, Request::DeleteMData(address))
     }
 
     /// Mutates `MutableData` entries in bulk.
@@ -600,7 +600,7 @@ pub trait Client: Clone + 'static {
 
     /// Get a current version of `MutableData` from the network.
     fn get_mdata_version_new(&self, address: MDataAddress) -> Box<CoreFuture<u64>> {
-        // trace!("GetMDataVersion for {:?}", address);
+        trace!("GetMDataVersion for {:?}", address);
 
         send_new(self, Request::GetMDataVersion(address))
             .and_then(|event| {
@@ -702,7 +702,7 @@ pub trait Client: Clone + 'static {
 
     /// Return a list of keys in `MutableData` stored on the network.
     fn list_mdata_keys(&self, name: XorName, tag: u64) -> Box<CoreFuture<BTreeSet<Vec<u8>>>> {
-        // trace!("ListMDataKeys for {:?}", name);
+        trace!("ListMDataKeys for {:?}", name);
 
         let msg_id = MessageId::new();
         send(self, msg_id, move |routing| {
@@ -714,7 +714,7 @@ pub trait Client: Clone + 'static {
 
     /// Return a list of keys in `MutableData` stored on the network.
     fn list_mdata_keys_new(&self, address: MDataAddress) -> Box<CoreFuture<BTreeSet<Vec<u8>>>> {
-        // trace!("ListMDataKeys for {:?}", name);
+        trace!("ListMDataKeys for {:?}", address);
 
         send_new(self, Request::ListMDataKeys(address))
             .and_then(|event| {
@@ -761,7 +761,7 @@ pub trait Client: Clone + 'static {
         address: MDataAddress,
         user: PublicKey,
     ) -> Box<CoreFuture<NewPermissionSet>> {
-        // trace!("GetMDataUserPermissions for {:?}", name);
+        trace!("GetMDataUserPermissions for {:?}", address);
 
         send_new(self, Request::ListMDataUserPermissions { address, user })
             .and_then(|event| {
@@ -860,7 +860,7 @@ pub trait Client: Clone + 'static {
         &self,
         address: MDataAddress,
     ) -> Box<CoreFuture<BTreeMap<PublicKey, NewPermissionSet>>> {
-        // trace!("List MDataPermissions for {:?}", name);
+        trace!("List MDataPermissions for {:?}", address);
 
         send_new(self, Request::ListMDataPermissions(address))
             .and_then(|event| {
@@ -931,7 +931,7 @@ pub trait Client: Clone + 'static {
         permissions: NewPermissionSet,
         version: u64,
     ) -> Box<CoreFuture<()>> {
-        // trace!("SetMDataUserPermissions for {:?}", name);
+        trace!("SetMDataUserPermissions for {:?}", address);
 
         send_mutation_new(
             self,
@@ -951,7 +951,7 @@ pub trait Client: Clone + 'static {
         user: PublicKey,
         version: u64,
     ) -> Box<CoreFuture<()>> {
-        // trace!("DelMDataUserPermissions for {:?}", name);
+        trace!("DelMDataUserPermissions for {:?}", address);
 
         send_mutation_new(
             self,

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -25,6 +25,8 @@ pub use self::mdata_info::MDataInfo;
 #[cfg(feature = "mock-network")]
 pub use self::mock::vault::mock_vault_path;
 #[cfg(feature = "mock-network")]
+pub use self::mock::NewFullId;
+#[cfg(feature = "mock-network")]
 pub use self::mock::Routing as MockRouting;
 
 #[cfg(feature = "mock-network")]
@@ -50,7 +52,7 @@ use routing::{
 };
 use rust_sodium::crypto::{box_, sign};
 use safe_nd::{
-    AppPermissions, Coins, FullIdentity, IDataAddress, ImmutableData, MDataAddress,
+    AppPermissions, Coins, IDataAddress, ImmutableData, MDataAddress,
     MDataPermissionSet as NewPermissionSet, MDataSeqEntryAction as SeqEntryAction,
     MDataUnseqEntryAction as UnseqEntryAction, MDataValue as Val, Message, MessageId,
     MutableData as NewMutableData, PublicKey, Request, Response, SeqMutableData, Transaction,
@@ -110,7 +112,7 @@ pub trait Client: Clone + 'static {
     fn full_id(&self) -> Option<FullId>;
 
     /// Return the client's new ID.
-    fn full_id_new(&self) -> Option<FullIdentity>;
+    fn full_id_new(&self) -> Option<NewFullId>;
 
     /// Return a `crust::Config` if the `Client` was initialized with one.
     fn config(&self) -> Option<BootstrapConfig>;
@@ -1159,7 +1161,7 @@ where
 /// Set up routing given a Client `full_id` and optional `config` and connect to the network.
 pub fn setup_routing(
     full_id: Option<FullId>,
-    full_id_new: Option<FullIdentity>,
+    full_id_new: Option<NewFullId>,
     config: Option<BootstrapConfig>,
 ) -> Result<(Routing, Receiver<Event>), CoreError> {
     let (routing_tx, routing_rx) = mpsc::channel();

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,8 +14,7 @@ serde = "~1.0.24"
 serde_json = "~1.0.2"
 serde_derive = "~1.0.24"
 unwrap = "~1.2.0"
-# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
-safe-nd = { path = "../../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 
 [dependencies.safe_app]
 path = "../safe_app"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,8 @@ serde = "~1.0.24"
 serde_json = "~1.0.2"
 serde_derive = "~1.0.24"
 unwrap = "~1.2.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+# safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = { path = "../../safe-nd" }
 
 [dependencies.safe_app]
 path = "../safe_app"


### PR DESCRIPTION
- Adapt to the changes in safe-nd for data type structs and request/response types
- Add `FullId` variant to mock-routing from which the vaults fetch the requester field
- Implement proper approach to signature verification and permissions validation for mutable / immutable data
- Re-enable IData tests
Resolves #849 