### PR TITLE
Refactor Jenkins build to use mock vault file on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,15 @@ ifeq ($(UNAME_S),Linux)
 else
 	./scripts/test-mock
 endif
-	mkdir artifacts
-	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+	make copy-artifacts
+
+tests-mock-file: clean
+	rm -rf artifacts
+	cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+	cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+	cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
+	cargo test --verbose --release --features=mock-network --manifest-path=tests/Cargo.toml
+	make copy-artifacts
 
 tests-integration: clean
 	rm -rf target/
@@ -233,3 +240,7 @@ tests-integration: clean
 
 debug:
 	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:build /bin/bash
+
+copy-artifacts:
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -30,7 +30,7 @@ stage('build & test') {
     mock_osx: {
         node('osx') {
             checkout(scm)
-            run_tests('mock')
+            run_tests('mock-file')
             strip_build_artifacts()
             package_build_artifacts('mock', 'osx')
             upload_build_artifacts()
@@ -181,6 +181,8 @@ def run_binary_compatibility_tests() {
 def run_tests(mode, bct_test_path='') {
     if (mode == 'mock') {
         sh("make tests")
+    } else if (mode == 'mock-file') {
+        sh("make tests-mock-file")
     } else if (mode == 'binary') {
         command = "SCL_BCT_PATH=${bct_test_path} "
         command += "make test-artifacts-binary"


### PR DESCRIPTION
With AppVeyor now deprecated, we need to consider other options to run tests
against the mock vault file. For this purpose, on OS X the test suite can be
run withouth enabling SAFE_MOCK_IN_MEMORY_STORAGE