### PR TITLE
Upgrade the deprecated tokio_core dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,8 +1612,7 @@ dependencies = [
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1653,8 +1652,7 @@ dependencies = [
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1714,8 +1712,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1740,11 +1737,6 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
@@ -2077,17 +2069,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.8"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2103,24 +2098,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2674,7 +2651,6 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
-"checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
@@ -2709,9 +2685,8 @@ dependencies = [
 "checksum threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95be1032c63011f20b01c5edb64930e2b51512782b43b458b1e3449613d70f87"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-"checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"
+"checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
-"checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -34,8 +34,7 @@ safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
 self_encryption = { git = "https://github.com/maidsafe/self_encryption" }
 threshold_crypto = "~0.3.2"
 tiny-keccak = "~1.5.0"
-tokio = "=0.1.8"
-tokio-core = "~0.1.17"
+tokio = "~0.1.22"
 unwrap = "~1.2.0"
 jni = { version = "~0.12.0", optional = true }
 

--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 use std::time::Duration;
-use tokio_core::reactor::Handle;
+use tokio::runtime::current_thread::Handle;
 
 /// Client object used by safe_app.
 pub struct AppClient {

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -31,8 +31,7 @@ serde = "~1.0.27"
 serde_derive = "~1.0.27"
 threshold_crypto = "~0.3.2"
 tiny-keccak = "~1.5.0"
-tokio = "=0.1.8"
-tokio-core = "~0.1.17"
+tokio = "~0.1.22"
 unwrap = "~1.2.0"
 jni = { version = "~0.12.0", optional = true }
 

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -42,7 +42,7 @@ use std::rc::Rc;
 use std::time::Duration;
 use threshold_crypto::SecretKey as BlsSecretKey;
 use tiny_keccak::sha3_256;
-use tokio_core::reactor::Handle;
+use tokio::runtime::current_thread::Handle;
 
 /// Client object used by safe_authenticator.
 pub struct AuthClient {
@@ -617,14 +617,14 @@ mod tests {
     use safe_core::{utils, CoreError, DIR_TAG};
     use safe_nd::{Coins, Error as SndError, MDataKind};
     use std::str::FromStr;
-    use tokio_core::reactor::Core;
+    use tokio::runtime::current_thread::Runtime;
     use AuthMsgTx;
 
     // Test account creation.
     // It should succeed the first time and fail the second time with the same secrets.
     #[test]
     fn registered_client() {
-        let el = unwrap!(Core::new());
+        let el = unwrap!(Runtime::new());
         let (core_tx, _): (AuthMsgTx, _) = mpsc::unbounded();
         let (net_tx, _) = mpsc::unbounded();
 
@@ -697,7 +697,7 @@ mod tests {
     fn seeded_login() {
         let invalid_seed = String::from("123");
         {
-            let el = unwrap!(Core::new());
+            let el = unwrap!(Runtime::new());
             let (core_tx, _): (AuthMsgTx, _) = mpsc::unbounded();
             let (net_tx, _) = mpsc::unbounded();
             let balance_sk = BlsSecretKey::random();
@@ -714,7 +714,7 @@ mod tests {
             }
         }
         {
-            let el = unwrap!(Core::new());
+            let el = unwrap!(Runtime::new());
             let (core_tx, _): (AuthMsgTx, _) = mpsc::unbounded();
             let (net_tx, _) = mpsc::unbounded();
 

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -24,8 +24,6 @@ lru-cache = "~0.1.1"
 maidsafe_utilities = "~0.18.0"
 rand = "~0.3.18"
 new_rand = { package = "rand", version = "0.6" }
-# routing = "~0.37.0"
-# routing = { git = "https://github.com/lionel1704/routing", branch = "patch" }
 routing = { package = "mock_routing", path = "../mock_routing" }
 rust_sodium = "~0.10.2"
 safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
@@ -35,8 +33,7 @@ serde = "~1.0.27"
 serde_derive = "~1.0.27"
 tiny-keccak = "~1.5.0"
 threshold_crypto = "~0.3.2"
-tokio = "=0.1.8"
-tokio-core = "~0.1.17"
+tokio = "~0.1.22"
 unwrap = "~1.2.0"
 
 [dev-dependencies]

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -37,7 +37,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use threshold_crypto::SecretKey as BlsSecretKey;
 use tiny_keccak::sha3_256;
-use tokio_core::reactor::Handle;
+use tokio::runtime::current_thread::Handle;
 
 /// Wait for a response from the `$rx` receiver with path `$res` and message ID `$msg_id`.
 #[macro_export]

--- a/safe_core/src/utils/test_utils/mod.rs
+++ b/safe_core/src/utils/test_utils/mod.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 use std::sync::mpsc as std_mpsc;
 use std::{iter, u8};
 use threshold_crypto::{PublicKey, SecretKey};
-use tokio_core::reactor::{Core, Handle};
+use tokio::runtime::current_thread::{Handle, Runtime};
 
 /// Generates a random BLS secret and public keypair.
 pub fn gen_bls_keys() -> (SecretKey, PublicKey) {
@@ -120,7 +120,7 @@ where
     E: Debug,
     F: Debug,
 {
-    let el = unwrap!(Core::new());
+    let mut el = unwrap!(Runtime::new());
     let el_h = el.handle();
 
     let (core_tx, core_rx) = mpsc::unbounded();
@@ -133,7 +133,7 @@ where
             Ok(())
         })
         .map_err(|e| panic!("Network event stream error: {:?}", e));
-    el_h.spawn(net_fut);
+    let _ = el.spawn(net_fut);
 
     let core_tx_clone = core_tx.clone();
     let (result_tx, result_rx) = std_mpsc::channel();


### PR DESCRIPTION
`tokio_core` has been deprecated for a while, causing some troubles. We had to fix the dependency version at `=0.1.8`. This PR updates `tokio_core` to latest `tokio`.

Closes #923 