### PR TITLE
fix/all: disable AppClients from accessing Auth Keys

### DIFF
--- a/safe_app/src/tests/mutable_data.rs
+++ b/safe_app/src/tests/mutable_data.rs
@@ -16,7 +16,7 @@ use futures::Future;
 use maidsafe_utilities::thread;
 use routing::{Action, ClientError, EntryAction, MutableData, PermissionSet, User, Value, XorName};
 use safe_core::utils::test_utils::random_client;
-use safe_core::{utils, Client, CoreError, FutureExt, DIR_TAG};
+use safe_core::{client::AuthActions, utils, Client, CoreError, FutureExt, DIR_TAG};
 use safe_nd::PublicKey;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::CString;

--- a/safe_app/src/tests/unpublished_mutable_data.rs
+++ b/safe_app/src/tests/unpublished_mutable_data.rs
@@ -15,7 +15,7 @@ use futures::Future;
 use maidsafe_utilities::thread;
 use rand::{OsRng, Rng};
 use safe_core::utils::test_utils::random_client;
-use safe_core::{Client, CoreError, FutureExt, DIR_TAG};
+use safe_core::{client::AuthActions, Client, CoreError, FutureExt, DIR_TAG};
 use safe_nd::{Error, PublicKey, XorName};
 use safe_nd::{
     MDataAction, MDataAddress, MDataPermissionSet, MDataSeqEntryActions, MDataUnseqEntryActions,

--- a/safe_authenticator/src/app_auth.rs
+++ b/safe_authenticator/src/app_auth.rs
@@ -20,7 +20,9 @@ use routing::ClientError;
 use safe_core::client;
 use safe_core::ipc::req::{AuthReq, ContainerPermissions, Permission};
 use safe_core::ipc::resp::{AccessContInfo, AccessContainerEntry, AppKeys, AuthGranted};
-use safe_core::{app_container_name, recovery, Client, CoreError, FutureExt, MDataInfo};
+use safe_core::{
+    app_container_name, client::AuthActions, recovery, Client, CoreError, FutureExt, MDataInfo,
+};
 use safe_nd::{AppPermissions, PublicKey};
 use std::collections::HashMap;
 use tiny_keccak::sha3_256;

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -27,7 +27,8 @@ use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, sign};
 use safe_core::client::account::Account;
 use safe_core::client::{
-    setup_routing, spawn_routing_thread, ClientInner, IMMUT_DATA_CACHE_SIZE, REQUEST_TIMEOUT_SECS,
+    setup_routing, spawn_routing_thread, AuthActions, ClientInner, IMMUT_DATA_CACHE_SIZE,
+    REQUEST_TIMEOUT_SECS,
 };
 use safe_core::crypto::{shared_box, shared_secretbox, shared_sign};
 #[cfg(any(test, feature = "testing"))]
@@ -476,6 +477,8 @@ where {
         account.root_dirs_created = val;
     }
 }
+
+impl AuthActions for AuthClient {}
 
 impl Client for AuthClient {
     type MsgType = ();

--- a/safe_authenticator/src/revocation.rs
+++ b/safe_authenticator/src/revocation.rs
@@ -16,7 +16,7 @@ use futures::future::{self, Either, Loop};
 use futures::Future;
 use routing::{ClientError, EntryActions, User, Value};
 use safe_core::recovery;
-use safe_core::{Client, CoreError, FutureExt, MDataInfo};
+use safe_core::{client::AuthActions, Client, CoreError, FutureExt, MDataInfo};
 use safe_nd::PublicKey;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::ffi::apps::*;
 use crate::ffi::ipc::{
     auth_revoke_app, encode_auth_resp, encode_containers_resp, encode_unregistered_resp,
 };
+use crate::safe_core::client::AuthActions;
 use crate::safe_core::ffi::ipc::req::AppExchangeInfo as FfiAppExchangeInfo;
 use crate::safe_core::ipc::{
     self, AuthReq, BootstrapConfig, ContainersReq, IpcError, IpcMsg, IpcReq, IpcResp, Permission,

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -45,7 +45,7 @@ mod mock_routing {
     use safe_core::ipc::{IpcError, Permission};
     use safe_core::utils::test_utils::Synchronizer;
     use safe_core::MockRouting;
-    use safe_core::{Client, FutureExt};
+    use safe_core::{client::AuthActions, Client, FutureExt};
     use std::collections::HashMap;
     use std::iter;
     use std::sync::{Arc, Barrier};

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -6,15 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client::account::{Account as ClientAccount, ClientKeys};
 #[cfg(feature = "mock-network")]
 use crate::client::mock::Routing;
-#[cfg(not(feature = "mock-network"))]
-use routing::Client as Routing;
-
-use crate::client::account::{Account as ClientAccount, ClientKeys};
 use crate::client::NewFullId;
 use crate::client::{
-    setup_routing, spawn_routing_thread, Client, ClientInner, IMMUT_DATA_CACHE_SIZE,
+    setup_routing, spawn_routing_thread, AuthActions, Client, ClientInner, IMMUT_DATA_CACHE_SIZE,
     REQUEST_TIMEOUT_SECS,
 };
 use crate::crypto::{shared_box, shared_secretbox, shared_sign};
@@ -24,6 +21,8 @@ use crate::event_loop::CoreMsgTx;
 use crate::utils;
 use lru_cache::LruCache;
 use maidsafe_utilities::serialisation::serialise;
+#[cfg(not(feature = "mock-network"))]
+use routing::Client as Routing;
 use routing::{
     AccountPacket, Authority, BootstrapConfig, Event, FullId, MutableData, Response, Value,
     ACC_LOGIN_ENTRY_KEY, TYPE_TAG_SESSION_PACKET,
@@ -256,6 +255,8 @@ impl Client for CoreClient {
         }
     }
 }
+
+impl AuthActions for CoreClient {}
 
 impl Clone for CoreClient {
     fn clone(&self) -> Self {

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -339,6 +339,7 @@ impl Vault {
         }
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub fn process_request(
         &mut self,
         requester: PublicId,
@@ -411,14 +412,12 @@ impl Vault {
             // ===== Client (Owner) to SrcElders =====
             Request::ListAuthKeysAndVersion => {
                 let name = requester.name();
-                if let Some(account) = self.get_account(&name) {
-                    Response::ListAuthKeysAndVersion(Ok((
-                        account.auth_keys().clone(),
-                        account.version(),
-                    )))
+                let res = if let Some(account) = self.get_account(&name) {
+                    Ok((account.auth_keys().clone(), account.version()))
                 } else {
-                    return Err(SndError::AccessDenied);
-                }
+                    Err(SndError::AccessDenied)
+                };
+                Response::ListAuthKeysAndVersion(res)
             }
             Request::InsAuthKey {
                 key,
@@ -426,19 +425,21 @@ impl Vault {
                 version,
             } => {
                 let name = requester.name();
-                if let Some(account) = self.get_account_mut(&name) {
-                    Response::Mutation(account.ins_auth_key(key, permissions, version))
+                let res = if let Some(account) = self.get_account_mut(&name) {
+                    account.ins_auth_key(key, permissions, version)
                 } else {
-                    return Err(SndError::AccessDenied);
-                }
+                    Err(SndError::AccessDenied)
+                };
+                Response::Mutation(res)
             }
             Request::DelAuthKey { key, version } => {
                 let name = requester.name();
-                if let Some(account) = self.get_account_mut(&name) {
-                    Response::Mutation(account.del_auth_key(&key, version))
+                let res = if let Some(account) = self.get_account_mut(&name) {
+                    account.del_auth_key(&key, version)
                 } else {
-                    return Err(SndError::AccessDenied);
-                }
+                    Err(SndError::AccessDenied)
+                };
+                Response::Mutation(res)
             }
             // ===== Coins =====
             Request::TransferCoins {

--- a/safe_core/src/client/recovery.rs
+++ b/safe_core/src/client/recovery.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::Client;
+use crate::client::AuthActions;
 use crate::errors::CoreError;
 use crate::event_loop::CoreFuture;
 use crate::utils::FutureExt;
@@ -300,7 +301,7 @@ fn union_permission_sets(a: PermissionSet, b: PermissionSet) -> PermissionSet {
 /// Insert key to maid managers.
 /// Covers the `InvalidSuccessor` error case (it should not fail if the key already exists).
 pub fn ins_auth_key(
-    client: &impl Client,
+    client: &(impl Client + AuthActions),
     key: PublicKey,
     permissions: AppPermissions,
     version: u64,


### PR DESCRIPTION
Resolves #896 and #897 

- Introduces a new trait implementing functions which are not supposed to be called by AppClients
- Adapts safe_authenticator to the new impl
- Fixes tests for auth keys
