### PR TITLE
Add functions for safecoin operations without a client instance

### DIFF
--- a/safe_app/src/tests/coins.rs
+++ b/safe_app/src/tests/coins.rs
@@ -31,7 +31,7 @@ fn coin_app_deny_permissions() {
     unwrap!(run(&app, |client, _app_context| {
         let owner_key = unwrap!(client.owner_key());
         let owner_coin_balance = XorName::from(owner_key);
-        client.test_create_coin_balance(
+        client.test_create_balance(
             &owner_coin_balance,
             unwrap!(Coins::from_str("100.0")),
             owner_key,
@@ -75,11 +75,7 @@ fn coin_app_allow_permissions() {
     let coin_balance2 = unwrap!(run(&app, |client, _app_context| {
         let owner_key = unwrap!(client.owner_key());
         let coin_balance2 = XorName::from(owner_key);
-        client.test_create_coin_balance(
-            &coin_balance2,
-            unwrap!(Coins::from_str("50.0")),
-            owner_key,
-        );
+        client.test_create_balance(&coin_balance2, unwrap!(Coins::from_str("50.0")), owner_key);
         Ok(coin_balance2)
     }));
 
@@ -95,7 +91,7 @@ fn coin_app_allow_permissions() {
     unwrap!(run(&app, move |client, _app_context| {
         let owner_key = unwrap!(client.owner_key());
         let owner_coin_balance = XorName::from(owner_key);
-        client.test_create_coin_balance(
+        client.test_create_balance(
             &owner_coin_balance,
             unwrap!(Coins::from_str("100.0")),
             owner_key,

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -1110,12 +1110,7 @@ impl Routing {
     }
 
     /// Create coin balance in the mock network arbitrarily.
-    pub fn create_coin_balance(
-        &self,
-        coin_balance_name: &XorName,
-        amount: Coins,
-        owner: PublicKey,
-    ) {
+    pub fn create_balance(&self, coin_balance_name: &XorName, amount: Coins, owner: PublicKey) {
         let mut vault = self.lock_vault(true);
         vault.mock_create_balance(coin_balance_name, amount, owner);
     }

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -348,7 +348,8 @@ impl Vault {
             request,
             message_id,
             signature,
-        } = unwrap!(deserialise(&payload))
+        } =
+            deserialise(&payload).map_err(|_| SndError::from("Error deserialising message"))?
         {
             (request, message_id, signature)
         } else {
@@ -790,8 +791,8 @@ impl Vault {
                 let result = self
                     .get_mdata(address, requester_pk, request)
                     .and_then(|data| match data {
-                        MData::Unseq(mdata) => Ok((*unwrap!(mdata.user_permissions(user))).clone()),
-                        MData::Seq(mdata) => Ok((*unwrap!(mdata.user_permissions(user))).clone()),
+                        MData::Unseq(mdata) => Ok((*mdata.user_permissions(user)?).clone()),
+                        MData::Seq(mdata) => Ok((*mdata.user_permissions(user)?).clone()),
                     });
                 Response::ListMDataUserPermissions(result)
             }
@@ -984,7 +985,7 @@ impl Vault {
                             }
                         }
                     });
-                unwrap!(res)
+                res?
             }
             Request::GetPubADataUserPermissions {
                 address,

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -300,11 +300,7 @@ impl Vault {
         let _ = self.cache.nae_manager.remove(&name);
     }
 
-    fn create_coin_balance(
-        &mut self,
-        destination: XorName,
-        owner: PublicKey,
-    ) -> Result<(), SndError> {
+    fn create_balance(&mut self, destination: XorName, owner: PublicKey) -> Result<(), SndError> {
         if self.get_coin_balance(&destination).is_some() {
             return Err(SndError::BalanceExists);
         }
@@ -463,7 +459,7 @@ impl Vault {
                             if source_balance.checked_sub(amount).is_none() {
                                 return Err(SndError::InsufficientBalance);
                             }
-                            self.create_coin_balance(destination, new_balance_owner)
+                            self.create_balance(destination, new_balance_owner)
                         })
                         .and_then(|_| {
                             self.transfer_coins(source, destination, amount, transaction_id)
@@ -519,7 +515,7 @@ impl Vault {
                                 None => return Err(SndError::NoSuchBalance),
                             };
                             // Create the balance and transfer the mentioned amount of coins
-                            self.create_coin_balance(new_balance_dest, new_owner)
+                            self.create_balance(new_balance_dest, new_owner)
                         })
                         .and_then(|_| {
                             self.transfer_coins(source, new_balance_dest, amount, transaction_id)


### PR DESCRIPTION
Users with a wallet and without an account should be able to perform coin operations. The functions added will allow coin operations to be performed, provided the secret key of the wallet is provided.