### PR TITLE
Use build-mock in Container Build

### DIFF
--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -31,7 +31,7 @@ COPY . .
 USER maidsafe:maidsafe
 ENV CARGO_TARGET_DIR=/target
 RUN cargo install cargo-script && \
-   ./scripts/build-real && \
+   ./scripts/build-mock && \
    ./scripts/package.rs --help && \
    find /target/release/ -maxdepth 1 -type f -exec rm '{}' \;
 ENTRYPOINT ["fixuid", "-q"]


### PR DESCRIPTION
Hi Nikita,

I'm setting up a job in Jenkins to build the container automatically on a merge to `experimental` or `master`, so need the Docker build definition changed to build mock rather than real.

Cheers,

Chris
