### PR TITLE
chore/ci: use project specific slave

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ UUID := $(shell uuidgen | sed 's/-//g')
 
 build-container:
 	rm -rf target/
-	docker rmi -f maidsafe/safe-client-libs-build:${SAFE_APP_VERSION}
-	docker build -f scripts/Dockerfile.build -t maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} .
+	docker rmi -f maidsafe/safe-client-libs-build:build
+	docker build -f scripts/Dockerfile.build -t maidsafe/safe-client-libs-build:build
 
 push-container:
-	docker push maidsafe/safe-client-libs-build:${SAFE_APP_VERSION}
+	docker push maidsafe/safe-client-libs-build:build
 
 clean:
 	@if docker ps -a | grep safe_app_build &> /dev/null; then \
@@ -26,7 +26,7 @@ clean:
 build:
 	rm -rf artifacts
 ifeq ($(UNAME_S),Linux)
-	./scripts/build-with-container "real" "${SAFE_APP_VERSION}"
+	./scripts/build-with-container "real"
 else
 	./scripts/build-real
 endif
@@ -36,7 +36,7 @@ endif
 build-mock:
 	rm -rf artifacts
 ifeq ($(UNAME_S),Linux)
-	./scripts/build-with-container "mock" "${SAFE_APP_VERSION}"
+	./scripts/build-with-container "mock"
 else
 	./scripts/build-mock
 endif
@@ -86,7 +86,7 @@ package-deploy-artifacts:
 	@rm -rf deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} \
+		maidsafe/safe-client-libs-build:build \
 		scripts/package-runner-container
 
 retrieve-cache:
@@ -202,7 +202,7 @@ endif
 		-e CARGO_TARGET_DIR=/target \
 		-e COMPAT_TESTS=/bct/tests \
 		-e SCL_TEST_SUITE=binary \
-		maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} \
+		maidsafe/safe-client-libs-build:build \
 		scripts/test-runner-container
 
 tests: clean
@@ -213,7 +213,7 @@ ifeq ($(UNAME_S),Linux)
 		-v "${PWD}":/usr/src/safe_client_libs \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} \
+		maidsafe/safe-client-libs-build:build \
 		scripts/test-mock
 	docker cp "safe_app_tests-${UUID}":/target .
 	docker rm -f "safe_app_tests-${UUID}"
@@ -228,8 +228,8 @@ tests-integration: clean
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} \
+		maidsafe/safe-client-libs-build:build \
 		scripts/test-integration
 
 debug:
-	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:${SAFE_APP_VERSION} /bin/bash
+	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:build /bin/bash

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
 
 stage('build & test') {
     parallel mock_linux: {
-        node('docker') {
+        node('safe_client_libs') {
             checkout(scm)
             clean()
             run_tests('mock')
@@ -37,7 +37,7 @@ stage('build & test') {
         }
     },
     integration_tests: {
-        node('docker') {
+        node('safe_client_libs') {
             checkout(scm)
             run_tests('integration')
         }
@@ -45,7 +45,7 @@ stage('build & test') {
 }
 
 stage('deployment') {
-    node('docker') {
+    node('safe_client_libs') {
         if (env.BRANCH_NAME == "master") {
             checkout(scm)
             package_deploy_artifacts()
@@ -70,7 +70,7 @@ stage('deployment') {
 }
 
 stage('clean') {
-    node('docker') {
+    node('safe_client_libs') {
         clean()
     }
 }

--- a/scripts/build-with-container
+++ b/scripts/build-with-container
@@ -21,13 +21,6 @@ if [[ -z "$build_mode" ]]; then
     exit 1
 fi
 
-safe_app_version=$2
-if [[ -z "$safe_app_version" ]]; then
-    echo "The safe app version number must be supplied as a 2nd argument to this script."
-    echo "Pass it in by reading it from Cargo.toml."
-    exit 1
-fi
-
 user_id=$(id -u)
 group_id=$(id -g)
 
@@ -44,7 +37,7 @@ docker run --name "$container_name" \
     -v "${PWD}":/usr/src/safe_client_libs:Z \
     -u "$user_id":"$group_id" \
     -e CARGO_TARGET_DIR=/target \
-    maidsafe/safe-client-libs-build:"$safe_app_version" \
+    maidsafe/safe-client-libs-build:build \
     scripts/build-"$build_mode"
 docker cp "$container_name":/target .
 docker rm -f "$container_name"


### PR DESCRIPTION
We had been using the generic slave for this project, but we need to
switch it over to a project specific slave. This will then be rebuilt
with Rust 1.37.

We also remove the container being versioned along with the application.
We don't really need that for a build container and we discovered from
another project that this system doesn't work anyway. When you try to
upgrade to a new version there is no container for that version, so it
doesn't work with the version change commit system. We may change the
tag later on from 'build' to perhaps the name of the branch, but this
works for now.