### PR TITLE
feat/adata: implement AppendOnly Data RPCs and support AppendOnly Data in Mock Vault

### DIFF
--- a/safe_core/src/client/mock/mod.rs
+++ b/safe_core/src/client/mock/mod.rs
@@ -36,6 +36,16 @@ impl MutableDataId {
     }
 }
 
+/// Identifier of appendonly data
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct AppendOnlyId(pub XorName, pub u64);
+
+impl AppendOnlyId {
+    pub fn name(&self) -> &XorName {
+        &self.0
+    }
+}
+
 /// Identifier for a data (immutable or mutable)
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub enum DataId {
@@ -43,6 +53,8 @@ pub enum DataId {
     Immutable(ImmutableDataId),
     /// Identifier of mutable data.
     Mutable(MutableDataId),
+    /// Identifier of mutable data.
+    AppendOnly(AppendOnlyId),
 }
 
 impl DataId {
@@ -56,11 +68,17 @@ impl DataId {
         DataId::Mutable(MutableDataId(name, tag))
     }
 
+    /// Create `DataId` for mutable data.
+    pub fn append_only(name: XorName, tag: u64) -> Self {
+        DataId::AppendOnly(AppendOnlyId(name, tag))
+    }
+
     /// Get name of this identifier.
     pub fn name(&self) -> &XorName {
         match *self {
             DataId::Immutable(ref id) => id.name(),
             DataId::Mutable(ref id) => id.name(),
+            DataId::AppendOnly(ref id) => id.name(),
         }
     }
 }


### PR DESCRIPTION
- Implements feature complete AppendOnly Data RPCs
- Implements AppendOnly Data in Mock Vault
- Adds tests for AppendOnly Data RPCs