### PR TITLE
Implement login packet operations

### DIFF
--- a/safe_core/src/client/mock/mod.rs
+++ b/safe_core/src/client/mock/mod.rs
@@ -9,6 +9,7 @@
 pub mod vault;
 
 mod account;
+#[macro_use]
 mod routing;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
- Adapt to the latest changes in safe-nd
- Handle RPCs for login packet operations
- Add `create_account` and `get_account` public API to establish new routing instances and perform the required operations

closes #858