### PR TITLE
Implement CreateCoinBalance RPC and remove src parameter for safecoin transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-nd#6077fab6ffc9b5e5d56f7ba63707275c9c0ae1ad"
+source = "git+https://github.com/maidsafe/safe-nd#d8615b265924e76ab97a6a3c727e129f9612afc5"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/safe_app/src/tests/coins.rs
+++ b/safe_app/src/tests/coins.rs
@@ -14,7 +14,7 @@ use crate::{run, AppError};
 use futures::Future;
 use routing::XorName;
 use safe_core::{Client, CoreError};
-use safe_nd::{AppPermissions, Coins, Error, PublicKey, Transaction};
+use safe_nd::{AppPermissions, Coins, Error, Transaction};
 use std::str::FromStr;
 
 // Apps should not be able to request the coin balance if they don't have
@@ -29,16 +29,12 @@ fn coin_app_deny_permissions() {
     let app = create_app();
 
     unwrap!(run(&app, |client, _app_context| {
-        let owner_bls_key = if let PublicKey::Bls(bls) = unwrap!(client.owner_key()) {
-            bls
-        } else {
-            panic!("Unexpected key type")
-        };
-        let owner_coin_balance = XorName::from(unwrap!(client.owner_key()));
-        client.create_coin_balance(
+        let owner_key = unwrap!(client.owner_key());
+        let owner_coin_balance = XorName::from(owner_key);
+        client.test_create_coin_balance(
             &owner_coin_balance,
             unwrap!(Coins::from_str("100.0")),
-            owner_bls_key,
+            owner_key,
         );
 
         let c2 = client.clone();
@@ -87,16 +83,12 @@ fn coin_app_allow_permissions() {
     let app = create_app();
 
     let coin_balance2 = unwrap!(run(&app, |client, _app_context| {
-        let owner_bls_key = if let PublicKey::Bls(bls) = unwrap!(client.owner_key()) {
-            bls
-        } else {
-            panic!("Unexpected key type")
-        };
-        let coin_balance2 = XorName::from(unwrap!(client.owner_key()));
-        client.create_coin_balance(
+        let owner_key = unwrap!(client.owner_key());
+        let coin_balance2 = XorName::from(owner_key);
+        client.test_create_coin_balance(
             &coin_balance2,
             unwrap!(Coins::from_str("50.0")),
-            owner_bls_key,
+            owner_key,
         );
         Ok(coin_balance2)
     }));
@@ -111,16 +103,12 @@ fn coin_app_allow_permissions() {
 
     // Test the basic coin operations.
     unwrap!(run(&app, move |client, _app_context| {
-        let owner_bls_key = if let PublicKey::Bls(bls) = unwrap!(client.owner_key()) {
-            bls
-        } else {
-            panic!("Unexpected key type")
-        };
-        let owner_coin_balance = XorName::from(unwrap!(client.owner_key()));
-        client.create_coin_balance(
+        let owner_key = unwrap!(client.owner_key());
+        let owner_coin_balance = XorName::from(owner_key);
+        client.test_create_coin_balance(
             &owner_coin_balance,
             unwrap!(Coins::from_str("100.0")),
-            owner_bls_key,
+            owner_key,
         );
 
         let c2 = client.clone();

--- a/safe_app/src/tests/coins.rs
+++ b/safe_app/src/tests/coins.rs
@@ -41,7 +41,7 @@ fn coin_app_deny_permissions() {
         let c3 = client.clone();
 
         client
-            .get_balance(owner_coin_balance, None)
+            .get_balance(None)
             .then(move |res| {
                 match res {
                     Err(CoreError::NewRoutingClientError(Error::AccessDenied)) => (),
@@ -49,7 +49,6 @@ fn coin_app_deny_permissions() {
                 }
 
                 c2.transfer_coins(
-                    owner_coin_balance,
                     None,
                     new_rand::random(),
                     unwrap!(Coins::from_str("1.0")),
@@ -115,7 +114,7 @@ fn coin_app_allow_permissions() {
         let c3 = client.clone();
 
         client
-            .get_balance(owner_coin_balance, None)
+            .get_balance(None)
             .then(move |res| {
                 match res {
                     Ok(balance) => println!("{:?}", balance),
@@ -123,7 +122,6 @@ fn coin_app_allow_permissions() {
                 }
 
                 c2.transfer_coins(
-                    owner_coin_balance,
                     None,
                     coin_balance2,
                     unwrap!(Coins::from_str("1.0")),

--- a/safe_core/src/client/mock/account.rs
+++ b/safe_core/src/client/mock/account.rs
@@ -11,7 +11,6 @@ use crate::config_handler::Config;
 use routing::AccountInfo;
 use safe_nd::{AppPermissions, Coins, Error, PublicKey};
 use std::collections::{BTreeMap, VecDeque};
-use threshold_crypto::PublicKey as BlsPublicKey;
 
 pub const DEFAULT_MAX_MUTATIONS: u64 = 1000;
 pub const DEFAULT_MAX_CREDITS: usize = 100;
@@ -19,13 +18,13 @@ pub const DEFAULT_MAX_CREDITS: usize = 100;
 
 #[derive(Deserialize, Serialize)]
 pub struct CoinBalance {
-    owner: BlsPublicKey,
+    owner: PublicKey,
     value: Coins,
     credits: VecDeque<Credit>,
 }
 
 impl CoinBalance {
-    pub fn new(value: Coins, owner: BlsPublicKey) -> Self {
+    pub fn new(value: Coins, owner: PublicKey) -> Self {
         Self {
             owner,
             value,
@@ -74,7 +73,7 @@ impl CoinBalance {
         self.credits.push_front(credit);
     }
 
-    pub fn owner(&self) -> &BlsPublicKey {
+    pub fn owner(&self) -> &PublicKey {
         &self.owner
     }
 }

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -1061,7 +1061,7 @@ impl Routing {
         &self,
         coin_balance_name: &XorName,
         amount: Coins,
-        owner: threshold_crypto::PublicKey,
+        owner: PublicKey,
     ) {
         let mut vault = self.lock_vault(true);
         vault.mock_create_balance(coin_balance_name, amount, owner);

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -82,7 +82,7 @@ impl Routing {
             .full_id_new
             .sign(&unwrap!(bincode::serialize(&(&request, message_id))));
         unwrap!(self.send(
-            Authority::ClientManager(new_rand::random()),
+            None,
             &unwrap!(serialise(&Message::Request {
                 request,
                 message_id,


### PR DESCRIPTION
- Implement create_coin_balace that creates a new coin balance for a
given address and public key, preloaded with some safecoin from an
existing wallet. If the existing wallet does not use the client's owner
key then the secret key must be specified
- Remove source fields from safecoin transactions, the wallet address is
derived from the Public Id of the client
- Replace the dest parameter in routing::send with a requester field to
send an optional PublicKey in case of arbitrary wallet transactions
- Refactor the handling of wallet transactions in the mock vault to
adapt to the above changes
Resolves #851, #844 