### PR TITLE
refactor/client: make `Client::full_id` return `SafeKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
  "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1883,7 +1883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safe-nd"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1916,7 +1916,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.9.1",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
@@ -1960,7 +1960,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.32.1",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2023,7 +2023,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_encryption 0.14.0 (git+https://github.com/maidsafe/self_encryption)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2369,7 +2369,7 @@ version = "0.1.0"
 dependencies = [
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.9.1",
  "safe_authenticator 0.9.1",
  "safe_core 0.32.1",
@@ -3080,7 +3080,7 @@ dependencies = [
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f271e3552cd835fa28c541c34a7e8fdd8cdff09d77fe4eb8f6c42e87a11b096e"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb177622a4b10632e2fc0b3967d13f0f3f432977359ba067eea2c49e375b6ad7"
+"checksum safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d0a69e37aa926cfad59c06dd90ba1f4b7bcceb738ef577aa24f83e6d8da6217"
 "checksum safe_bindgen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "399b14d048a9a9ff0c60efb6cf56fd5e57e8840af43c561e01a490abfb6ea753"
 "checksum safemem 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e133ccc4f4d1cd4f89cc8a7ff618287d56dc7f638b8e38fc32c5fdcadc339dd5"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -206,6 +206,8 @@ fn authorise_app(
 
 // Get the number of containers for `app`
 fn num_containers(app: &App) -> usize {
+    trace!("Getting the number of containers.");
+
     unwrap!(run(app, move |client, context| {
         context.get_access_info(client).then(move |res| {
             let info = unwrap!(res);
@@ -224,9 +226,8 @@ fn num_containers(app: &App) -> usize {
 // 4. Make sure that the app's own container is also created when it's re-authorised
 // with `app_container` set to `true` after it's been revoked.
 #[test]
-#[allow(unsafe_code)]
 fn app_container_creation() {
-    // Authorise an app for the first time with `app_container` set to `true`.
+    trace!("Authorising an app for the first time with `app_container` set to `true`.");
     let auth = authenticator::create_account_and_login();
 
     let app_info = gen_app_exchange_info();
@@ -235,7 +236,7 @@ fn app_container_creation() {
 
     assert_eq!(num_containers(&app), 1); // should only contain app container
 
-    // Authorise a new app with `app_container` set to `false`.
+    trace!("Authorising a new app with `app_container` set to `false`.");
     let auth = authenticator::create_account_and_login();
 
     let app_info = gen_app_exchange_info();
@@ -244,12 +245,12 @@ fn app_container_creation() {
 
     assert_eq!(num_containers(&app), 0); // should be empty
 
-    // Re-authorise the app with `app_container` set to `true`.
+    trace!("Re-authorising the app with `app_container` set to `true`.");
     app = authorise_app(&auth, &app_info, &app_id, true);
 
     assert_eq!(num_containers(&app), 1); // should only contain app container
 
-    // Make sure no mutations are done when re-authorising the app now.
+    trace!("Making sure no mutations are done when re-authorising the app now.");
     let orig_balance: Coins = unwrap!(auth_run(&auth, |client| {
         client.get_balance(None).map_err(AuthError::from)
     }));
@@ -262,7 +263,7 @@ fn app_container_creation() {
 
     assert_eq!(orig_balance, new_balance);
 
-    // Authorise a new app with `app_container` set to `false`.
+    trace!("Authorising a new app with `app_container` set to `false`.");
     let auth = authenticator::create_account_and_login();
 
     let app_info = gen_app_exchange_info();
@@ -271,10 +272,10 @@ fn app_container_creation() {
 
     assert_eq!(num_containers(&app), 0); // should be empty
 
-    // Revoke the app
+    trace!("Revoking the app.");
     revoke(&auth, &app_id);
 
-    // Re-authorise the app with `app_container` set to `true`.
+    trace!("Re-authorising the app with `app_container` set to `true`.");
     let app = authorise_app(&auth, &app_info, &app_id, true);
 
     assert_eq!(num_containers(&app), 1); // should only contain app container

--- a/safe_core/src/client/account.rs
+++ b/safe_core/src/client/account.rs
@@ -6,12 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client::id::SafeKey;
 use crate::client::MDataInfo;
 use crate::crypto::{shared_box, shared_secretbox, shared_sign};
 use crate::errors::CoreError;
 use crate::DIR_TAG;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
-use routing::FullId;
 use rust_sodium::crypto::sign::Seed;
 use rust_sodium::crypto::{box_, pwhash, secretbox, sign};
 use safe_nd::{AppFullId, ClientFullId, MDataKind, PublicKey, XorName, XOR_NAME_LEN};
@@ -176,34 +176,34 @@ impl ClientKeys {
         }
     }
 
+    /// Convert `ClientKeys` into a full client identity.
+    fn client_full_id(&self) -> ClientFullId {
+        let bls_sk = (self.bls_sk).clone();
+
+        ClientFullId::with_bls_key(bls_sk)
+    }
+
     /// Convert `ClientKeys` into a full app identity.
-    pub fn into_app_full_id(self, owner_key: PublicKey) -> AppFullId {
+    pub fn app_full_id(&self, owner_key: PublicKey) -> AppFullId {
         let bls_sk = (self.bls_sk).clone();
 
         AppFullId::with_keys(bls_sk, owner_key)
+    }
+
+    /// Convert `ClientKeys` into a Client `SafeKey`.
+    pub fn client_safe_key(&self) -> SafeKey {
+        SafeKey::client(self.client_full_id())
+    }
+
+    /// Convert `ClientKeys` into an App `SafeKey`.
+    pub fn app_safe_key(&self, owner_key: PublicKey) -> SafeKey {
+        SafeKey::app(self.app_full_id(owner_key))
     }
 }
 
 impl Default for ClientKeys {
     fn default() -> Self {
         Self::new(None)
-    }
-}
-
-impl Into<FullId> for ClientKeys {
-    fn into(self) -> FullId {
-        let enc_sk = (*self.enc_sk).clone();
-        let sign_sk = (*self.sign_sk).clone();
-
-        FullId::with_keys((self.enc_pk, enc_sk), (self.sign_pk, sign_sk), self.bls_sk)
-    }
-}
-
-impl Into<ClientFullId> for ClientKeys {
-    fn into(self) -> ClientFullId {
-        let bls_sk = (self.bls_sk).clone();
-
-        ClientFullId::with_bls_key(bls_sk)
     }
 }
 

--- a/safe_core/src/client/id.rs
+++ b/safe_core/src/client/id.rs
@@ -8,6 +8,7 @@
 
 use safe_nd::{AppFullId, ClientFullId, PublicId, Signature};
 use std::sync::Arc;
+use threshold_crypto::SecretKey as BlsSecretKey;
 
 /// An enum representing the Full Id variants for a Client or App
 #[derive(Clone)]
@@ -21,27 +22,32 @@ pub enum SafeKey {
 impl SafeKey {
     /// Create a client full ID.
     pub fn client(full_id: ClientFullId) -> Self {
-        SafeKey::Client(Arc::new(full_id))
+        Self::Client(Arc::new(full_id))
+    }
+
+    /// Create a client full ID from a given secret BLS key.
+    pub fn client_from_bls_key(bls_sk: BlsSecretKey) -> Self {
+        Self::client(ClientFullId::with_bls_key(bls_sk))
     }
 
     /// Create an app full ID.
     pub fn app(full_id: AppFullId) -> Self {
-        SafeKey::App(Arc::new(full_id))
+        Self::App(Arc::new(full_id))
     }
 
     /// Sign a given message using the App / Client full id as required.
     pub fn sign(&self, msg: &[u8]) -> Signature {
         match self {
-            SafeKey::App(app_full_id) => app_full_id.sign(msg),
-            SafeKey::Client(client_full_id) => client_full_id.sign(msg),
+            Self::App(app_full_id) => app_full_id.sign(msg),
+            Self::Client(client_full_id) => client_full_id.sign(msg),
         }
     }
 
     /// Return a corresponding public ID.
     pub fn public_id(&self) -> PublicId {
         match self {
-            SafeKey::App(app_full_id) => PublicId::App(app_full_id.public_id().clone()),
-            SafeKey::Client(client_full_id) => PublicId::Client(client_full_id.public_id().clone()),
+            Self::App(app_full_id) => PublicId::App(app_full_id.public_id().clone()),
+            Self::Client(client_full_id) => PublicId::Client(client_full_id.public_id().clone()),
         }
     }
 }

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -1832,6 +1832,6 @@ fn create_account(
 
     (
         Authority::ClientManager(account_name),
-        SafeKey::Client(ClientFullId::with_bls_key(owner_sk.clone())),
+        SafeKey::client_from_bls_key(owner_sk.clone()),
     )
 }

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -16,9 +16,9 @@ use maidsafe_utilities::serialisation::{deserialise, serialise};
 use routing::{Authority, ClientError};
 use safe_nd::{
     verify_signature, AData, ADataAction, ADataAddress, ADataIndex, AppPermissions, AppendOnlyData,
-    Coins, Error as SndError, IData, IDataAddress, LoginPacket, MData, MDataAction, MDataAddress,
-    MDataKind, Message, PublicId, PublicKey, Request, Response, Result as SndResult, SeqAppendOnly,
-    Transaction, UnseqAppendOnly, XorName,
+    Coins, Data, Error as SndError, IData, IDataAddress, LoginPacket, MData, MDataAction,
+    MDataAddress, MDataKind, Message, PublicId, PublicKey, Request, Response, Result as SndResult,
+    SeqAppendOnly, Transaction, UnseqAppendOnly, XorName,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -34,14 +34,6 @@ use std::time::Duration;
 use std::time::SystemTime;
 #[cfg(test)]
 use tempfile::tempfile;
-
-// TODO: Replace this with `Data` from safe-nd
-#[derive(Clone, Deserialize, Serialize)]
-pub enum Data {
-    Immutable(IData),
-    Mutable(MData),
-    AppendOnly(AData),
-}
 
 const FILE_NAME: &str = "SCL-Mock";
 


### PR DESCRIPTION
Also implement `compose_message` as a trait method on `Client`

Fixes #995
Fixes #994
Fixes #958

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
