### PR TITLE
chore/ffi: allow file_open to accept null file arg #783

### DIFF
--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -159,6 +159,12 @@ pub unsafe extern "C" fn dir_delete_file(
 }
 
 /// Open the file to read or write its contents.
+///
+/// # Notes
+///
+/// When creating an empty file with no metadata, a null pointer can be passed
+/// in for the `file` argument. In such cases, the library will internally
+/// create a default File with a 0 length `user_metadata_ptr`
 #[no_mangle]
 pub unsafe extern "C" fn file_open(
     app: *const App,
@@ -174,7 +180,11 @@ pub unsafe extern "C" fn file_open(
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         let parent_info = NativeMDataInfo::clone_from_repr_c(parent_info)?;
-        let file = NativeFile::clone_from_repr_c(file)?;
+        let file = if file.is_null() {
+            NativeFile::new(Vec::new())
+        } else {
+            NativeFile::clone_from_repr_c(file)?
+        };
 
         send(app, user_data, o_cb, move |client, context| {
             let context = context.clone();

--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn dir_delete_file(
 ///
 /// When creating an empty file with no metadata, a null pointer can be passed
 /// in for the `file` argument. In such cases, the library will internally
-/// create a default File with a 0 length `user_metadata_ptr`
+/// create a default File with no user metadata.
 #[no_mangle]
 pub unsafe extern "C" fn file_open(
     app: *const App,

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -134,20 +134,17 @@ fn basics() {
 fn open_file() {
     let (app, container_info) = setup();
 
-    // Create non-empty file.
-    let file = NativeFile::new(Vec::new());
-    let ffi_file = file.into_repr_c();
-
     let file_name1 = "file1.txt";
     let ffi_file_name1 = unwrap!(CString::new(file_name1));
 
     let content = b"hello world";
 
+    // Use a null ffi_file, since it's not necessary for creating a new empty file
     let write_h = unsafe {
         unwrap!(call_1(|ud, cb| file_open(
             &app,
             &container_info,
-            &ffi_file,
+            std::ptr::null(),
             OPEN_MODE_OVERWRITE,
             ud,
             cb,


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
First contribution. I think I crossed all t's and dotted all i's.
