### PR TITLE
Fix Build Container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UUID := $(shell uuidgen | sed 's/-//g')
 build-container:
 	rm -rf target/
 	docker rmi -f maidsafe/safe-client-libs-build:build
-	docker build -f scripts/Dockerfile.build -t maidsafe/safe-client-libs-build:build
+	docker build -f scripts/Dockerfile.build -t maidsafe/safe-client-libs-build:build .
 
 push-container:
 	docker push maidsafe/safe-client-libs-build:build

--- a/scripts/Dockerfile.build
+++ b/scripts/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM rust:1.34.1
+FROM rust:latest
 
 RUN addgroup --gid 1001 maidsafe && \
     adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \


### PR DESCRIPTION
Somehow this ended up with the . missing at the end, which is required for a docker build command.
