### PR TITLE
Combine Build and Test Stages

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -5,22 +5,21 @@ properties([
     ])
 ])
 
-stage('build') {
+stage('build & test') {
     parallel mock_linux: {
         node('docker') {
             checkout(scm)
             clean()
-            build_safe_client_libs('mock')
+            run_tests('mock')
             strip_build_artifacts()
             package_build_artifacts('mock', 'linux')
             upload_build_artifacts()
-            upload_binary_compatibility_test()
         }
     },
     mock_windows: {
         node('windows') {
             checkout(scm)
-            build_safe_client_libs('mock')
+            run_tests('mock')
             strip_build_artifacts()
             package_build_artifacts('mock', 'windows')
             upload_build_artifacts()
@@ -29,40 +28,15 @@ stage('build') {
     mock_osx: {
         node('osx') {
             checkout(scm)
-            build_safe_client_libs('mock')
+            run_tests('mock')
             strip_build_artifacts()
             package_build_artifacts('mock', 'osx')
             upload_build_artifacts()
         }
-    }
-}
-
-stage('test') {
-    parallel mocked_linux: {
+    },
+    integration_tests: {
         node('docker') {
             checkout(scm)
-            retrieve_build_artifacts('mock', 'linux')
-            run_tests('mock')
-        }
-    },
-    mocked_windows: {
-        node('windows') {
-            checkout(scm)
-            retrieve_build_artifacts('mock', 'windows')
-            run_tests('mock')
-        }
-    },
-    mocked_macos: {
-        node('osx') {
-            checkout(scm)
-            retrieve_build_artifacts('mock', 'osx')
-            run_tests('mock')
-        }
-    },
-    integration_linux: {
-        node('docker') {
-            checkout(scm)
-            retrieve_build_artifacts('mock', 'linux')
             run_tests('integration')
         }
     }
@@ -140,14 +114,6 @@ def package_deploy_artifacts() {
     sh("make package-deploy-artifacts")
 }
 
-def build_safe_client_libs(mode) {
-    if (mode == "real") {
-        sh("make build")
-    } else {
-        sh("make build-mock")
-    }
-}
-
 def strip_build_artifacts() {
     sh("make strip-artifacts")
 }
@@ -182,25 +148,6 @@ def upload_binary_compatibility_test() {
     }
 }
 
-def retrieve_build_artifacts(mode, os) {
-    command = ""
-    if (env.CHANGE_ID?.trim()) {
-        command += "SCL_BRANCH=${env.CHANGE_ID} "
-    } else {
-        command += "SCL_BRANCH=${env.BRANCH_NAME} "
-    }
-    command += "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
-    command += "SCL_BUILD_OS=${os} "
-    if (mode == 'mock') {
-        command += "SCL_BUILD_MOCK=true "
-    } else {
-        command += "SCL_BUILD_MOCK=false "
-    }
-    command += "make retrieve-build-artifacts"
-    sh(command)
-}
-
-
 def run_binary_compatibility_tests() {
     build_number = get_last_successful_build_number(currentBuild)
     if (build_number != -1) {
@@ -221,13 +168,13 @@ def run_binary_compatibility_tests() {
 
 def run_tests(mode, bct_test_path='') {
     if (mode == 'mock') {
-        sh("make test-artifacts-mock")
+        sh("make tests")
     } else if (mode == 'binary') {
         command = "SCL_BCT_PATH=${bct_test_path} "
         command += "make test-artifacts-binary"
         sh(command)
     } else {
-        sh("make test-artifacts-integration")
+        sh("make tests-integration")
     }
 }
 

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -63,6 +63,10 @@ stage('deployment') {
             echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
         }
     }
+    if (env.BRANCH_NAME == "experimental") {
+        build(job: '../rust_cache_build-safe_client_libs-windows', wait: false)
+        build(job: '../docker_build-safe_client_libs_build_container', wait: false)
+    }
 }
 
 stage('clean') {
@@ -72,9 +76,6 @@ stage('clean') {
 }
 
 def retrieve_cache() {
-    dir('target') {
-        deleteDir() // REMOVE AFTER TEST
-    }
     if (!fileExists('target')) {
         sh("SCL_BRANCH=${params.CACHE_BRANCH} make retrieve-cache")
     }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,6 +1,7 @@
 properties([
     parameters([
-        string(name: 'ARTIFACTS_BUCKET', defaultValue: 'safe-client-libs-jenkins'),
+        string(name: 'ARTIFACTS_BUCKET', defaultValue: 'safe-jenkins-build-artifacts'),
+        string(name: 'CACHE_BRANCH', defaultValue: 'experimental'),
         string(name: 'DEPLOY_BUCKET', defaultValue: 'safe-client-libs')
     ])
 ])
@@ -19,6 +20,7 @@ stage('build & test') {
     mock_windows: {
         node('windows') {
             checkout(scm)
+            retrieve_cache()
             run_tests('mock')
             strip_build_artifacts()
             package_build_artifacts('mock', 'windows')
@@ -66,6 +68,15 @@ stage('deployment') {
 stage('clean') {
     node('docker') {
         clean()
+    }
+}
+
+def retrieve_cache() {
+    dir('target') {
+        deleteDir() // REMOVE AFTER TEST
+    }
+    if (!fileExists('target')) {
+        sh("SCL_BRANCH=${params.CACHE_BRANCH} make retrieve-cache")
     }
 }
 


### PR DESCRIPTION
Hi Nikita/Lionel/Marcin,

In the interest of saving time, this combines the build and test into one stage. There wasn't really any need for an explicit build stage.

This also introduces a 'cache' for the Windows build. Due to Jenkins creating a new workspace for every PR and the way Cargo is designed, this meant every PR opened would force a Windows build from scratch, which takes about 25 minutes. If there is no target directory in the workspace (the first time building the PR), the build now retrieves a pre-built target directory that is based on a build of the experimental branch at the last merge.

Finally, at the end of the process, on a merge to experimental, it will trigger a build to regenerate the cache and also the Docker container. [This](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-907/7/pipeline/73/) build has an example of the trigger firing (at that time there was only 1). It will only fire now on merge builds.

Cheers,

Chris