### PR TITLE
enhancement/ffi: add fn file_cancel to free FileContextHandle without…

### DIFF
--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -370,3 +370,32 @@ pub unsafe extern "C" fn file_close(
         })
     })
 }
+
+/// Prevents saving to the network any changes performed on the given file
+/// context handle and frees the handle and its associated file contents.
+///
+/// This should be used sparingly, as it wastes the network GET used to
+/// obtain the file handle.
+#[no_mangle]
+pub unsafe extern "C" fn file_cancel(
+    app: *const App,
+    file_h: FileContextHandle,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, file: *const File),
+) {
+    catch_unwind_cb(user_data, o_cb, || {
+        let user_data = OpaqueCtx(user_data);
+
+        (*app).send(move |_client, context| {
+            let file_ctx = try_cb!(context.object_cache().remove_file(file_h), user_data, o_cb);
+
+            // The reader and/or writer will be dropped automatically.
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                &file_ctx.original_file.into_repr_c(),
+            );
+            None
+        })
+    })
+}

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -1172,3 +1172,89 @@ fn write_chunks(
         unwrap!(call_1(|ud, cb| file_close(app, write_h, ud, cb)))
     }
 }
+
+#[test]
+fn cancel_file() {
+    let (app, container_info) = setup();
+
+    // Create empty file and save to directory
+    let user_metadata = b"metadata".to_vec();
+    let file = NativeFile::new(user_metadata.clone());
+    let ffi_file = file.into_repr_c();
+    let file_name = "file.txt";
+    let ffi_file_name = unwrap!(CString::new(file_name));
+
+    unsafe {
+        unwrap!(call_0(|ud, cb| dir_insert_file(
+            &app,
+            &container_info,
+            ffi_file_name.as_ptr(),
+            &ffi_file,
+            ud,
+            cb,
+        )))
+    }
+
+    // Open file for overwriting
+    let write_h = unsafe {
+        unwrap!(call_1(|ud, cb| file_open(
+            &app,
+            &container_info,
+            &ffi_file,
+            OPEN_MODE_OVERWRITE,
+            ud,
+            cb,
+        )))
+    };
+
+    let new_content = b"don't save me";
+
+    // Write file and then cancel
+    let _cancelled_file: NativeFile = unsafe {
+        unwrap!(call_0(|ud, cb| file_write(
+            &app,
+            write_h,
+            new_content.as_ptr(),
+            new_content.len(),
+            ud,
+            cb
+        )));
+        unwrap!(call_1(|ud, cb| file_cancel(&app, write_h, ud, cb)))
+    };
+
+    let even_more_content = b"hello";
+
+    // Using write_h after file_cancel should fail
+    let res: Result<(), i32> = unsafe {
+        call_0(|ud, cb| {
+            file_write(
+                &app,
+                write_h,
+                even_more_content.as_ptr(),
+                even_more_content.len(),
+                ud,
+                cb,
+            )
+        })
+    };
+
+    match res {
+        Err(code) if code == AppError::InvalidFileContextHandle.error_code() => (),
+        Err(x) => panic!("Unexpected: {:?}", x),
+        Ok(_) => panic!("Unexpected success"),
+    }
+
+    // Fetch it back from container and ensure nothing has changed
+    let (retrieved_file, retrieved_version): (NativeFile, u64) = unsafe {
+        unwrap!(call_2(|ud, cb| dir_fetch_file(
+            &app,
+            &container_info,
+            ffi_file_name.as_ptr(),
+            ud,
+            cb
+        )))
+    };
+    assert_eq!(retrieved_file.user_metadata(), &user_metadata[..]);
+    assert_eq!(retrieved_file.size(), 0);
+    assert_eq!(retrieved_version, 0);
+}


### PR DESCRIPTION
… closing #785

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
Not sure whether the test should be more thorough. I mean, it's pretty clear that a new file isn't saved to the directory. But should it also test whether changes to an existing file are not saved?
