### PR TITLE
fix/nfs: allow opening empty file in append mode #970

### DIFF
--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -39,7 +39,9 @@ pub const GET_NEXT_VERSION: u64 = 0;
 
 /// Replaces the entire content of the file when writing data.
 pub static OPEN_MODE_OVERWRITE: u64 = 1;
-/// Appends to existing data in the file.
+/// Appends to existing data in the file. Falls back to OPEN_MODE_OVERWRITE if it encounters an
+/// empty file. If it is known ahead of time that a file is empty, use OPEN_MODE_OVERWRITE instead
+/// to avoid incurring an unnecessary GET.
 pub static OPEN_MODE_APPEND: u64 = 2;
 /// Open file to read.
 pub static OPEN_MODE_READ: u64 = 4;

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -145,7 +145,7 @@ fn open_file() {
             &app,
             &container_info,
             std::ptr::null(),
-            OPEN_MODE_OVERWRITE,
+            OPEN_MODE_APPEND,
             ud,
             cb,
         )))


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
Wraps the Future returned by `data_map::get()` with an or_else Future that will return None when it matches the `NoSuchData` error. This effectively sets the writer to `OPEN_MODE_OVERWRITE` mode, though I believe it wastes a GET to do so. I updated the doc comment on `OPEN_MODE_APPEND` to indicate it is better to use overwrite mode when it is known ahead of time that the file is empty.
