### PR TITLE
fix/mock: refactor vault::process_request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-nd#4f424f608865e4b1a2e8c505470aeca417be44fb"
+source = "git+https://github.com/maidsafe/safe-nd#3f73ac50a4604209aec2208302ffc4f33eb5a2e4"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/safe_app/src/tests/unpublished_mutable_data.rs
+++ b/safe_app/src/tests/unpublished_mutable_data.rs
@@ -18,8 +18,8 @@ use safe_core::utils::test_utils::random_client;
 use safe_core::{client::AuthActions, Client, CoreError, FutureExt, DIR_TAG};
 use safe_nd::{Error, PublicKey, XorName};
 use safe_nd::{
-    MDataAction, MDataAddress, MDataPermissionSet, MDataSeqEntryActions, MDataUnseqEntryActions,
-    MDataValue, SeqMutableData, UnseqMutableData,
+    MDataAction, MDataAddress, MDataPermissionSet, MDataSeqEntryActions, MDataSeqValue,
+    MDataUnseqEntryActions, SeqMutableData, UnseqMutableData,
 };
 use std::collections::BTreeMap;
 use std::sync::mpsc;
@@ -305,7 +305,7 @@ fn multiple_apps() {
                 let (value, entry_key) = unwrap!(res);
                 assert_eq!(
                     value,
-                    MDataValue {
+                    MDataSeqValue {
                         data: vec![8, 9, 9],
                         version: 0
                     }
@@ -722,14 +722,14 @@ fn sequenced_entries_crud() {
         let mut data = BTreeMap::new();
         let _ = data.insert(
             vec![0, 0, 1],
-            MDataValue {
+            MDataSeqValue {
                 data: vec![1],
                 version: 0,
             },
         );
         let _ = data.insert(
             vec![0, 1, 0],
-            MDataValue {
+            MDataSeqValue {
                 data: vec![2, 8],
                 version: 0,
             },
@@ -762,14 +762,14 @@ fn sequenced_entries_crud() {
                 assert!(entries.get(&vec![0, 0, 1]).is_none());
                 assert_eq!(
                     *unwrap!(entries.get(&vec![0, 1, 0])),
-                    MDataValue {
+                    MDataSeqValue {
                         data: vec![2, 8, 64],
                         version: 1,
                     }
                 );
                 assert_eq!(
                     *unwrap!(entries.get(&vec![0, 1, 1])),
-                    MDataValue {
+                    MDataSeqValue {
                         data: vec![2, 3, 17],
                         version: 0,
                     }
@@ -790,7 +790,7 @@ fn sequenced_entries_crud() {
                 assert!(entries.get(&vec![0, 0, 1]).is_none());
                 assert_eq!(
                     *unwrap!(entries.get(&vec![0, 1, 0])),
-                    MDataValue {
+                    MDataSeqValue {
                         data: vec![64, 8, 1],
                         version: 2,
                     }
@@ -798,7 +798,7 @@ fn sequenced_entries_crud() {
                 assert!(entries.get(&vec![0, 1, 1]).is_none());
                 assert_eq!(
                     *unwrap!(entries.get(&vec![1, 0, 0])),
-                    MDataValue {
+                    MDataSeqValue {
                         data: vec![4, 4, 4, 4],
                         version: 0,
                     }

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -189,8 +189,9 @@ impl Routing {
                 None => self.public_id.clone(),
             };
             let mut vault = self.lock_vault(true);
-            unwrap!(vault.process_request(public_id, payload.to_vec()))
-        };
+            vault.process_request(public_id, payload.to_vec())
+        }?;
+
         // Send response back to a client
         let (message_id, response) = if let Message::Response {
             message_id,
@@ -205,6 +206,7 @@ impl Routing {
             res: Ok(unwrap!(serialise(&response))),
             msg_id: message_id,
         };
+
         // Use dummy authority for now
         let dummy_authority = Authority::ClientManager(new_rand::random());
         self.send_response(DEFAULT_DELAY_MS, dummy_authority, dummy_authority, response);

--- a/safe_core/src/client/mock/routing.rs
+++ b/safe_core/src/client/mock/routing.rs
@@ -189,7 +189,7 @@ impl Routing {
                 None => self.public_id.clone(),
             };
             let mut vault = self.lock_vault(true);
-            vault.process_request(public_id, payload.to_vec())
+            vault.process_request(public_id, payload)
         }?;
 
         // Send response back to a client

--- a/safe_core/src/errors.rs
+++ b/safe_core/src/errors.rs
@@ -12,7 +12,7 @@ use futures::sync::mpsc::SendError;
 use maidsafe_utilities::serialisation::SerialisationError;
 use routing::messaging;
 use routing::{ClientError, InterfaceError, RoutingError};
-use safe_nd::Error;
+use safe_nd::Error as SndError;
 use self_encryption::SelfEncryptionError;
 use std::error::Error as StdError;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -49,7 +49,7 @@ pub enum CoreError {
     /// Routing Client Error.
     RoutingClientError(ClientError),
     /// Routing Client Error.
-    NewRoutingClientError(Error),
+    NewRoutingClientError(SndError),
     /// Unable to pack into or operate with size of Salt.
     UnsupportedSaltSizeForPwHash,
     /// Unable to complete computation for password hashing - usually because OS
@@ -113,8 +113,8 @@ impl From<ClientError> for CoreError {
     }
 }
 
-impl From<Error> for CoreError {
-    fn from(error: Error) -> CoreError {
+impl From<SndError> for CoreError {
+    fn from(error: SndError) -> CoreError {
         CoreError::NewRoutingClientError(error)
     }
 }

--- a/safe_core/src/nfs/errors.rs
+++ b/safe_core/src/nfs/errors.rs
@@ -32,25 +32,25 @@ pub enum NfsError {
 }
 
 impl From<CoreError> for NfsError {
-    fn from(error: CoreError) -> NfsError {
+    fn from(error: CoreError) -> Self {
         NfsError::CoreError(error)
     }
 }
 
 impl From<SerialisationError> for NfsError {
-    fn from(error: SerialisationError) -> NfsError {
+    fn from(error: SerialisationError) -> Self {
         NfsError::EncodeDecodeError(error)
     }
 }
 
 impl<'a> From<&'a str> for NfsError {
-    fn from(error: &'a str) -> NfsError {
+    fn from(error: &'a str) -> Self {
         NfsError::Unexpected(error.to_string())
     }
 }
 
 impl From<SelfEncryptionError<SelfEncryptionStorageError>> for NfsError {
-    fn from(error: SelfEncryptionError<SelfEncryptionStorageError>) -> NfsError {
+    fn from(error: SelfEncryptionError<SelfEncryptionStorageError>) -> Self {
         NfsError::SelfEncryption(error)
     }
 }


### PR DESCRIPTION
+ Do not return early errors from `process_request`, encapsulate them in the
proper response variant instead
+ Do not unwrap result of `process_request` in `send`
+ Add missing checks for mismatch between requested data address and received
data kind
+ Do some refactoring and simplication of `process_request`

Closes #910 