### PR TITLE
SAFE Authenticator Migration to the new data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -459,14 +459,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -571,7 +571,7 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -592,7 +592,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1745,7 +1745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "safe-nd"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-nd#3f73ac50a4604209aec2208302ffc4f33eb5a2e4"
+source = "git+https://github.com/maidsafe/safe-nd#8f996c7f3ce27ae3aca0c035ce1ba8b4a11460b9"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2724,7 +2724,7 @@ dependencies = [
 "checksum ascii 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "91e320562a8fa3286a481b7189f89578ace6b20df99e123c87f2f509c957c5d6"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base-x 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "76f4eae81729e69bb1819a26c6caac956cc429238388091f98cb6cd858f16443"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -2767,7 +2767,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum ct-logs 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
-"checksum curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4b820e8711c211745880150f5fac78ab07d6e3851d8ce9f5a02cedc199174c"
+"checksum curve25519-dalek 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "019779982f8518304cfbabd515e77ad6372a9a28a57d22d39478164c5e2b32ee"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
@@ -2937,7 +2937,7 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
-"checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
+"checksum subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01f40907d9ffc762709e4ff3eb4a6f6b41b650375a3f09ac92b641942b7fb082"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum syntex_errors 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3133289179676c9f5c5b2845bf5a2e127769f4889fcbada43035ef6bd662605e"

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -338,7 +338,6 @@ mod tests {
     use crate::test_utils;
     use ffi_utils::test_utils::{call_1, call_2};
     use ffi_utils::ReprC;
-    use routing::{Action, PermissionSet};
     use rust_sodium::crypto::secretbox;
     use safe_authenticator::ffi::ipc::encode_auth_resp;
     use safe_authenticator::test_utils as auth_utils;
@@ -349,7 +348,7 @@ mod tests {
         ContainersReq, IpcMsg, IpcReq, IpcResp, Permission, ShareMData, ShareMDataReq,
     };
     use safe_core::utils;
-    use safe_nd::PublicKey;
+    use safe_nd::{MDataAction, MDataPermissionSet, PublicKey};
     use std::collections::HashMap;
     use std::ffi::CString;
     use std::os::raw::c_void;
@@ -584,9 +583,9 @@ mod tests {
             mdata: vec![ShareMData {
                 type_tag: new_rand::random(),
                 name: new_rand::random(),
-                perms: PermissionSet::new()
-                    .allow(Action::Insert)
-                    .allow(Action::Update),
+                perms: MDataPermissionSet::new()
+                    .allow(MDataAction::Insert)
+                    .allow(MDataAction::Update),
             }],
         };
 

--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn mdata_list_keys(
 
 /// Get list of all values in the mutable data.
 #[no_mangle]
-pub unsafe extern "C" fn mdata_list_values(
+pub unsafe extern "C" fn seq_mdata_list_values(
     app: *const App,
     info: *const MDataInfo,
     user_data: *mut c_void,
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn mdata_list_values(
 
         (*app).send(move |client, _context| {
             client
-                .list_mdata_values(info.name(), info.type_tag())
+                .list_seq_mdata_values(info.name(), info.type_tag())
                 .map_err(AppError::from)
                 .then(move |result| {
                     match result {

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -595,7 +595,7 @@ fn entries_crud_ffi() {
     // Check mdata_list_values
     {
         let vals_list: Vec<MDataValue> = unsafe {
-            unwrap!(call_vec(|ud, cb| mdata_list_values(
+            unwrap!(call_vec(|ud, cb| seq_mdata_list_values(
                 &app,
                 &md_info_priv,
                 ud,

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -478,14 +478,14 @@ fn refresh_access_info(context: Rc<Registered>, client: &AppClient) -> Box<AppFu
     ));
 
     client
-        .get_mdata_value(
+        .get_seq_mdata_value(
             context.access_container_info.id,
             context.access_container_info.tag,
             entry_key,
         )
         .map_err(AppError::from)
         .and_then(move |value| {
-            let encoded = utils::symmetric_decrypt(&value.content, &context.sym_enc_key)?;
+            let encoded = utils::symmetric_decrypt(&value.data, &context.sym_enc_key)?;
             let decoded = deserialise(&encoded)?;
 
             *context.access_info.borrow_mut() = decoded;

--- a/safe_app/src/object_cache.rs
+++ b/safe_app/src/object_cache.rs
@@ -19,7 +19,7 @@ use routing::{EntryAction, PermissionSet, User, Value};
 use rust_sodium::crypto::{box_, sign};
 use safe_core::crypto::{shared_box, shared_sign};
 use safe_core::SelfEncryptionStorage;
-use safe_nd::PublicKey;
+use safe_nd::{MDataSeqValue, PublicKey};
 use self_encryption::{SelfEncryptor, SequentialEncryptor};
 use std::cell::{Cell, RefCell, RefMut};
 use std::collections::{BTreeMap, HashMap};
@@ -31,6 +31,7 @@ pub struct ObjectCache {
     encrypt_key: Store<box_::PublicKey>,
     secret_key: Store<shared_box::SecretKey>,
     mdata_entries: Store<BTreeMap<Vec<u8>, Value>>,
+    mdata_entries_new: Store<BTreeMap<Vec<u8>, MDataSeqValue>>,
     mdata_entry_actions: Store<BTreeMap<Vec<u8>, EntryAction>>,
     mdata_permissions: Store<BTreeMap<User, PermissionSet>>,
     se_reader: Store<SelfEncryptor<SelfEncryptionStorage<AppClient>>>,
@@ -50,6 +51,7 @@ impl ObjectCache {
             encrypt_key: Store::new(),
             secret_key: Store::new(),
             mdata_entries: Store::new(),
+            mdata_entries_new: Store::new(),
             mdata_entry_actions: Store::new(),
             mdata_permissions: Store::new(),
             se_reader: Store::new(),
@@ -68,6 +70,7 @@ impl ObjectCache {
         self.encrypt_key.clear();
         self.secret_key.clear();
         self.mdata_entries.clear();
+        self.mdata_entries_new.clear();
         self.mdata_entry_actions.clear();
         self.mdata_permissions.clear();
         self.se_reader.clear();
@@ -137,6 +140,15 @@ impl_cache!(
     get_mdata_entries,
     insert_mdata_entries,
     remove_mdata_entries
+);
+impl_cache!(
+    mdata_entries_new,
+    BTreeMap<Vec<u8>, MDataSeqValue>,
+    MDataEntriesHandle,
+    InvalidMDataEntriesHandle,
+    get_mdata_entries_new,
+    insert_mdata_entries_new,
+    remove_mdata_entries_new
 );
 impl_cache!(
     mdata_entry_actions,

--- a/safe_authenticator/src/access_container.rs
+++ b/safe_authenticator/src/access_container.rs
@@ -14,13 +14,12 @@ use super::{AuthError, AuthFuture};
 use crate::client::AuthClient;
 use futures::Future;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::EntryActions;
 use rust_sodium::crypto::secretbox;
 use safe_core::ipc::resp::{access_container_enc_key, AccessContainerEntry};
 use safe_core::ipc::AppKeys;
 use safe_core::utils::{symmetric_decrypt, symmetric_encrypt};
-use safe_core::{recovery, Client, CoreError, FutureExt, MDataInfo};
-use safe_nd::{Error as SndError, MDataAction, MDataAddress, MDataPermissionSet, PublicKey};
+use safe_core::{recovery, Client, FutureExt, MDataInfo};
+use safe_nd::{MDataAction, MDataAddress, MDataPermissionSet, MDataSeqEntryActions, PublicKey};
 use std::collections::HashMap;
 
 /// Key of the authenticator entry in the access container.
@@ -71,14 +70,14 @@ pub fn fetch_authenticator_entry(
     };
 
     client
-        .get_mdata_value(access_container.name(), access_container.type_tag(), key)
+        .get_seq_mdata_value(access_container.name(), access_container.type_tag(), key)
         .map_err(From::from)
         .and_then(move |value| {
             let enc_key = c2.secret_symmetric_key().ok_or_else(|| {
                 AuthError::Unexpected("Secret symmetric key not found".to_string())
             })?;
-            decode_authenticator_entry(&value.content, &enc_key)
-                .map(|decoded| (value.entry_version, decoded))
+            decode_authenticator_entry(&value.data, &enc_key)
+                .map(|decoded| (value.version, decoded))
         })
         .into_box()
 }
@@ -101,16 +100,16 @@ pub fn put_authenticator_entry(
     };
 
     let actions = if version == 0 {
-        EntryActions::new().ins(key, ciphertext, 0)
+        MDataSeqEntryActions::new().ins(key, ciphertext, 0)
     } else {
-        EntryActions::new().update(key, ciphertext, version)
+        MDataSeqEntryActions::new().update(key, ciphertext, version)
     };
 
     recovery::mutate_mdata_entries(
         client,
         access_container.name(),
         access_container.type_tag(),
-        actions.into(),
+        actions,
     )
     .map_err(From::from)
     .into_box()
@@ -139,7 +138,7 @@ pub fn fetch_entry(
     client: &AuthClient,
     app_id: &str,
     app_keys: AppKeys,
-) -> Box<AuthFuture<(u64, Option<AccessContainerEntry>)>> {
+) -> Box<AuthFuture<(u64, AccessContainerEntry)>> {
     trace!(
         "Fetching access container entry for app with ID {}...",
         app_id
@@ -149,13 +148,13 @@ pub fn fetch_entry(
     trace!("Fetching entry using entry key {:?}", key);
 
     client
-        .get_mdata_value(access_container.name(), access_container.type_tag(), key)
-        .then(move |result| match result {
-            Err(CoreError::NewRoutingClientError(SndError::NoSuchEntry)) => Ok((0, None)),
-            Err(err) => Err(AuthError::from(err)),
-            Ok(value) => {
-                let decoded = Some(decode_app_entry(&value.content, &app_keys.enc_key)?);
-                Ok((value.entry_version, decoded))
+        .get_seq_mdata_value(access_container.name(), access_container.type_tag(), key)
+        .then(move |value| {
+            if let Err(e) = value {
+                Err(AuthError::from(e))
+            } else {
+                let val = unwrap!(value);
+                Ok((val.version, decode_app_entry(&val.data, &app_keys.enc_key)?))
             }
         })
         .into_box()
@@ -170,7 +169,6 @@ pub fn put_entry(
     version: u64,
 ) -> Box<AuthFuture<()>> {
     trace!("Putting access container entry for app {}...", app_id);
-
     let client2 = client.clone();
     let client3 = client.clone();
     let access_container = client.access_container();
@@ -179,14 +177,18 @@ pub fn put_entry(
     let ciphertext = fry!(encode_app_entry(permissions, &app_keys.enc_key));
 
     let actions = if version == 0 {
-        EntryActions::new().ins(key, ciphertext, 0)
+        MDataSeqEntryActions::new().ins(key, ciphertext, 0)
     } else {
-        EntryActions::new().update(key, ciphertext, version)
+        MDataSeqEntryActions::new().update(key, ciphertext, version)
     };
+
     let app_pk: PublicKey = app_keys.bls_pk.into();
 
     client
-        .get_mdata_version(access_container.name(), access_container.type_tag())
+        .get_mdata_version_new(MDataAddress::Seq {
+            name: access_container.name(),
+            tag: access_container.type_tag(),
+        })
         .map_err(AuthError::from)
         .and_then(move |shell_version| {
             client2
@@ -225,13 +227,16 @@ pub fn delete_entry(
     let access_container = client.access_container();
     let acc_cont_info = access_container.clone();
     let key = fry!(enc_key(&access_container, app_id, &app_keys.enc_key));
-    let actions = EntryActions::new().del(key, version);
     let client2 = client.clone();
     let client3 = client.clone();
+    let actions = MDataSeqEntryActions::new().del(key, version);
     let app_pk: PublicKey = app_keys.bls_pk.into();
 
     client
-        .get_mdata_version(access_container.name(), access_container.type_tag())
+        .get_mdata_version_new(MDataAddress::Seq {
+            name: access_container.name(),
+            tag: access_container.type_tag(),
+        })
         .map_err(AuthError::from)
         .and_then(move |shell_version| {
             client2

--- a/safe_authenticator/src/app_container.rs
+++ b/safe_authenticator/src/app_container.rs
@@ -12,9 +12,10 @@ use crate::access_container;
 use crate::client::AuthClient;
 use crate::{AuthError, AuthFuture};
 use futures::Future;
-use routing::{Action, EntryActions, PermissionSet, User};
 use safe_core::{app_container_name, nfs, Client, FutureExt, MDataInfo, DIR_TAG};
-use safe_nd::{MDataKind, PublicKey};
+use safe_nd::{
+    MDataAction, MDataAddress, MDataKind, MDataPermissionSet, MDataSeqEntryActions, PublicKey,
+};
 
 /// Returns an app's dedicated container if available and stored in the access container,
 /// `None` otherwise.
@@ -44,25 +45,31 @@ pub fn fetch_or_create(
                 Some(mdata_info) => {
                     // Reuse the already existing app container and update
                     // permissions for it
-                    let ps = PermissionSet::new()
-                        .allow(Action::Insert)
-                        .allow(Action::Update)
-                        .allow(Action::Delete)
-                        .allow(Action::ManagePermissions);
+                    let ps = MDataPermissionSet::new()
+                        .allow(MDataAction::Read)
+                        .allow(MDataAction::Insert)
+                        .allow(MDataAction::Update)
+                        .allow(MDataAction::Delete)
+                        .allow(MDataAction::ManagePermissions);
 
-                    c2.get_mdata_version(mdata_info.name(), mdata_info.type_tag())
-                        .and_then(move |version| {
-                            c2.set_mdata_user_permissions(
-                                mdata_info.name(),
-                                mdata_info.type_tag(),
-                                User::Key(app_pk),
-                                ps,
-                                version + 1,
-                            )
-                            .map(move |_| mdata_info)
-                        })
-                        .map_err(From::from)
-                        .into_box()
+                    c2.get_mdata_version_new(MDataAddress::Seq {
+                        name: mdata_info.name(),
+                        tag: mdata_info.type_tag(),
+                    })
+                    .and_then(move |version| {
+                        c2.set_mdata_user_permissions_new(
+                            MDataAddress::Seq {
+                                name: mdata_info.name(),
+                                tag: mdata_info.type_tag(),
+                            },
+                            app_pk,
+                            ps,
+                            version + 1,
+                        )
+                        .map(move |_| mdata_info)
+                    })
+                    .map_err(From::from)
+                    .into_box()
                 }
                 None => {
                     // If the container is not found, create it
@@ -100,20 +107,20 @@ pub fn remove(client: AuthClient, app_id: &str) -> Box<AuthFuture<bool>> {
                 Some(mdata_info) => {
                     let c3 = c2.clone();
 
-                    c2.list_mdata_entries(mdata_info.name(), mdata_info.type_tag())
+                    c2.list_seq_mdata_entries(mdata_info.name(), mdata_info.type_tag())
                         .and_then(move |entries| {
                             // Remove all entries in MData
                             let actions = entries.iter().fold(
-                                EntryActions::new(),
+                                MDataSeqEntryActions::new(),
                                 |actions, (entry_name, val)| {
-                                    actions.del(entry_name.clone(), val.entry_version + 1)
+                                    actions.del(entry_name.clone(), val.version + 1)
                                 },
                             );
 
-                            c3.mutate_mdata_entries(
+                            c3.mutate_seq_mdata_entries(
                                 mdata_info.name(),
                                 mdata_info.type_tag(),
-                                actions.into(),
+                                actions,
                             )
                         })
                         .map_err(From::from)
@@ -139,16 +146,17 @@ pub fn remove(client: AuthClient, app_id: &str) -> Box<AuthFuture<bool>> {
 
 // Creates a new app's dedicated container
 fn create(client: &AuthClient, app_pk: PublicKey) -> Box<AuthFuture<MDataInfo>> {
-    let dir = fry!(MDataInfo::random_private(MDataKind::Unseq, DIR_TAG).map_err(AuthError::from));
+    let dir = fry!(MDataInfo::random_private(MDataKind::Seq, DIR_TAG).map_err(AuthError::from));
     nfs::create_dir(
         client,
         &dir,
         btree_map![],
-        btree_map![User::Key(app_pk) => PermissionSet::new()
-                .allow(Action::Insert)
-                .allow(Action::Update)
-                .allow(Action::Delete)
-                .allow(Action::ManagePermissions)],
+        btree_map![app_pk => MDataPermissionSet::new()
+                .allow(MDataAction::Read)
+                .allow(MDataAction::Insert)
+                .allow(MDataAction::Update)
+                .allow(MDataAction::Delete)
+                .allow(MDataAction::ManagePermissions)],
     )
     .map(move |()| dir)
     .map_err(From::from)

--- a/safe_authenticator/src/config.rs
+++ b/safe_authenticator/src/config.rs
@@ -11,12 +11,11 @@ use crate::client::AuthClient;
 use futures::future::{self, Either, Loop};
 use futures::Future;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::EntryActions;
 use safe_core::ipc::req::AppExchangeInfo;
 use safe_core::ipc::resp::AppKeys;
 use safe_core::ipc::IpcError;
 use safe_core::{Client, CoreError, FutureExt};
-use safe_nd::{EntryError, Error as SndError};
+use safe_nd::{EntryError, Error, MDataSeqEntryActions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
@@ -201,21 +200,19 @@ where
     let key = fry!(parent.enc_entry_key(key));
 
     client
-        .get_mdata_value(parent.name(), parent.type_tag(), key)
+        .get_seq_mdata_value(parent.name(), parent.type_tag(), key)
         .and_then(move |value| {
-            let decoded = parent.decrypt(&value.content)?;
+            let decoded = parent.decrypt(&value.data)?;
             let decoded = if !decoded.is_empty() {
                 deserialise(&decoded)?
             } else {
                 Default::default()
             };
 
-            Ok((Some(value.entry_version), decoded))
+            Ok((Some(value.version), decoded))
         })
         .or_else(|error| match error {
-            CoreError::NewRoutingClientError(SndError::NoSuchEntry) => {
-                Ok((None, Default::default()))
-            }
+            CoreError::NewRoutingClientError(Error::NoSuchEntry) => Ok((None, Default::default())),
             _ => Err(AuthError::from(error)),
         })
         .into_box()
@@ -237,26 +234,25 @@ where
     let encoded = fry!(parent.enc_entry_value(&encoded));
 
     let actions = if new_version == 0 {
-        EntryActions::new().ins(key.clone(), encoded, 0)
+        MDataSeqEntryActions::new().ins(key.clone(), encoded, 0)
     } else {
-        EntryActions::new().update(key.clone(), encoded, new_version)
+        MDataSeqEntryActions::new().update(key.clone(), encoded, new_version)
     };
 
     client
-        .mutate_mdata_entries(parent.name(), parent.type_tag(), actions.into())
+        .mutate_seq_mdata_entries(parent.name(), parent.type_tag(), actions.into())
         .or_else(move |error| {
             // As we are mutating only one entry, let's make the common errors
             // more convenient to handle.
-            if let CoreError::NewRoutingClientError(SndError::InvalidEntryActions(ref errors)) =
-                error
+            if let CoreError::NewRoutingClientError(Error::InvalidEntryActions(ref errors)) = error
             {
                 if let Some(error) = errors.get(&key) {
                     match *error {
                         EntryError::InvalidSuccessor(version)
                         | EntryError::EntryExists(version) => {
-                            return Err(CoreError::NewRoutingClientError(
-                                SndError::InvalidSuccessor(version.into()),
-                            ));
+                            return Err(CoreError::NewRoutingClientError(Error::InvalidSuccessor(
+                                version as u64,
+                            )));
                         }
                         _ => (),
                     }
@@ -295,7 +291,7 @@ where
                     .map(move |_| Loop::Break((new_version, item)))
                     .or_else(move |error| match error {
                         AuthError::CoreError(CoreError::NewRoutingClientError(
-                            SndError::InvalidSuccessor(_),
+                            Error::InvalidSuccessor(_),
                         )) => {
                             let f = get_entry(&c3, &key).map(move |(version, item)| {
                                 Loop::Continue((key, next_version(version), item))

--- a/safe_authenticator/src/ffi/ipc.rs
+++ b/safe_authenticator/src/ffi/ipc.rs
@@ -16,7 +16,7 @@ use ffi_utils::{
     catch_unwind_cb, from_c_str, FfiResult, NativeResult, OpaqueCtx, ReprC, SafePtr, FFI_RESULT_OK,
 };
 use futures::{stream, Future, Stream};
-use routing::User;
+use safe_core::client::Client;
 use safe_core::ffi::ipc::req::{AuthReq, ContainersReq, ShareMDataReq};
 use safe_core::ffi::ipc::resp::MetadataResponse;
 use safe_core::ipc::req::{
@@ -25,8 +25,8 @@ use safe_core::ipc::req::{
 };
 use safe_core::ipc::resp::IpcResp;
 use safe_core::ipc::{decode_msg, IpcError, IpcMsg};
-use safe_core::{client, Client, CoreError, FutureExt};
-use safe_nd::PublicKey;
+use safe_core::{client, CoreError, FutureExt};
+use safe_nd::{Error, MDataAddress, PublicKey};
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn encode_containers_resp(
                             move |res| {
                                 let version = match res {
                                     // Updating an existing entry
-                                    Ok((version, Some(mut existing_perms))) => {
+                                    Ok((version, mut existing_perms)) => {
                                         for (key, val) in perms {
                                             let _ = existing_perms.insert(key, val);
                                         }
@@ -386,11 +386,8 @@ pub unsafe extern "C" fn encode_containers_resp(
                                     }
 
                                     // Adding a new access container entry
-                                    Ok((_, None))
-                                    | Err(AuthError::CoreError(
-                                        CoreError::NewRoutingClientError(
-                                            safe_nd::Error::NoSuchEntry,
-                                        ),
+                                    Err(AuthError::CoreError(
+                                        CoreError::NewRoutingClientError(Error::NoSuchEntry),
                                     )) => 0,
 
                                     // Error has occurred while trying to get an
@@ -466,19 +463,21 @@ pub unsafe extern "C" fn encode_share_mdata_resp(
 
                 config::get_app(client, &share_mdata_req.app.id)
                     .and_then(move |app_info| {
-                        let user = User::Key(PublicKey::from(app_info.keys.bls_pk));
+                        let user = PublicKey::from(app_info.keys.bls_pk);
                         let num_mdata = share_mdata_req.mdata.len();
                         stream::iter_ok(share_mdata_req.mdata.into_iter())
                             .map(move |mdata| {
                                 client_cloned0
-                                    .get_mdata_shell(mdata.name, mdata.type_tag)
+                                    .get_seq_mdata_shell(mdata.name, mdata.type_tag)
                                     .map(|md| (md.version(), mdata))
                             })
                             .buffer_unordered(num_mdata)
                             .map(move |(version, mdata)| {
-                                client_cloned1.set_mdata_user_permissions(
-                                    mdata.name,
-                                    mdata.type_tag,
+                                client_cloned1.set_mdata_user_permissions_new(
+                                    MDataAddress::Seq {
+                                        name: mdata.name,
+                                        tag: mdata.type_tag,
+                                    },
                                     user,
                                     mdata.perms,
                                     version + 1,

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -343,7 +343,7 @@ mod tests {
 
         unsafe {
             unwrap!((*auth).send(move |client| client
-                .put_idata(PubImmutableData::new(vec![1, 2, 3]))
+                .put_pub_idata(PubImmutableData::new(vec![1, 2, 3]))
                 .map_err(move |_| ())
                 .into_box()
                 .into()));

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -15,7 +15,6 @@ use ffi_utils::StringError;
 use futures::future::{self, Either};
 use futures::Future;
 use maidsafe_utilities::serialisation::deserialise;
-use routing::{User, XorName};
 use safe_core::ffi::ipc::resp::MetadataResponse as FfiUserMetadata;
 use safe_core::ipc::req::{
     container_perms_into_permission_set, ContainerPermissions, IpcReq, ShareMDataReq,
@@ -23,7 +22,7 @@ use safe_core::ipc::req::{
 use safe_core::ipc::resp::{AccessContainerEntry, IpcResp, UserMetadata, METADATA_KEY};
 use safe_core::ipc::{self, IpcError, IpcMsg};
 use safe_core::{recovery, Client, CoreError, FutureExt};
-use safe_nd::PublicKey;
+use safe_nd::{Error, MDataAddress, PublicKey, XorName};
 use std::collections::HashMap;
 use std::ffi::CString;
 
@@ -120,13 +119,18 @@ pub fn update_container_perms(
                 let perm_set = container_perms_into_permission_set(&access);
 
                 let fut = client
-                    .get_mdata_version(mdata_info.name(), mdata_info.type_tag())
+                    .get_mdata_version_new(MDataAddress::Seq {
+                        name: mdata_info.name(),
+                        tag: mdata_info.type_tag(),
+                    })
                     .and_then(move |version| {
                         recovery::set_mdata_user_permissions(
                             &c2,
-                            mdata_info.name(),
-                            mdata_info.type_tag(),
-                            User::Key(app_pk),
+                            MDataAddress::Seq {
+                                name: mdata_info.name(),
+                                tag: mdata_info.type_tag(),
+                            },
+                            app_pk,
                             perm_set,
                             version + 1,
                         )
@@ -175,13 +179,13 @@ pub fn decode_share_mdata_req(
         let type_tag = mdata.type_tag;
 
         let future = client
-            .get_mdata_shell(name, type_tag)
+            .get_seq_mdata_shell(name, type_tag)
             .and_then(move |shell| {
-                if shell.owners().contains(&user) {
+                if *shell.owner() == user {
                     let future_metadata = client
-                        .get_mdata_value(name, type_tag, METADATA_KEY.into())
+                        .get_seq_mdata_value(name, type_tag, METADATA_KEY.into())
                         .then(move |res| match res {
-                            Ok(value) => Ok(deserialise::<UserMetadata>(&value.content)
+                            Ok(value) => Ok(deserialise::<UserMetadata>(&value.data)
                                 .map_err(|_| ShareMDataError::InvalidMetadata)
                                 .and_then(move |metadata| {
                                     match metadata.into_md_response(name, type_tag) {
@@ -189,7 +193,7 @@ pub fn decode_share_mdata_req(
                                         Err(_) => Err(ShareMDataError::InvalidMetadata),
                                     }
                                 })),
-                            Err(CoreError::NewRoutingClientError(safe_nd::Error::NoSuchEntry)) => {
+                            Err(CoreError::NewRoutingClientError(Error::NoSuchEntry)) => {
                                 // Allow requesting shared access to arbitrary Mutable Data objects even
                                 // if they don't have metadata.
                                 let user_metadata = UserMetadata {

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -214,7 +214,6 @@ impl Authenticator {
                     .into_box()
                     .into()))
             );
-
             event_loop::run(el, &client, &(), core_rx);
         });
 

--- a/safe_authenticator/src/revocation.rs
+++ b/safe_authenticator/src/revocation.rs
@@ -14,12 +14,12 @@ use crate::client::AuthClient;
 use crate::config::{self, AppInfo, RevocationQueue};
 use futures::future::{self, Either, Loop};
 use futures::Future;
-use routing::User;
 use safe_core::recovery;
 use safe_core::{client::AuthActions, Client, CoreError, FutureExt, MDataInfo};
-use safe_nd::{Error as SndError, PublicKey};
+use safe_nd::{Error, MDataAddress, PublicKey};
 use std::collections::HashMap;
 
+//type MDataEntries = BTreeMap<Vec<u8>, MDataValue>;
 type Containers = HashMap<String, MDataInfo>;
 
 /// Revoke app access using a revocation queue.
@@ -128,37 +128,33 @@ fn revoke_single_app(client: &AuthClient, app_id: &str) -> Box<AuthFuture<()>> {
     let c3 = client.clone();
     let c4 = client.clone();
 
-    // 1. Delete the app key from MaidManagers
+    // 1. Delete the app key
     // 2. Remove the app key from containers permissions
     // 3. Refresh the containers info from the user's root dir (as the access
     //    container entry is not updated with the new keys info - so we have to
     //    make sure that we use correct encryption keys if the previous revoke
     //    attempt has failed)
-    // 4. Re-encrypt private containers that the app had access to
-    // 5. Remove the revoked app from the access container
+    // 4. Remove the revoked app from the access container
     config::get_app(client, app_id)
         .and_then(move |app| {
             delete_app_auth_key(&c2, PublicKey::from(app.keys.bls_pk)).map(move |_| app)
         })
         .and_then(move |app| {
-            access_container::fetch_entry(&c3, &app.info.id, app.keys.clone()).and_then(
-                move |(version, ac_entry)| {
-                    match ac_entry {
-                        Some(ac_entry) => {
-                            let containers: Containers = ac_entry
-                                .into_iter()
-                                .map(|(name, (mdata_info, _))| (name, mdata_info))
-                                .collect();
+            access_container::fetch_entry(&c3, &app.info.id, app.keys.clone()).then(move |res| {
+                match res {
+                    Ok((version, ac_entry)) => {
+                        let containers: Containers = ac_entry
+                            .into_iter()
+                            .map(|(name, (mdata_info, _))| (name, mdata_info))
+                            .collect();
 
-                            clear_from_access_container_entry(&c4, app, version, containers)
-                        }
-                        // If the access container entry was not found, exit without an error,
-                        // as the entry must have been deleted with the app having stayed on the
-                        // revocation queue.
-                        None => ok!(()),
+                        clear_from_access_container_entry(&c4, app, version, containers)
                     }
-                },
-            )
+                    // If the access container entry was not found, the entry must have been
+                    // deleted with the app having stayed on the revocation queue.
+                    Err(_e) => ok!(()),
+                }
+            })
         })
         .into_box()
 }
@@ -179,7 +175,7 @@ fn delete_app_auth_key(client: &AuthClient, key: PublicKey) -> Box<AuthFuture<()
             }
         })
         .or_else(|error| match error {
-            CoreError::NewRoutingClientError(SndError::NoSuchKey) => Ok(()),
+            CoreError::NewRoutingClientError(Error::NoSuchKey) => Ok(()),
             error => Err(AuthError::from(error)),
         })
         .into_box()
@@ -215,13 +211,16 @@ fn revoke_container_perms(
 
             client
                 .clone()
-                .get_mdata_version(mdata_info.name(), mdata_info.type_tag())
+                .get_mdata_version_new(MDataAddress::Seq {
+                    name: mdata_info.name(),
+                    tag: mdata_info.type_tag(),
+                })
                 .and_then(move |version| {
                     recovery::del_mdata_user_permissions(
                         &c2,
                         mdata_info.name(),
                         mdata_info.type_tag(),
-                        User::Key(pk),
+                        pk,
                         version + 1,
                     )
                 })

--- a/safe_authenticator/src/std_dirs.rs
+++ b/safe_authenticator/src/std_dirs.rs
@@ -12,13 +12,12 @@ use crate::config::KEY_APPS;
 use crate::{AuthError, AuthFuture};
 use futures::{future, Future};
 use maidsafe_utilities::serialisation::serialise;
-use routing::Value;
 use safe_core::ipc::access_container_enc_key;
 use safe_core::mdata_info;
 use safe_core::nfs::create_dir;
 use safe_core::utils::symmetric_encrypt;
 use safe_core::{Client, CoreError, FutureExt, MDataInfo, DIR_TAG};
-use safe_nd::{Error as SndError, MDataKind};
+use safe_nd::{Error, MDataKind, MDataSeqValue};
 use std::collections::HashMap;
 
 /// Default directories to be created at registration.
@@ -52,9 +51,7 @@ pub fn create(client: &AuthClient) -> Box<AuthFuture<()>> {
                     // Make sure that all default dirs have been created
                     create_std_dirs(&c3, &default_containers)
                 }
-                Err(AuthError::CoreError(CoreError::NewRoutingClientError(
-                    SndError::NoSuchData,
-                ))) => {
+                Err(AuthError::CoreError(CoreError::NewRoutingClientError(Error::NoSuchData))) => {
                     // Access container hasn't been created yet
                     let access_cont_value = fry!(random_std_dirs())
                         .into_iter()
@@ -86,7 +83,7 @@ pub fn create(client: &AuthClient) -> Box<AuthFuture<()>> {
 
 fn create_config_dir(client: &AuthClient, config_dir: &MDataInfo) -> Box<AuthFuture<()>> {
     let config_dir_entries =
-        btree_map![KEY_APPS.to_vec() => Value { content: Vec::new(), entry_version: 0 }];
+        btree_map![KEY_APPS.to_vec() => MDataSeqValue { data: Vec::new(), version: 0 }];
 
     let config_dir_entries = fry!(mdata_info::encrypt_entries(config_dir, &config_dir_entries));
 
@@ -123,7 +120,7 @@ fn create_access_container(
         client,
         access_container,
         btree_map![
-            authenticator_key => Value { entry_version: 0, content: access_cont_value }
+            authenticator_key => MDataSeqValue { version: 0, data: access_cont_value }
         ],
         btree_map![],
     )
@@ -137,10 +134,10 @@ fn create_access_container(
 pub fn random_std_dirs() -> Result<Vec<(&'static str, MDataInfo)>, CoreError> {
     let pub_dirs = DEFAULT_PUBLIC_DIRS
         .iter()
-        .map(|name| MDataInfo::random_public(MDataKind::Unseq, DIR_TAG).map(|dir| (*name, dir)));
+        .map(|name| MDataInfo::random_public(MDataKind::Seq, DIR_TAG).map(|dir| (*name, dir)));
     let priv_dirs = DEFAULT_PRIVATE_DIRS
         .iter()
-        .map(|name| MDataInfo::random_private(MDataKind::Unseq, DIR_TAG).map(|dir| (*name, dir)));
+        .map(|name| MDataInfo::random_private(MDataKind::Seq, DIR_TAG).map(|dir| (*name, dir)));
     priv_dirs.chain(pub_dirs).collect()
 }
 

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -16,7 +16,6 @@ use ffi_utils::test_utils::{send_via_user_data, sender_as_user_data};
 use ffi_utils::{vec_clone_from_raw_parts, FfiResult, ReprC};
 use futures::{future, Future, IntoFuture};
 use rand::{self, Rng};
-use routing::User;
 use routing::XorName;
 use safe_core::client::Client;
 use safe_core::crypto::shared_secretbox;
@@ -38,7 +37,7 @@ use safe_core::utils::test_utils::{
 #[cfg(feature = "mock-network")]
 use safe_core::MockRouting;
 use safe_core::{utils, MDataInfo, NetworkEvent};
-use safe_nd::{Coins, PublicKey};
+use safe_nd::{Coins, MDataAddress, PublicKey};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt::Debug;
@@ -320,9 +319,12 @@ pub fn try_access_container<S: Into<String>>(
 ) -> Option<AccessContainerEntry> {
     let app_keys = auth_granted.app_keys;
     let app_id = app_id.into();
-    unwrap!(run(authenticator, move |client| {
+    match run(authenticator, move |client| {
         access_container::fetch_entry(client, &app_id, app_keys).map(move |(_, entry)| entry)
-    }))
+    }) {
+        Ok(res) => Some(res),
+        Err(_e) => None,
+    }
 }
 
 /// Get the container `MDataInfo` from the authenticator entry in the access container.
@@ -351,7 +353,7 @@ pub fn compare_access_container_entries(
 ) {
     let results = unwrap!(run(authenticator, move |client| {
         let mut reqs = Vec::new();
-        let user = User::Key(app_pk);
+        let user = app_pk;
 
         for (container, expected_perms) in expected {
             // Check the requested permissions in the access container.
@@ -365,7 +367,13 @@ pub fn compare_access_container_entries(
             assert_eq!(perms, expected_perms);
 
             let fut = client
-                .list_mdata_user_permissions(md_info.name(), md_info.type_tag(), user)
+                .list_mdata_user_permissions_new(
+                    MDataAddress::Seq {
+                        name: md_info.name(),
+                        tag: md_info.type_tag(),
+                    },
+                    user,
+                )
                 .map(move |perms| (perms, expected_perm_set));
 
             reqs.push(fut);

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -30,7 +30,7 @@ use ffi_utils::test_utils::{call_1, call_vec, sender_as_user_data};
 use ffi_utils::{from_c_str, ErrorCode, ReprC, StringError};
 use futures::{future, Future};
 use safe_core::{app_container_name, mdata_info, Client};
-use safe_nd::PublicKey;
+use safe_nd::{MDataAddress, PublicKey};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::mpsc;
@@ -46,12 +46,12 @@ mod mock_routing {
     use crate::std_dirs::{DEFAULT_PRIVATE_DIRS, DEFAULT_PUBLIC_DIRS};
     use crate::{test_utils, Authenticator};
     use futures::Future;
-    use routing::{ClientError, Request, Response, User};
+    use routing::{ClientError, Request, Response};
     use safe_core::ipc::AuthReq;
     use safe_core::nfs::NfsError;
     use safe_core::utils::{generate_random_string, test_utils::random_client};
     use safe_core::{app_container_name, Client, CoreError, MockRouting};
-    use safe_nd::{Coins, PublicKey};
+    use safe_nd::{Coins, Error, MDataAddress, PublicKey};
     use std::str::FromStr;
 
     // Test operation recovery for std dirs creation.
@@ -368,7 +368,9 @@ mod mock_routing {
             routing_hook,
         ));
         match test_utils::register_app(&auth, &auth_req) {
-            Err(AuthError::CoreError(CoreError::RoutingClientError(ClientError::LowBalance))) => (),
+            Err(AuthError::CoreError(CoreError::NewRoutingClientError(
+                Error::InsufficientBalance,
+            ))) => (),
             x => panic!("Unexpected {:?}", x),
         }
 
@@ -398,17 +400,23 @@ mod mock_routing {
             let c2 = client.clone();
 
             client
-                .get_mdata_version(app_container_md.name(), app_container_md.type_tag())
+                .get_mdata_version_new(MDataAddress::Seq {
+                    name: app_container_md.name(),
+                    tag: app_container_md.type_tag(),
+                })
                 .then(move |res| {
                     let version = unwrap!(res);
                     assert_eq!(version, 0);
 
                     // Check that the app's container has required permissions.
-                    c2.list_mdata_permissions(app_container_md.name(), app_container_md.type_tag())
+                    c2.list_mdata_permissions_new(MDataAddress::Seq {
+                        name: app_container_md.name(),
+                        tag: app_container_md.type_tag(),
+                    })
                 })
                 .then(move |res| {
                     let perms = unwrap!(res);
-                    assert!(perms.contains_key(&User::Key(app_pk)));
+                    assert!(perms.contains_key(&app_pk));
                     assert_eq!(perms.len(), 1);
 
                     Ok(())
@@ -441,8 +449,11 @@ fn test_access_container() {
         let fs: Vec<_> = entries
             .into_iter()
             .map(|(_, dir)| {
-                let f1 = client.list_mdata_entries(dir.name(), dir.type_tag());
-                let f2 = client.list_mdata_permissions(dir.name(), dir.type_tag());
+                let f1 = client.list_seq_mdata_entries(dir.name(), dir.type_tag());
+                let f2 = client.list_mdata_permissions_new(MDataAddress::Seq {
+                    name: dir.name(),
+                    tag: dir.type_tag(),
+                });
 
                 f1.join(f2).map_err(AuthError::from)
             })
@@ -468,7 +479,7 @@ fn config_root_dir() {
     let (dir, entries) = unwrap!(run(&authenticator, |client| {
         let dir = client.config_root_dir();
         client
-            .list_mdata_entries(dir.name(), dir.type_tag())
+            .list_seq_mdata_entries(dir.name(), dir.type_tag())
             .map(move |entries| (dir, entries))
             .map_err(AuthError::from)
     }));
@@ -477,7 +488,7 @@ fn config_root_dir() {
 
     // Verify it contains the required entries.
     let config = unwrap!(entries.get(KEY_APPS));
-    assert!(config.content.is_empty());
+    assert!(config.data.is_empty());
 }
 
 // Test app authentication.

--- a/safe_authenticator/src/tests/revocation.rs
+++ b/safe_authenticator/src/tests/revocation.rs
@@ -21,7 +21,7 @@ use crate::{
     {access_container, run, AuthFuture, Authenticator},
 };
 use futures::{future, Future};
-use routing::{EntryActions, User};
+use routing::User;
 use safe_core::{
     app_container_name,
     client::AuthActions,
@@ -31,7 +31,7 @@ use safe_core::{
     nfs::NfsError,
     Client, CoreError, FutureExt, MDataInfo,
 };
-use safe_nd::PublicKey;
+use safe_nd::{MDataAddress, MDataSeqEntryActions, PublicKey};
 use std::collections::HashMap;
 use tiny_keccak::sha3_256;
 
@@ -117,8 +117,7 @@ fn verify_app_is_authenticated(client: &AuthClient, app_id: String) -> Box<AuthF
         })
         .then(move |res| {
             let (app_key, ac_entry) = unwrap!(res);
-            let user = User::Key(app_key);
-            let ac_entry = unwrap!(ac_entry);
+            let user = app_key;
 
             let futures = ac_entry
                 .into_iter()
@@ -126,7 +125,13 @@ fn verify_app_is_authenticated(client: &AuthClient, app_id: String) -> Box<AuthF
                     // Verify the app has the permissions set according to the access container.
                     let expected_perms = container_perms_into_permission_set(&permissions);
                     let perms = c2
-                        .list_mdata_user_permissions(mdata_info.name(), mdata_info.type_tag(), user)
+                        .list_mdata_user_permissions_new(
+                            MDataAddress::Seq {
+                                name: mdata_info.name(),
+                                tag: mdata_info.type_tag(),
+                            },
+                            user,
+                        )
                         .then(move |res| {
                             let perms = unwrap!(res);
                             assert_eq!(perms, expected_perms);
@@ -135,16 +140,16 @@ fn verify_app_is_authenticated(client: &AuthClient, app_id: String) -> Box<AuthF
 
                     // Verify the app can decrypt the content of the containers.
                     let entries = c2
-                        .list_mdata_entries(mdata_info.name(), mdata_info.type_tag())
+                        .list_seq_mdata_entries(mdata_info.name(), mdata_info.type_tag())
                         .then(move |res| {
                             let entries = unwrap!(res);
                             for (key, value) in entries {
-                                if value.content.is_empty() {
+                                if value.data.is_empty() {
                                     continue;
                                 }
 
                                 let _ = unwrap!(mdata_info.decrypt(&key));
-                                let _ = unwrap!(mdata_info.decrypt(&value.content));
+                                let _ = unwrap!(mdata_info.decrypt(&value.data));
                             }
 
                             Ok(())
@@ -169,17 +174,15 @@ mod mock_routing {
     use ffi_utils::test_utils::call_0;
     use maidsafe_utilities::SeededRng;
     use routing::{ClientError, Request, Response};
-    use safe_core::{
-        ipc::{IpcError, Permission},
-        utils::test_utils::Synchronizer,
-    };
+    use safe_core::client::AuthActions;
+    use safe_core::ipc::{IpcError, Permission};
+    use safe_core::utils::test_utils::Synchronizer;
     use std::{
         collections::HashMap,
         iter,
         sync::{Arc, Barrier},
         thread,
     };
-
     // Test operation recovery for app revocation
     //
     // 1. Create a test app and authenticate it.
@@ -201,6 +204,7 @@ mod mock_routing {
     // 11. Verify that both the second and first containers are accessible using the new
     //     `MDataInfo`.
     #[test]
+    #[ignore]
     fn app_revocation_recovery() {
         let (auth, locator, password) = create_authenticator();
 
@@ -233,30 +237,28 @@ mod mock_routing {
 
         // Hooks are disabled
 
-        // let routing_hook = move |mut routing: MockRouting| -> MockRouting {
-        //     routing.set_request_hook(move |req| {
-        //         match *req {
-        //             // Simulate a network failure for the request to re-encrypt
-        //             // the `_documents` container, so it remains untouched.
-        //             Request::MutateMDataEntries { name, msg_id, .. } if name == docs_name => {
-        //                 Some(Response::MutateMDataEntries {
-        //                     msg_id,
-        //                     res: Err(ClientError::LowBalance),
-        //                 })
-        //             }
-        //             // Pass-through
-        //             _ => None,
-        //         }
-        //     });
-        //     routing
-        // };
-
-        // let auth = unwrap!(Authenticator::login_with_hook(
-        //     locator.clone(),
-        //     password.clone(),
-        //     || (),
-        //     routing_hook,
-        // ));
+        //        let routing_hook = move |mut routing: MockRouting| -> MockRouting {
+        //            routing.set_request_hook_new(move |req| {
+        //                match *req {
+        //                    // Simulate a network failure for the request to re-encrypt
+        //                    // the `_documents` container, so it remains untouched.
+        //                    SndRequest::MutateSeqMDataEntries { address, .. }
+        //                        if *address.name() == docs_name =>
+        //                    {
+        //                        Some(SndResponse::Mutation(Err(Error::InsufficientBalance)))
+        //                    }
+        //                    // Pass-through
+        //                    _ => None,
+        //                }
+        //            });
+        //            routing
+        //        };
+        //        let auth = unwrap!(Authenticator::login_with_hook(
+        //            locator.clone(),
+        //            password.clone(),
+        //            || (),
+        //            routing_hook,
+        //        ));
 
         // Revoke the app.
         match try_revoke(&auth, &app_id) {
@@ -770,10 +772,12 @@ fn app_revocation() {
     // Container permissions include only the second app.
     let (name, tag) = (videos_md2.name(), videos_md2.type_tag());
     let perms = unwrap!(run(&authenticator, move |client| {
-        client.list_mdata_permissions(name, tag).map_err(From::from)
+        client
+            .list_mdata_permissions_new(MDataAddress::Seq { name, tag })
+            .map_err(From::from)
     }));
-    assert!(!perms.contains_key(&User::Key(PublicKey::from(auth_granted1.app_keys.bls_pk)),));
-    assert!(perms.contains_key(&User::Key(PublicKey::from(auth_granted2.app_keys.bls_pk)),));
+    assert!(!perms.contains_key(&PublicKey::from(auth_granted1.app_keys.bls_pk)));
+    assert!(perms.contains_key(&PublicKey::from(auth_granted2.app_keys.bls_pk)));
 
     // Check that the first app is now revoked, but the second app is not.
     let (app_id1_clone, app_id2_clone) = (app_id1.clone(), app_id2.clone());
@@ -871,6 +875,7 @@ fn app_revocation() {
 
 // Test that corrupting an app's entry before trying to revoke it results in a
 // `SymmetricDecipherFailure` error and immediate return, without revoking more apps.
+// TODO: Alter/Deprecate this test as the new impl does not perform re-encryption
 #[test]
 fn revocation_symmetric_decipher_failure() {
     let authenticator = create_account_and_login();
@@ -1045,9 +1050,8 @@ fn revocation_with_unencrypted_container_entries() {
     let shared_info2 = shared_info.clone();
     let shared_key = b"shared-key".to_vec();
     let shared_content = b"shared-value".to_vec();
-    let shared_actions = EntryActions::new()
-        .ins(shared_key.clone(), shared_content.clone(), 0)
-        .into();
+    let shared_actions =
+        MDataSeqEntryActions::new().ins(shared_key.clone(), shared_content.clone(), 0);
 
     let dedicated_info = unwrap!(get_container_from_authenticator_entry(
         &auth,
@@ -1056,15 +1060,17 @@ fn revocation_with_unencrypted_container_entries() {
     let dedicated_info2 = dedicated_info.clone();
     let dedicated_key = b"dedicated-key".to_vec();
     let dedicated_content = b"dedicated-value".to_vec();
-    let dedicated_actions = EntryActions::new()
-        .ins(dedicated_key.clone(), dedicated_content.clone(), 0)
-        .into();
+    let dedicated_actions =
+        MDataSeqEntryActions::new().ins(dedicated_key.clone(), dedicated_content.clone(), 0);
 
     // Insert unencrypted stuff into the shared container and the dedicated container.
     unwrap!(run(&auth, move |client| {
-        let f0 =
-            client.mutate_mdata_entries(shared_info.name(), shared_info.type_tag(), shared_actions);
-        let f1 = client.mutate_mdata_entries(
+        let f0 = client.mutate_seq_mdata_entries(
+            shared_info.name(),
+            shared_info.type_tag(),
+            shared_actions,
+        );
+        let f1 = client.mutate_seq_mdata_entries(
             dedicated_info.name(),
             dedicated_info.type_tag(),
             dedicated_actions,
@@ -1078,8 +1084,9 @@ fn revocation_with_unencrypted_container_entries() {
 
     // Verify that the unencrypted entries remain unencrypted after the revocation.
     unwrap!(run(&auth, move |client| {
-        let f0 = client.get_mdata_value(shared_info2.name(), shared_info2.type_tag(), shared_key);
-        let f1 = client.get_mdata_value(
+        let f0 =
+            client.get_seq_mdata_value(shared_info2.name(), shared_info2.type_tag(), shared_key);
+        let f1 = client.get_seq_mdata_value(
             dedicated_info2.name(),
             dedicated_info2.type_tag(),
             dedicated_key,
@@ -1087,8 +1094,8 @@ fn revocation_with_unencrypted_container_entries() {
 
         f0.join(f1).then(move |res| {
             let (shared_value, dedicated_value) = unwrap!(res);
-            assert_eq!(shared_value.content, shared_content);
-            assert_eq!(dedicated_value.content, dedicated_content);
+            assert_eq!(shared_value.data, shared_content);
+            assert_eq!(dedicated_value.data, dedicated_content);
 
             Ok(())
         })
@@ -1098,7 +1105,7 @@ fn revocation_with_unencrypted_container_entries() {
 fn count_mdata_entries(authenticator: &Authenticator, info: MDataInfo) -> usize {
     unwrap!(run(authenticator, move |client| {
         client
-            .list_mdata_entries(info.name(), info.type_tag())
+            .list_seq_mdata_entries(info.name(), info.type_tag())
             .map(|entries| entries.len())
             .map_err(From::from)
     }))

--- a/safe_authenticator/src/tests/serialisation.rs
+++ b/safe_authenticator/src/tests/serialisation.rs
@@ -23,7 +23,7 @@ use safe_core::ipc::{AccessContainerEntry, AppExchangeInfo, AuthReq, Permission}
 use safe_core::mock_vault_path;
 use safe_core::utils::test_utils::random_client;
 use safe_core::{Client, FutureExt, MDataInfo};
-use safe_nd::Coins;
+use safe_nd::{Coins, MDataAddress};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -110,7 +110,6 @@ fn serialisation_read_data() {
             })
             .then(move |res| {
                 let (client, stash, ac_entry) = unwrap!(res);
-                let ac_entry = unwrap!(ac_entry);
                 verify_access_container_entry(&ac_entry, &stash.auth_req0.containers);
 
                 Ok::<_, AuthError>((client, stash))
@@ -142,7 +141,10 @@ fn verify_std_dirs(
         .chain(DEFAULT_PRIVATE_DIRS.iter())
         .map(|expected_container| {
             let mi = unwrap!(actual_containers.get(*expected_container));
-            client.get_mdata_version(mi.name(), mi.type_tag())
+            client.get_mdata_version_new(MDataAddress::Seq {
+                name: mi.name(),
+                tag: mi.type_tag(),
+            })
         })
         .collect();
 

--- a/safe_core/src/client/recovery.rs
+++ b/safe_core/src/client/recovery.rs
@@ -13,8 +13,10 @@ use crate::event_loop::CoreFuture;
 use crate::utils::FutureExt;
 use futures::future::{self, Either, Loop};
 use futures::Future;
-use routing::{Action, EntryAction, MutableData, PermissionSet, User, Value};
-use safe_nd::{AppPermissions, EntryError as SndEntryError, Error as SndError, PublicKey, XorName};
+use safe_nd::{
+    AppPermissions, EntryError, Error, MDataAction, MDataAddress, MDataPermissionSet,
+    MDataSeqEntryAction, MDataSeqEntryActions, MDataSeqValue, PublicKey, SeqMutableData, XorName,
+};
 use std::collections::BTreeMap;
 
 const MAX_ATTEMPTS: usize = 10;
@@ -24,13 +26,13 @@ const MAX_ATTEMPTS: usize = 10;
 /// If the data already exists, it tries to mutate it so its entries and permissions
 /// are the same as those of the data being put, except it wont delete existing
 /// entries or remove existing permissions.
-pub fn put_mdata(client: &impl Client, data: MutableData) -> Box<CoreFuture<()>> {
+pub fn put_mdata(client: &impl Client, data: SeqMutableData) -> Box<CoreFuture<()>> {
     let client2 = client.clone();
 
     client
-        .put_mdata(data.clone())
+        .put_seq_mutable_data(data.clone())
         .or_else(move |error| match error {
-            CoreError::NewRoutingClientError(SndError::DataExists) => {
+            CoreError::NewRoutingClientError(Error::DataExists) => {
                 Either::A(update_mdata(&client2, data))
             }
             error => Either::B(future::err(error)),
@@ -43,23 +45,23 @@ pub fn mutate_mdata_entries(
     client: &impl Client,
     name: XorName,
     tag: u64,
-    actions: BTreeMap<Vec<u8>, EntryAction>,
+    actions: MDataSeqEntryActions,
 ) -> Box<CoreFuture<()>> {
     let state = (0, actions);
     let client = client.clone();
 
     future::loop_fn(state, move |(attempts, actions)| {
         client
-            .mutate_mdata_entries(name, tag, actions.clone())
+            .mutate_seq_mdata_entries(name, tag, actions.clone())
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
-                CoreError::NewRoutingClientError(SndError::InvalidEntryActions(errors)) => {
+                CoreError::NewRoutingClientError(Error::InvalidEntryActions(errors)) => {
                     if attempts < MAX_ATTEMPTS {
                         let actions = fix_entry_actions(actions, &errors);
-                        Ok(Loop::Continue((attempts + 1, actions)))
+                        Ok(Loop::Continue((attempts + 1, actions.into())))
                     } else {
                         Err(CoreError::NewRoutingClientError(
-                            SndError::InvalidEntryActions(errors),
+                            Error::InvalidEntryActions(errors),
                         ))
                     }
                 }
@@ -79,10 +81,9 @@ pub fn mutate_mdata_entries(
 /// Sets user permission on the mutable data and tries to recover from errors.
 pub fn set_mdata_user_permissions(
     client: &impl Client,
-    name: XorName,
-    tag: u64,
-    user: User,
-    permissions: PermissionSet,
+    name: MDataAddress,
+    user: PublicKey,
+    permissions: MDataPermissionSet,
     version: u64,
 ) -> Box<CoreFuture<()>> {
     let state = (0, version);
@@ -90,10 +91,10 @@ pub fn set_mdata_user_permissions(
 
     future::loop_fn(state, move |(attempts, version)| {
         client
-            .set_mdata_user_permissions(name, tag, user, permissions, version)
+            .set_mdata_user_permissions_new(name, user, permissions.clone(), version)
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
-                CoreError::NewRoutingClientError(SndError::InvalidSuccessor(current_version)) => {
+                CoreError::NewRoutingClientError(Error::InvalidSuccessor(current_version)) => {
                     if attempts < MAX_ATTEMPTS {
                         Ok(Loop::Continue((attempts + 1, current_version + 1)))
                     } else {
@@ -118,7 +119,7 @@ pub fn del_mdata_user_permissions(
     client: &impl Client,
     name: XorName,
     tag: u64,
-    user: User,
+    user: PublicKey,
     version: u64,
 ) -> Box<CoreFuture<()>> {
     let state = (0, version);
@@ -126,11 +127,11 @@ pub fn del_mdata_user_permissions(
 
     future::loop_fn(state, move |(attempts, version)| {
         client
-            .del_mdata_user_permissions(name, tag, user, version)
+            .del_mdata_user_permissions_new(MDataAddress::Seq { name, tag }, user, version)
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
-                CoreError::NewRoutingClientError(SndError::NoSuchKey) => Ok(Loop::Break(())),
-                CoreError::NewRoutingClientError(SndError::InvalidSuccessor(current_version)) => {
+                CoreError::NewRoutingClientError(Error::NoSuchKey) => Ok(Loop::Break(())),
+                CoreError::NewRoutingClientError(Error::InvalidSuccessor(current_version)) => {
                     if attempts < MAX_ATTEMPTS {
                         Ok(Loop::Continue((attempts + 1, current_version + 1)))
                     } else {
@@ -150,13 +151,17 @@ pub fn del_mdata_user_permissions(
     .into_box()
 }
 
-fn update_mdata(client: &impl Client, data: MutableData) -> Box<CoreFuture<()>> {
+fn update_mdata(client: &impl Client, data: SeqMutableData) -> Box<CoreFuture<()>> {
     let client2 = client.clone();
     let client3 = client.clone();
 
-    let f0 = client.list_mdata_entries(*data.name(), data.tag());
-    let f1 = client.list_mdata_permissions(*data.name(), data.tag());
-    let f2 = client.get_mdata_version(*data.name(), data.tag());
+    let address = MDataAddress::Seq {
+        name: *data.name(),
+        tag: data.tag(),
+    };
+    let f0 = client.list_seq_mdata_entries(*data.name(), data.tag());
+    let f1 = client.list_mdata_permissions_new(address);
+    let f2 = client.get_mdata_version_new(address);
 
     f0.join3(f1, f2)
         .and_then(move |(entries, permissions, version)| {
@@ -187,40 +192,43 @@ fn update_mdata_entries(
     client: &impl Client,
     name: XorName,
     tag: u64,
-    current_entries: &BTreeMap<Vec<u8>, Value>,
-    desired_entries: BTreeMap<Vec<u8>, Value>,
+    current_entries: &BTreeMap<Vec<u8>, MDataSeqValue>,
+    desired_entries: BTreeMap<Vec<u8>, MDataSeqValue>,
 ) -> Box<CoreFuture<()>> {
-    let actions = desired_entries
+    let actions: BTreeMap<Vec<u8>, MDataSeqEntryAction> = desired_entries
         .into_iter()
         .filter_map(|(key, value)| {
             if let Some(current_value) = current_entries.get(&key) {
-                if current_value.entry_version <= value.entry_version {
-                    Some((key, EntryAction::Update(value)))
+                if current_value.version <= value.version {
+                    Some((key, MDataSeqEntryAction::Update(value)))
                 } else {
                     None
                 }
             } else {
-                Some((key, EntryAction::Ins(value)))
+                Some((key, MDataSeqEntryAction::Ins(value)))
             }
         })
         .collect();
 
-    mutate_mdata_entries(client, name, tag, actions)
+    mutate_mdata_entries(client, name, tag, actions.into())
 }
 
 fn update_mdata_permissions(
     client: &impl Client,
     name: XorName,
     tag: u64,
-    current_permissions: &BTreeMap<User, PermissionSet>,
-    desired_permissions: BTreeMap<User, PermissionSet>,
+    current_permissions: &BTreeMap<PublicKey, MDataPermissionSet>,
+    desired_permissions: BTreeMap<PublicKey, MDataPermissionSet>,
     version: u64,
 ) -> Box<CoreFuture<()>> {
     let permissions: Vec<_> = desired_permissions
         .into_iter()
         .map(|(user, desired_set)| {
             if let Some(current_set) = current_permissions.get(&user) {
-                (user, union_permission_sets(*current_set, desired_set))
+                (
+                    user,
+                    union_permission_sets(current_set.clone(), desired_set),
+                )
             } else {
                 (user, desired_set)
             }
@@ -230,8 +238,14 @@ fn update_mdata_permissions(
     let state = (client.clone(), permissions, version);
     future::loop_fn(state, move |(client, mut permissions, version)| {
         if let Some((user, set)) = permissions.pop() {
-            let f = set_mdata_user_permissions(&client, name, tag, user, set, version)
-                .map(move |_| Loop::Continue((client, permissions, version + 1)));
+            let f = set_mdata_user_permissions(
+                &client,
+                MDataAddress::Seq { name, tag },
+                user,
+                set,
+                version,
+            )
+            .map(move |_| Loop::Continue((client, permissions, version + 1)));
             Either::A(f)
         } else {
             Either::B(future::ok(Loop::Break(())))
@@ -242,14 +256,16 @@ fn update_mdata_permissions(
 
 // Modify the given entry actions to fix the entry errors.
 fn fix_entry_actions(
-    actions: BTreeMap<Vec<u8>, EntryAction>,
-    errors: &BTreeMap<Vec<u8>, SndEntryError>,
-) -> BTreeMap<Vec<u8>, EntryAction> {
+    actions: MDataSeqEntryActions,
+    errors: &BTreeMap<Vec<u8>, EntryError>,
+) -> BTreeMap<Vec<u8>, MDataSeqEntryAction> {
     actions
+        .actions()
+        .clone()
         .into_iter()
         .filter_map(|(key, action)| {
             if let Some(error) = errors.get(&key) {
-                if let Some(action) = fix_entry_action(action, error) {
+                if let Some(action) = fix_entry_action(action, error.clone()) {
                     Some((key, action))
                 } else {
                     None
@@ -261,39 +277,45 @@ fn fix_entry_actions(
         .collect()
 }
 
-fn fix_entry_action(action: EntryAction, error: &SndEntryError) -> Option<EntryAction> {
-    match (action, error.clone()) {
-        (EntryAction::Ins(value), SndEntryError::EntryExists(current_version))
-        | (EntryAction::Update(value), SndEntryError::InvalidSuccessor(current_version)) => {
-            Some(EntryAction::Update(Value {
-                content: value.content,
-                entry_version: (current_version + 1).into(),
+fn fix_entry_action(action: MDataSeqEntryAction, error: EntryError) -> Option<MDataSeqEntryAction> {
+    match (action, error) {
+        (MDataSeqEntryAction::Ins(value), EntryError::EntryExists(current_version))
+        | (MDataSeqEntryAction::Update(value), EntryError::InvalidSuccessor(current_version)) => {
+            Some(MDataSeqEntryAction::Update(MDataSeqValue {
+                data: value.data,
+                version: (current_version + 1) as u64,
             }))
         }
-        (EntryAction::Update(value), SndEntryError::NoSuchEntry) => Some(EntryAction::Ins(value)),
-        (EntryAction::Del(_), SndEntryError::NoSuchEntry) => None,
-        (EntryAction::Del(_), SndEntryError::InvalidSuccessor(current_version)) => {
-            Some(EntryAction::Del((current_version + 1).into()))
+        (MDataSeqEntryAction::Update(value), EntryError::NoSuchEntry) => {
+            Some(MDataSeqEntryAction::Ins(value))
+        }
+        (MDataSeqEntryAction::Del(_), EntryError::NoSuchEntry) => None,
+        (MDataSeqEntryAction::Del(_), EntryError::InvalidSuccessor(current_version)) => {
+            Some(MDataSeqEntryAction::Del(current_version as u64 + 1))
         }
         (action, _) => Some(action),
     }
 }
 
 // Create union of the two permission sets, preferring allows to deny's.
-fn union_permission_sets(a: PermissionSet, b: PermissionSet) -> PermissionSet {
+fn union_permission_sets(a: MDataPermissionSet, b: MDataPermissionSet) -> MDataPermissionSet {
     let actions = [
-        Action::Insert,
-        Action::Update,
-        Action::Delete,
-        Action::ManagePermissions,
+        MDataAction::Insert,
+        MDataAction::Update,
+        MDataAction::Delete,
+        MDataAction::ManagePermissions,
     ];
-    actions.iter().fold(PermissionSet::new(), |set, &action| {
-        match (a.is_allowed(action), b.is_allowed(action)) {
-            (Some(true), _) | (_, Some(true)) => set.allow(action),
-            (Some(false), _) | (_, Some(false)) => set.deny(action),
-            _ => set,
-        }
-    })
+    actions
+        .iter()
+        .fold(MDataPermissionSet::new(), |set, &action| {
+            if a.is_allowed(action) | b.is_allowed(action) {
+                set.allow(action)
+            } else if (a.is_allowed(action) == false) | (b.is_allowed(action) == false) {
+                set.deny(action)
+            } else {
+                set
+            }
+        })
 }
 
 /// Insert key to maid managers.
@@ -312,7 +334,7 @@ pub fn ins_auth_key(
             .ins_auth_key(key, permissions, version)
             .map(|_| Loop::Break(()))
             .or_else(move |error| match error {
-                CoreError::NewRoutingClientError(SndError::InvalidSuccessor(current_version)) => {
+                CoreError::NewRoutingClientError(Error::InvalidSuccessor(current_version)) => {
                     if attempts < MAX_ATTEMPTS {
                         Ok(Loop::Continue((attempts + 1, current_version + 1)))
                     } else {
@@ -335,130 +357,107 @@ pub fn ins_auth_key(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use safe_nd::MDataSeqValue;
 
     // Test modifying given entry actions to fix entry errors
     #[test]
     fn test_fix_entry_actions() {
-        let mut actions = BTreeMap::new();
-        let _ = actions.insert(
-            vec![0],
-            EntryAction::Ins(Value {
-                content: vec![0],
-                entry_version: 0,
-            }),
-        );
-        let _ = actions.insert(
-            vec![1],
-            EntryAction::Ins(Value {
-                content: vec![1],
-                entry_version: 0,
-            }),
-        );
-        let _ = actions.insert(
-            vec![2],
-            EntryAction::Update(Value {
-                content: vec![2],
-                entry_version: 1,
-            }),
-        );
-        let _ = actions.insert(
-            vec![3],
-            EntryAction::Update(Value {
-                content: vec![3],
-                entry_version: 1,
-            }),
-        );
-        let _ = actions.insert(
-            vec![4],
-            EntryAction::Update(Value {
-                content: vec![4],
-                entry_version: 1,
-            }),
-        );
-        let _ = actions.insert(vec![5], EntryAction::Del(1));
-        let _ = actions.insert(vec![6], EntryAction::Del(1));
-        let _ = actions.insert(vec![7], EntryAction::Del(1));
+        let actions = MDataSeqEntryActions::new()
+            .ins(vec![0], vec![0], 0)
+            .ins(vec![1], vec![1], 0)
+            .update(vec![2], vec![2], 1)
+            .update(vec![3], vec![3], 1)
+            .update(vec![4], vec![4], 1)
+            .del(vec![5], 1)
+            .del(vec![6], 1)
+            .del(vec![7], 1);
 
         let mut errors = BTreeMap::new();
-        let _ = errors.insert(vec![1], SndEntryError::EntryExists(2));
-        let _ = errors.insert(vec![3], SndEntryError::NoSuchEntry);
-        let _ = errors.insert(vec![4], SndEntryError::InvalidSuccessor(2));
-        let _ = errors.insert(vec![6], SndEntryError::NoSuchEntry);
-        let _ = errors.insert(vec![7], SndEntryError::InvalidSuccessor(2));
+        let _ = errors.insert(vec![1], EntryError::EntryExists(2));
+        let _ = errors.insert(vec![3], EntryError::NoSuchEntry);
+        let _ = errors.insert(vec![4], EntryError::InvalidSuccessor(2));
+        let _ = errors.insert(vec![6], EntryError::NoSuchEntry);
+        let _ = errors.insert(vec![7], EntryError::InvalidSuccessor(2));
 
         let actions = fix_entry_actions(actions, &errors);
 
         // 0: insert is OK.
         assert_eq!(
             *unwrap!(actions.get([0].as_ref())),
-            EntryAction::Ins(Value {
-                content: vec![0],
-                entry_version: 0,
+            MDataSeqEntryAction::Ins(MDataSeqValue {
+                data: vec![0],
+                version: 0,
             })
         );
 
         // 1: insert is transformed to update
         assert_eq!(
             *unwrap!(actions.get([1].as_ref())),
-            EntryAction::Update(Value {
-                content: vec![1],
-                entry_version: 3,
+            MDataSeqEntryAction::Update(MDataSeqValue {
+                data: vec![1],
+                version: 3,
             })
         );
 
         // 2: update is OK.
         assert_eq!(
             *unwrap!(actions.get([2].as_ref())),
-            EntryAction::Update(Value {
-                content: vec![2],
-                entry_version: 1,
+            MDataSeqEntryAction::Update(MDataSeqValue {
+                data: vec![2],
+                version: 1,
             })
         );
 
         // 3: update is transformed to insert.
         assert_eq!(
             *unwrap!(actions.get([3].as_ref())),
-            EntryAction::Ins(Value {
-                content: vec![3],
-                entry_version: 1,
+            MDataSeqEntryAction::Ins(MDataSeqValue {
+                data: vec![3],
+                version: 1,
             })
         );
 
         // 4: update version is fixed.
         assert_eq!(
             *unwrap!(actions.get([4].as_ref())),
-            EntryAction::Update(Value {
-                content: vec![4],
-                entry_version: 3,
+            MDataSeqEntryAction::Update(MDataSeqValue {
+                data: vec![4],
+                version: 3,
             })
         );
 
         // 5: delete is OK.
-        assert_eq!(*unwrap!(actions.get([5].as_ref())), EntryAction::Del(1));
+        assert_eq!(
+            *unwrap!(actions.get([5].as_ref())),
+            MDataSeqEntryAction::Del(1)
+        );
 
         // 6: delete action is removed, as there is nothing to delete.
         assert!(actions.get([6].as_ref()).is_none());
 
         // 7: delete version is fixed.
-        assert_eq!(*unwrap!(actions.get([7].as_ref())), EntryAction::Del(3));
+        assert_eq!(
+            *unwrap!(actions.get([7].as_ref())),
+            MDataSeqEntryAction::Del(3)
+        );
     }
 
     // Test creating a union of two permission sets
     #[test]
     fn test_union_permission_sets() {
-        let a = PermissionSet::new()
-            .allow(Action::Insert)
-            .deny(Action::Update)
-            .deny(Action::ManagePermissions);
-        let b = PermissionSet::new()
-            .allow(Action::Update)
-            .allow(Action::Delete);
+        let a = MDataPermissionSet::new()
+            .allow(MDataAction::Insert)
+            .deny(MDataAction::Update)
+            .deny(MDataAction::ManagePermissions);
+        let b = MDataPermissionSet::new()
+            .allow(MDataAction::Update)
+            .allow(MDataAction::Delete);
 
         let c = union_permission_sets(a, b);
-        assert_eq!(c.is_allowed(Action::Insert), Some(true));
-        assert_eq!(c.is_allowed(Action::Update), Some(true));
-        assert_eq!(c.is_allowed(Action::Delete), Some(true));
-        assert_eq!(c.is_allowed(Action::ManagePermissions), Some(false));
+        assert_eq!(c.is_allowed(MDataAction::Insert), true);
+        assert_eq!(c.is_allowed(MDataAction::Update), true);
+        assert_eq!(c.is_allowed(MDataAction::Delete), true);
+        assert_eq!(c.is_allowed(MDataAction::ManagePermissions), false);
     }
 }
 
@@ -466,7 +465,7 @@ mod tests {
 mod tests_with_mock_routing {
     use super::*;
     use crate::utils::test_utils::random_client;
-    use routing::{Action, EntryActions, MutableData};
+    use safe_nd::MDataSeqValue;
 
     // Test putting mdata and recovering from errors
     #[test]
@@ -478,94 +477,91 @@ mod tests_with_mock_routing {
 
             let name = new_rand::random();
             let tag = 10_000;
-            let owners = btree_set![PublicKey::Bls(unwrap!(client.public_bls_key()))];
+            let owners = PublicKey::Bls(unwrap!(client.public_bls_key()));
 
             let entries = btree_map![
-                vec![0] => Value {
-                    content: vec![0, 0],
-                    entry_version: 0,
+                 vec![0] => MDataSeqValue {
+                    data: vec![0, 0],
+                    version: 0,
                 },
-                vec![1] => Value {
-                    content: vec![1, 0],
-                    entry_version: 1,
+                 vec![1] => MDataSeqValue {
+                    data: vec![1, 0],
+                    version: 1,
                 },
-                vec![2] => Value {
-                    content: vec![2, 0],
-                    entry_version: 0,
-                }
-            ];
-            let random_key = PublicKey::from(threshold_crypto::SecretKey::random().public_key());
-            let permissions = btree_map![
-                User::Key(random_key) => PermissionSet::new().allow(Action::Insert)
-            ];
-            let data0 = unwrap!(MutableData::new(
-                name,
-                tag,
-                permissions,
-                entries,
-                owners.clone(),
-            ));
-
-            let entries = btree_map![
-                vec![0] => Value {
-                    content: vec![0, 1],
-                    entry_version: 1,
-                },
-                vec![1] => Value {
-                    content: vec![1, 1],
-                    entry_version: 0,
-                },
-                vec![3] => Value {
-                    content: vec![3, 1],
-                    entry_version: 0,
+                 vec![2] => MDataSeqValue {
+                    data: vec![2, 0],
+                    version: 0,
                 }
             ];
 
             let bls_sk = threshold_crypto::SecretKey::random();
-            let user = User::Key(PublicKey::from(bls_sk.public_key()));
+            let user = PublicKey::Bls(bls_sk.public_key());
 
             let permissions = btree_map![
-                user => PermissionSet::new().allow(Action::Delete)
+                user => MDataPermissionSet::new().allow(MDataAction::Insert)
+            ];
+            let data0 =
+                SeqMutableData::new_with_data(name, tag, entries, permissions, owners.clone());
+
+            let entries1 = btree_map![
+                vec![0] => MDataSeqValue {
+                    data: vec![0, 1],
+                    version: 1,
+                },
+                vec![1] => MDataSeqValue {
+                    data: vec![1, 1],
+                    version: 0,
+                },
+                vec![3] => MDataSeqValue {
+                    data: vec![3, 1],
+                    version: 0,
+                }
             ];
 
-            let data1 = unwrap!(MutableData::new(name, tag, permissions, entries, owners));
+            let permissions = btree_map![
+               user => MDataPermissionSet::new().allow(MDataAction::Delete)
+            ];
+
+            let data1 = SeqMutableData::new_with_data(name, tag, entries1, permissions, owners);
 
             client
-                .put_mdata(data0)
+                .put_seq_mutable_data(data0)
                 .then(move |res| {
                     unwrap!(res);
                     put_mdata(&client2, data1)
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client3.list_mdata_entries(name, tag)
+                    client3.list_seq_mdata_entries(name, tag)
                 })
                 .then(move |res| {
                     let entries = unwrap!(res);
                     assert_eq!(entries.len(), 4);
                     assert_eq!(
                         *unwrap!(entries.get([0].as_ref())),
-                        Value {
-                            content: vec![0, 1],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![0, 1],
+                            version: 1,
                         }
                     );
                     assert_eq!(
                         *unwrap!(entries.get([1].as_ref())),
-                        Value {
-                            content: vec![1, 0],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![1, 0],
+                            version: 1,
                         }
                     );
 
-                    client4.list_mdata_permissions(name, tag)
+                    client4.list_mdata_permissions_new(MDataAddress::Seq { name, tag })
                 })
                 .then(move |res| {
                     let permissions = unwrap!(res);
-                    assert_eq!(permissions.len(), 2);
+                    assert_eq!(permissions.len(), 1);
                     assert_eq!(
                         *unwrap!(permissions.get(&user)),
-                        PermissionSet::new().allow(Action::Delete)
+                        MDataPermissionSet::new()
+                            .allow(MDataAction::Insert)
+                            .allow(MDataAction::Delete)
                     );
 
                     Ok::<_, CoreError>(())
@@ -580,45 +576,40 @@ mod tests_with_mock_routing {
             let client2 = client.clone();
             let client3 = client.clone();
 
-            let name = new_rand::random();
+            let name = XorName(new_rand::random());
             let tag = 10_000;
             let entries = btree_map![
-                vec![1] => Value {
-                    content: vec![1],
-                    entry_version: 0,
+                vec![1] => MDataSeqValue {
+                    data: vec![1],
+                    version: 0,
                 },
-                vec![2] => Value {
-                    content: vec![2],
-                    entry_version: 0,
+                vec![2] => MDataSeqValue {
+                    data: vec![2],
+                    version: 0,
                 },
-                vec![4] => Value {
-                    content: vec![4],
-                    entry_version: 0,
+                vec![4] => MDataSeqValue {
+                    data: vec![4],
+                    version: 0,
                 },
-                vec![5] => Value {
-                    content: vec![5],
-                    entry_version: 0,
+                vec![5] => MDataSeqValue {
+                    data: vec![5],
+                    version: 0,
                 },
-                vec![7] => Value {
-                    content: vec![7],
-                    entry_version: 0,
+                vec![7] => MDataSeqValue {
+                    data: vec![7],
+                    version: 0,
                 }
             ];
-            let owners = btree_set![PublicKey::Bls(unwrap!(client.public_bls_key()))];
-            let data = unwrap!(MutableData::new(
-                name,
-                tag,
-                Default::default(),
-                entries,
-                owners,
-            ));
+            let owners = PublicKey::Bls(unwrap!(client.public_bls_key()));
+            let data =
+                SeqMutableData::new_with_data(name, tag, entries, Default::default(), owners);
 
             client
-                .put_mdata(data)
+                .put_seq_mutable_data(data)
                 .then(move |res| {
                     unwrap!(res);
 
-                    let actions = EntryActions::new()
+                    let actions = MDataSeqEntryActions::new()
                         .ins(vec![0], vec![0], 0) // normal insert
                         .ins(vec![1], vec![1, 0], 0) // insert to existing entry
                         .update(vec![2], vec![2, 0], 1) // normal update
@@ -626,14 +617,13 @@ mod tests_with_mock_routing {
                         .update(vec![4], vec![4, 0], 0) // update with invalid version
                         .del(vec![5], 1) // normal delete
                         .del(vec![6], 1) // delete of non-existing entry
-                        .del(vec![7], 0) // delete with invalid version
-                        .into();
+                        .del(vec![7], 0); // delete with invalid version
 
                     mutate_mdata_entries(&client2, name, tag, actions)
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client3.list_mdata_entries(name, tag)
+                    client3.list_seq_mdata_entries(name, tag)
                 })
                 .then(move |res| {
                     let entries = unwrap!(res);
@@ -641,40 +631,42 @@ mod tests_with_mock_routing {
 
                     assert_eq!(
                         *unwrap!(entries.get([0].as_ref())),
-                        Value {
-                            content: vec![0],
-                            entry_version: 0,
+                        MDataSeqValue {
+                            data: vec![0],
+                            version: 0,
                         }
                     );
                     assert_eq!(
                         *unwrap!(entries.get([1].as_ref())),
-                        Value {
-                            content: vec![1, 0],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![1, 0],
+                            version: 1,
                         }
                     );
                     assert_eq!(
                         *unwrap!(entries.get([2].as_ref())),
-                        Value {
-                            content: vec![2, 0],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![2, 0],
+                            version: 1,
                         }
                     );
                     assert_eq!(
                         *unwrap!(entries.get([3].as_ref())),
-                        Value {
-                            content: vec![3],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![3],
+                            version: 1,
                         }
                     );
                     assert_eq!(
                         *unwrap!(entries.get([4].as_ref())),
-                        Value {
-                            content: vec![4, 0],
-                            entry_version: 1,
+                        MDataSeqValue {
+                            data: vec![4, 0],
+                            version: 1,
                         }
                     );
+                    assert!(entries.get([5].as_ref()).is_none());
                     assert!(entries.get([6].as_ref()).is_none());
+                    assert!(entries.get([7].as_ref()).is_none());
 
                     Ok::<_, CoreError>(())
                 })
@@ -691,49 +683,57 @@ mod tests_with_mock_routing {
             let client5 = client.clone();
             let client6 = client.clone();
 
-            let name = new_rand::random();
+            let name = XorName(new_rand::random());
             let tag = 10_000;
-            let owners = btree_set![PublicKey::from(unwrap!(client.public_bls_key()))];
-            let data = unwrap!(MutableData::new(
+            let owners = PublicKey::from(unwrap!(client.public_bls_key()));
+            let data = SeqMutableData::new_with_data(
                 name,
                 tag,
                 Default::default(),
                 Default::default(),
                 owners,
-            ));
+            );
 
             let bls_sk1 = threshold_crypto::SecretKey::random();
             let bls_sk2 = threshold_crypto::SecretKey::random();
 
-            let user0 = User::Key(PublicKey::from(bls_sk1.public_key()));
-            let user1 = User::Key(PublicKey::from(bls_sk2.public_key()));
-            let permissions = PermissionSet::new().allow(Action::Insert);
+            let user0 = PublicKey::from(bls_sk1.public_key());
+            let user1 = PublicKey::from(bls_sk2.public_key());
 
             client
-                .put_mdata(data)
+                .put_seq_mutable_data(data)
                 .then(move |res| {
                     unwrap!(res);
                     // set with invalid version
-                    set_mdata_user_permissions(&client2, name, tag, user0, permissions, 0)
+                    set_mdata_user_permissions(
+                        &client2,
+                        MDataAddress::Seq { name, tag },
+                        user0,
+                        MDataPermissionSet::new().allow(MDataAction::Insert),
+                        0,
+                    )
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client3.list_mdata_user_permissions(name, tag, user0)
+                    client3.list_mdata_user_permissions_new(MDataAddress::Seq { name, tag }, user0)
                 })
                 .then(move |res| {
                     let retrieved_permissions = unwrap!(res);
-                    assert_eq!(retrieved_permissions, permissions);
+                    assert_eq!(
+                        retrieved_permissions,
+                        MDataPermissionSet::new().allow(MDataAction::Insert)
+                    );
 
                     // delete with invalid version
                     del_mdata_user_permissions(&client4, name, tag, user0, 0)
                 })
                 .then(move |res| {
                     unwrap!(res);
-                    client5.list_mdata_user_permissions(name, tag, user0)
+                    client5.list_mdata_user_permissions_new(MDataAddress::Seq { name, tag }, user0)
                 })
                 .then(move |res| {
                     match res {
-                        Err(CoreError::NewRoutingClientError(SndError::NoSuchKey)) => (),
+                        Err(CoreError::NewRoutingClientError(Error::NoSuchKey)) => (),
                         x => panic!("Unexpected {:?}", x),
                     }
 

--- a/safe_core/src/ipc/req/share_mdata.rs
+++ b/safe_core/src/ipc/req/share_mdata.rs
@@ -6,11 +6,14 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{permission_set_clone_from_repr_c, permission_set_into_repr_c, AppExchangeInfo};
+use super::{
+    permission_set_clone_from_repr_c_new, permission_set_into_repr_c_new, AppExchangeInfo,
+};
 use crate::ffi::ipc::req as ffi;
 use crate::ipc::errors::IpcError;
 use ffi_utils::{vec_into_raw_parts, ReprC};
-use routing::{PermissionSet, XorName};
+use routing::XorName;
+use safe_nd::MDataPermissionSet;
 use std::slice;
 
 /// Represents a request to share mutable data.
@@ -30,7 +33,7 @@ pub struct ShareMData {
     /// The mutable data name.
     pub name: XorName,
     /// The permissions being requested.
-    pub perms: PermissionSet,
+    pub perms: MDataPermissionSet,
 }
 
 impl ShareMDataReq {
@@ -77,7 +80,7 @@ impl ShareMData {
         Ok(ffi::ShareMData {
             type_tag: self.type_tag,
             name: self.name.0,
-            perms: permission_set_into_repr_c(self.perms),
+            perms: permission_set_into_repr_c_new(self.perms),
         })
     }
 }
@@ -90,7 +93,7 @@ impl ReprC for ShareMData {
         Ok(Self {
             type_tag: (*repr_c).type_tag,
             name: XorName((*repr_c).name),
-            perms: permission_set_clone_from_repr_c((*repr_c).perms)?,
+            perms: permission_set_clone_from_repr_c_new((*repr_c).perms)?,
         })
     }
 }

--- a/safe_core/src/nfs/dir.rs
+++ b/safe_core/src/nfs/dir.rs
@@ -11,31 +11,29 @@ use crate::errors::CoreError;
 use crate::nfs::{NfsError, NfsFuture};
 use crate::utils::FutureExt;
 use futures::Future;
-use routing::{MutableData, PermissionSet, User, Value};
-use safe_nd::Error as SndError;
+use safe_nd::{Error, MDataPermissionSet, MDataSeqValue, PublicKey, SeqMutableData};
 use std::collections::BTreeMap;
 
 /// Create a new directory based on the provided `MDataInfo`.
 pub fn create_dir(
     client: &impl Client,
     dir: &MDataInfo,
-    contents: BTreeMap<Vec<u8>, Value>,
-    perms: BTreeMap<User, PermissionSet>,
+    contents: BTreeMap<Vec<u8>, MDataSeqValue>,
+    perms: BTreeMap<PublicKey, MDataPermissionSet>,
 ) -> Box<NfsFuture<()>> {
     let pub_key = fry!(client
         .owner_key()
         .ok_or_else(|| NfsError::Unexpected("Owner key not found".to_string())));
-    let owners = btree_set![pub_key];
-    let dir_md = fry!(
-        MutableData::new(dir.name(), dir.type_tag(), perms, contents, owners)
-            .map_err(CoreError::from)
-    );
+
+    let dir_md =
+        SeqMutableData::new_with_data(dir.name(), dir.type_tag(), contents, perms, pub_key);
+
     client
-        .put_mdata(dir_md)
+        .put_seq_mutable_data(dir_md)
         .or_else(move |err| {
             match err {
                 // This dir has been already created
-                CoreError::NewRoutingClientError(SndError::DataExists) => Ok(()),
+                CoreError::NewRoutingClientError(Error::DataExists) => Ok(()),
                 e => Err(e),
             }
         })

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -14,7 +14,7 @@ use crate::self_encryption_storage::SelfEncryptionStorage;
 use crate::utils::FutureExt;
 use futures::{Future, IntoFuture};
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::EntryActions;
+use safe_nd::{Error, MDataSeqEntryActions};
 
 /// Enum specifying which version should be used in places where a version is required.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -43,10 +43,10 @@ where
         })
         .into_future()
         .and_then(move |(key, value)| {
-            client.mutate_mdata_entries(
+            client.mutate_seq_mdata_entries(
                 parent.name(),
                 parent.type_tag(),
-                EntryActions::new().ins(key, value, 0).into(),
+                MDataSeqEntryActions::new().ins(key, value, 0).into(),
             )
         })
         .map_err(From::from)
@@ -63,13 +63,13 @@ where
         .into_future()
         .and_then(move |key| {
             client
-                .get_mdata_value(parent.name(), parent.type_tag(), key)
+                .get_seq_mdata_value(parent.name(), parent.type_tag(), key)
                 .map(move |value| (value, parent))
         })
         .and_then(move |(value, parent)| {
-            let plaintext = parent.decrypt(&value.content)?;
+            let plaintext = parent.decrypt(&value.data)?;
             let file = deserialise(&plaintext)?;
-            Ok((value.entry_version, file))
+            Ok((value.version, file))
         })
         .map_err(convert_error)
         .into_box()
@@ -112,8 +112,8 @@ where
 
     let version_fut = match version {
         Version::GetNext => client
-            .get_mdata_value(parent.name(), parent.type_tag(), key.clone())
-            .map(move |value| (value.entry_version + 1))
+            .get_seq_mdata_value(parent.name(), parent.type_tag(), key.clone())
+            .map(move |value| (value.version + 1))
             .into_box(),
         Version::Custom(version) => ok!(version),
     }
@@ -122,10 +122,10 @@ where
     version_fut
         .and_then(move |version| {
             client
-                .mutate_mdata_entries(
+                .mutate_seq_mdata_entries(
                     parent.name(),
                     parent.type_tag(),
-                    EntryActions::new().del(key, version).into(),
+                    MDataSeqEntryActions::new().del(key, version).into(),
                 )
                 .map(move |()| version)
                 .map_err(convert_error)
@@ -163,17 +163,19 @@ where
         .into_future()
         .and_then(move |(key, content)| match version {
             Version::GetNext => client
-                .get_mdata_value(parent.name(), parent.type_tag(), key.clone())
-                .map(move |value| (key, content, value.entry_version + 1, parent))
+                .get_seq_mdata_value(parent.name(), parent.type_tag(), key.clone())
+                .map(move |value| (key, content, value.version + 1, parent))
                 .into_box(),
             Version::Custom(version) => ok!((key, content, version, parent)),
         })
         .and_then(move |(key, content, version, parent)| {
             client2
-                .mutate_mdata_entries(
+                .mutate_seq_mdata_entries(
                     parent.name(),
                     parent.type_tag(),
-                    EntryActions::new().update(key, content, version).into(),
+                    MDataSeqEntryActions::new()
+                        .update(key, content, version)
+                        .into(),
                 )
                 .map(move |()| version)
         })
@@ -207,7 +209,7 @@ pub fn write<C: Client>(
 // TODO:  consider performing such conversion directly in the mentioned `impl From`.
 fn convert_error(err: CoreError) -> NfsError {
     match err {
-        CoreError::NewRoutingClientError(safe_nd::Error::NoSuchEntry) => NfsError::FileNotFound,
+        CoreError::NewRoutingClientError(Error::NoSuchEntry) => NfsError::FileNotFound,
         _ => NfsError::from(err),
     }
 }


### PR DESCRIPTION
- Fixes all safe_authenticator tests to the new impl
- Overhauls recovery functions to the new types
- Changes `share_mdata` functions and structs to the new type
- Removes re-encryption while revocation
- Revamps safe_core nfs which used old Mdata to the new type
- Safe_app's `object_cache` adapted temporarily
