### PR TITLE
Allow GET requests to be sent by unregistered clients

### DIFF
--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -462,7 +462,7 @@ impl Vault {
                 let source = owner_pk.into();
                 let destination = new_balance_owner.into();
                 if let Err(e) = self.authorise_coin_operation(&source, requester_pk) {
-                    Response::Mutation(Err(e))
+                    Response::Transaction(Err(e))
                 } else {
                     let res = self
                         .get_balance(&source)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -90,13 +90,13 @@ fn unregistered_client() {
     // Registered Client PUTs something onto the network.
     {
         let orig_data = orig_data.clone();
-        random_client(|client| client.put_idata(orig_data));
+        random_client(|client| client.put_pub_idata(orig_data));
     }
 
     // Unregistered Client should be able to retrieve the data.
     let app = unwrap!(App::unregistered(|| (), None));
     unwrap!(run(&app, move |client, _context| {
-        let _ = client.get_idata(*orig_data.name()).map(move |data| {
+        let _ = client.get_pub_idata(*orig_data.name()).map(move |data| {
             assert_eq!(data, orig_data);
         });
         Ok(())


### PR DESCRIPTION
- Create a random keypair for every unregistered session and init routing using a ClientFullId generated from those keys
- Add tests for unregistered access to published AData

Resolves #899, #900 