### PR TITLE
Refactor Jenkins to use mock file on OSX and lock file only for mutations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,17 @@ ifeq ($(UNAME_S),Linux)
 else
 	./scripts/test-mock
 endif
-	mkdir artifacts
-	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+	make copy-artifacts
+
+test-with-mock-vault-file: clean
+ifeq ($(UNAME_S),Darwin)
+	rm -rf artifacts
+	./scripts/test-with-mock-vault-file
+	make copy-artifacts
+else
+	@echo "Tests against the mock vault file are run only on OS X."
+	@exit 1
+endif
 
 tests-integration: clean
 	rm -rf target/
@@ -233,3 +242,7 @@ tests-integration: clean
 
 debug:
 	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:build /bin/bash
+
+copy-artifacts:
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/safe_core/src/client/mock/connection_manager.rs
+++ b/safe_core/src/client/mock/connection_manager.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::vault::{self, Vault};
+use super::vault::{self, Vault, RequestType, request_is_get};
 use crate::config_handler::{get_config, Config};
 use crate::{
     client::SafeKey,
@@ -63,7 +63,18 @@ impl ConnectionManager {
     /// Send `message` via the `ConnectionGroup` specified by our given `pub_id`.
     pub fn send(&mut self, pub_id: &PublicId, msg: &Message) -> Box<CoreFuture<Response>> {
         let msg: Message = {
-            let mut vault = vault::lock(&self.vault, true);
+            let writing = {
+                if let Message::Request { request, .. } = msg {
+                    if let RequestType::Mutation = request_is_get(&request) {
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+            let mut vault = vault::lock(&self.vault, writing);
             unwrap!(vault.process_request(pub_id.clone(), &unwrap!(serialise(&msg))))
         };
 

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -161,14 +161,14 @@ fn check_perms_mdata(data: &MData, request: &Request, requester: PublicKey) -> S
     }
 }
 
-enum RequestType {
+pub enum RequestType {
     GetForPub,
     GetForUnpub,
     Mutation,
 }
 
 // Is the request a GET and if so, is it for pub or unpub data?
-fn request_is_get(request: &Request) -> RequestType {
+pub fn request_is_get(request: &Request) -> RequestType {
     match *request {
         Request::GetIData(address) => {
             if address.is_pub() {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -30,7 +30,7 @@ stage('build & test') {
     mock_osx: {
         node('osx') {
             checkout(scm)
-            run_tests('mock')
+            run_tests('mock-file')
             strip_build_artifacts()
             package_build_artifacts('mock', 'osx')
             upload_build_artifacts()
@@ -181,6 +181,8 @@ def run_binary_compatibility_tests() {
 def run_tests(mode, bct_test_path='') {
     if (mode == 'mock') {
         sh("make tests")
+    } else if (mode == 'mock-file') {
+        sh("make test-with-mock-vault-file")
     } else if (mode == 'binary') {
         command = "SCL_BCT_PATH=${bct_test_path} "
         command += "make test-artifacts-binary"

--- a/scripts/test-with-mock-vault-file
+++ b/scripts/test-with-mock-vault-file
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -x
+
+cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
+cargo test --verbose --release --features=mock-network --manifest-path=tests/Cargo.toml

--- a/scripts/test-with-mock-vault-file
+++ b/scripts/test-with-mock-vault-file
@@ -2,6 +2,7 @@
 
 set -e -x
 
+export RUST_BACKTRACE=full
 cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
 cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
 cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml


### PR DESCRIPTION
Hey guys, 
I wanted to close and re-open #999 to re-trigger the build since GH is having issues, but I'm unable to re-open it now. So here's a new one.

closes #996 