### PR TITLE
chore/ci: reenable real builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ stages:
 jobs:
   include:
     # # Warm up the cache dependencies
-    # - stage: warmup
-    #   script: set -x; scripts/build-real-core
-    #   os: linux
+    - stage: warmup
+      script: set -x; scripts/build-real-core
+      os: linux
     # # Warm up the cache for a real build
-    # - stage: warmup
-    #   script: set -x; scripts/build-real
-    #   os: linux
+    - stage: warmup
+      script: set -x; scripts/build-real
+      os: linux
     # Warm up the cache for a mock build
     - stage: warmup
       script: set -x; scripts/build-mock
@@ -30,9 +30,9 @@ jobs:
       os: osx
 
     # Tests + clippy
-    # - stage: tests
-    #  script: set -x; scripts/test-binary
-    #  os: linux
+    - stage: tests
+      script: set -x; scripts/test-binary
+      os: linux
     - stage: tests
       script: set -x; scripts/test-mock && scripts/test-integration
       os: linux

--- a/scripts/check-all
+++ b/scripts/check-all
@@ -2,5 +2,5 @@
 
 set -x;
 
-# scripts/check-real &&
+scripts/check-real &&
   scripts/check-mock

--- a/scripts/clippy-all
+++ b/scripts/clippy-all
@@ -2,9 +2,5 @@
 
 set -x;
 
-# TODO: remove `check-all` line below.
-# This fixes a Clippy issue when compiling JNI dependency by running `cargo check` first.
-# See https://github.com/rust-lang-nursery/rust-clippy/issues/2831
-scripts/check-all &&
-  # scripts/clippy-real &&
+scripts/clippy-real &&
   scripts/clippy-mock


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->

Also, it looks like [this](https://github.com/rust-lang/rust-clippy/issues/2831) was fixed some time back! A report of the bug and its fix can be found [here](https://phansch.net/2018/10/10/fixing-a-clippy-crash/).