### PR TITLE
test/access_container: add test for `from_mdata_info`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ stages:
   - deploy
 jobs:
   include:
-    # # Warm up the cache dependencies
+    # Warm up the cache dependencies
     - stage: warmup
       script: set -x; scripts/build-real-core
       os: linux
-    # # Warm up the cache for a real build
+    # Warm up the cache for a real build
     - stage: warmup
       script: set -x; scripts/build-real
       os: linux


### PR DESCRIPTION
Closes #784

Also re-enables the `app_keys` test.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
