### PR TITLE
style/ci: change style from python to java

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ else
 endif
 
 package-build-artifacts:
-ifndef SCL_BRANCH
+ifndef SCL_BUILD_BRANCH
 	@echo "A branch or PR reference must be provided."
-	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@echo "Please set SCL_BUILD_BRANCH to a valid branch or PR reference."
 	@exit 1
 endif
 ifndef SCL_BUILD_NUMBER
@@ -126,9 +126,9 @@ ifndef SCL_BUILD_OS
 	@exit 1
 endif
 ifeq ($(SCL_BUILD_MOCK),true)
-	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
 else
-	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
 endif
 	tar -C artifacts -zcvf ${ARCHIVE_NAME} .
 	rm artifacts/**
@@ -149,25 +149,25 @@ package-commit_hash-deploy-artifacts:
 		scripts/package-runner-container "false"
 
 retrieve-cache:
-ifndef SCL_BRANCH
+ifndef SCL_BUILD_BRANCH
 	@echo "A branch reference must be provided."
-	@echo "Please set SCL_BRANCH to a valid branch reference."
+	@echo "Please set SCL_BUILD_BRANCH to a valid branch reference."
 	@exit 1
 endif
 ifeq ($(OS),Windows_NT)
 	aws s3 cp \
 		--no-sign-request \
 		--region eu-west-2 \
-		s3://${S3_BUCKET}/scl-${SCL_BRANCH}-windows-cache.tar.gz .
+		s3://${S3_BUCKET}/scl-${SCL_BUILD_BRANCH}-windows-cache.tar.gz .
 endif
 	mkdir target
-	tar -C target -xvf scl-${SCL_BRANCH}-windows-cache.tar.gz
-	rm scl-${SCL_BRANCH}-windows-cache.tar.gz
+	tar -C target -xvf scl-${SCL_BUILD_BRANCH}-windows-cache.tar.gz
+	rm scl-${SCL_BUILD_BRANCH}-windows-cache.tar.gz
 
 retrieve-build-artifacts:
-ifndef SCL_BRANCH
+ifndef SCL_BUILD_BRANCH
 	@echo "A branch or PR reference must be provided."
-	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@echo "Please set SCL_BUILD_BRANCH to a valid branch or PR reference."
 	@exit 1
 endif
 ifndef SCL_BUILD_NUMBER
@@ -186,9 +186,9 @@ ifndef SCL_BUILD_OS
 	@exit 1
 endif
 ifeq ($(SCL_BUILD_MOCK),true)
-	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-${SCL_BUILD_OS}-x86_64.tar.gz)
 else
-	$(eval ARCHIVE_NAME := ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
+	$(eval ARCHIVE_NAME := ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-${SCL_BUILD_OS}-x86_64.tar.gz)
 endif
 	aws s3 cp \
 		--no-sign-request \
@@ -211,9 +211,9 @@ endif
 	rm ${ARCHIVE_NAME}
 
 retrieve-all-build-artifacts:
-ifndef SCL_BRANCH
+ifndef SCL_BUILD_BRANCH
 	@echo "A branch or PR reference must be provided."
-	@echo "Please set SCL_BRANCH to a valid branch or PR reference."
+	@echo "Please set SCL_BUILD_BRANCH to a valid branch or PR reference."
 	@exit 1
 endif
 ifndef SCL_BUILD_NUMBER
@@ -228,24 +228,48 @@ endif
 	mkdir -p artifacts/win/mock/release
 	mkdir -p artifacts/osx/real/release
 	mkdir -p artifacts/osx/mock/release
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz .
-	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz .
-	tar -C artifacts/linux/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
-	tar -C artifacts/linux/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
-	tar -C artifacts/win/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
-	tar -C artifacts/win/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
-	tar -C artifacts/osx/real/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
-	tar -C artifacts/osx/mock/release -xvf ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
-	rm ${SCL_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz .
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz .
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz .
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz .
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz .
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz .
+	tar -C artifacts/linux/real/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
+	tar -C artifacts/linux/mock/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
+	tar -C artifacts/win/real/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
+	tar -C artifacts/win/mock/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	tar -C artifacts/osx/real/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	tar -C artifacts/osx/mock/release \
+		-xvf ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-linux-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-linux-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-windows-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-windows-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-osx-x86_64.tar.gz
+	rm ${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-osx-x86_64.tar.gz
 
 test-artifacts-binary:
 ifndef SCL_BCT_PATH

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,71 +1,71 @@
 properties([
     parameters([
-        string(name: 'ARTIFACTS_BUCKET', defaultValue: 'safe-jenkins-build-artifacts'),
-        string(name: 'CACHE_BRANCH', defaultValue: 'master'),
-        string(name: 'DEPLOY_BUCKET', defaultValue: 'safe-client-libs')
+        string(name: "ARTIFACTS_BUCKET", defaultValue: "safe-jenkins-build-artifacts"),
+        string(name: "CACHE_BRANCH", defaultValue: "master"),
+        string(name: "DEPLOY_BUCKET", defaultValue: "safe-client-libs")
     ])
 ])
 
-stage('build & test') {
+stage("build & test") {
     parallel mock_linux: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             checkout(scm)
-            run_tests('mock')
-            strip_build_artifacts()
-            package_build_artifacts('mock', 'linux')
-            upload_build_artifacts()
+            runTests("mock")
+            stripBuildArtifacts()
+            packageBuildArtifacts("mock", "linux")
+            uploadBuildArtifacts()
         }
     },
     mock_windows: {
-        node('windows') {
+        node("windows") {
             checkout(scm)
-            retrieve_cache()
-            run_tests('mock')
-            strip_build_artifacts()
-            package_build_artifacts('mock', 'windows')
-            upload_build_artifacts()
+            retrieveCache()
+            runTests("mock")
+            stripBuildArtifacts()
+            packageBuildArtifacts("mock", "windows")
+            uploadBuildArtifacts()
         }
     },
     mock_osx: {
-        node('osx') {
+        node("osx") {
             checkout(scm)
-            run_tests('mock')
-            strip_build_artifacts()
-            package_build_artifacts('mock', 'osx')
-            upload_build_artifacts()
+            runTests("mock")
+            stripBuildArtifacts()
+            packageBuildArtifacts("mock", "osx")
+            uploadBuildArtifacts()
         }
     },
     real_linux: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             checkout(scm)
             sh("make build")
-            strip_build_artifacts()
-            package_build_artifacts('real', 'linux')
-            upload_build_artifacts()
+            stripBuildArtifacts()
+            packageBuildArtifacts("real", "linux")
+            uploadBuildArtifacts()
         }
     },
     real_windows: {
-        node('windows') {
+        node("windows") {
             checkout(scm)
             sh("make build")
-            strip_build_artifacts()
-            package_build_artifacts('real', 'windows')
-            upload_build_artifacts()
+            stripBuildArtifacts()
+            packageBuildArtifacts("real", "windows")
+            uploadBuildArtifacts()
         }
     },
     real_macos: {
-        node('osx') {
+        node("osx") {
             checkout(scm)
             sh("make build")
-            strip_build_artifacts()
-            package_build_artifacts('real', 'osx')
-            upload_build_artifacts()
+            stripBuildArtifacts()
+            packageBuildArtifacts("real", "osx")
+            uploadBuildArtifacts()
         }
     },
     integration_tests: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             checkout(scm)
-            run_tests('integration')
+            runTests("integration")
         }
     },
     clippy_and_rustfmt: {
@@ -77,23 +77,23 @@ stage('build & test') {
     }
 }
 
-stage('deployment') {
+stage("deployment") {
     parallel deploy_artifacts: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             if (env.BRANCH_NAME == "master") {
                 checkout(scm)
                 sh("git fetch --tags --force")
-                retrieve_build_artifacts()
-                if (is_version_change_commit()) {
-                    version = get_version()
-                    package_deploy_artifacts(true)
-                    create_tag(version)
-                    create_github_release(version)
-                    upload_deploy_artifacts("mock")
+                retrieveBuildArtifacts()
+                if (isVersionChangeCommit()) {
+                    def version = getVersion()
+                    packageDeployArtifacts(true)
+                    createTag(version)
+                    createGitHubRelease(version)
+                    uploadDeployArtifacts("mock")
                 } else {
-                    package_deploy_artifacts(false)
-                    upload_deploy_artifacts("mock")
-                    upload_deploy_artifacts("real")
+                    packageDeployArtifacts(false)
+                    uploadDeployArtifacts("mock")
+                    uploadDeployArtifacts("real")
                 }
             } else {
                 echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
@@ -101,110 +101,103 @@ stage('deployment') {
         }
     },
     publish_safe_core_crate: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             if (env.BRANCH_NAME == "master") {
                 checkout(scm)
-                publish_crate("safe_core")
+                publishCrate("safe_core")
             } else {
                 echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
             }
         }
     },
     publish_safe_app_crate: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             if (env.BRANCH_NAME == "master") {
                 checkout(scm)
-                publish_crate("safe_app")
+                publishCrate("safe_app")
             } else {
                 echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
             }
         }
     },
     publish_safe_auth_crate: {
-        node('safe_client_libs') {
+        node("safe_client_libs") {
             if (env.BRANCH_NAME == "master") {
                 checkout(scm)
-                publish_crate("safe_auth")
+                publishCrate("safe_auth")
             } else {
                 echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
             }
         }
     }
     if (env.BRANCH_NAME == "master") {
-        build(job: '../rust_cache_build-safe_client_libs-windows', wait: false)
-        build(job: '../docker_build-safe_client_libs_build_container', wait: false)
+        build(job: "../rust_cache_build-safe_client_libs-windows", wait: false)
+        build(job: "../docker_build-safe_client_libs_build_container", wait: false)
     }
 }
 
-def retrieve_cache() {
-    if (!fileExists('target')) {
-        sh("SCL_BRANCH=${params.CACHE_BRANCH} make retrieve-cache")
+def retrieveCache() {
+    if (!fileExists("target")) {
+        sh("SCL_BUILD_BRANCH=${params.CACHE_BRANCH} make retrieve-cache")
     }
 }
 
-def is_version_change_commit() {
-    short_commit_hash = sh(
+def isVersionChangeCommit() {
+    def shortCommitHash = sh(
         returnStdout: true,
         script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
-    message = sh(
+    def message = sh(
         returnStdout: true,
         script: "git log --format=%B -n 1 ${short_commit_hash}").trim()
     return message.startsWith("Version change")
 }
 
-def package_build_artifacts(mode, os) {
-    command = ""
-    if (env.CHANGE_ID?.trim()) {
-        command += "SCL_BRANCH=${env.CHANGE_ID} "
-    } else {
-        command += "SCL_BRANCH=${env.BRANCH_NAME} "
+def packageBuildArtifacts(mode, os) {
+    def isMock = mode == "mock" ? "true" : "false"
+    def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
+    withEnv(["SCL_BUILD_NUMBER=${env.BUILD_NUMBER}",
+             "SCL_BUILD_BRANCH=${branch}",
+             "SCL_BUILD_OS=${os}",
+             "SCL_BUILD_MOCK=${isMock}"]) {
+        sh("make package-build-artifacts")
     }
-    command += "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
-    command += "SCL_BUILD_OS=${os} "
-    if (mode == 'mock') {
-        command += "SCL_BUILD_MOCK=true "
-    } else {
-        command += "SCL_BUILD_MOCK=false "
-    }
-    command += "make package-build-artifacts"
-    sh(command)
 }
 
-def retrieve_build_artifacts() {
-    branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
-    withEnv(["SCL_BRANCH=${branch}",
+def retrieveBuildArtifacts() {
+    def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
+    withEnv(["SCL_BUILD_BRANCH=${branch}",
              "SCL_BUILD_NUMBER=${env.BUILD_NUMBER}"]) {
         sh("make retrieve-all-build-artifacts")
     }
 }
 
-def package_deploy_artifacts(is_version_change_commit) {
-    if (is_version_change_commit) {
+def packageDeployArtifacts(isVersionChangeCommit) {
+    if (isVersionChangeCommit) {
         sh("make package-versioned-deploy-artifacts")
     } else {
         sh("make package-commit_hash-deploy-artifacts")
     }
 }
 
-def strip_build_artifacts() {
+def stripBuildArtifacts() {
     sh("make strip-artifacts")
 }
 
-def upload_build_artifacts() {
-    withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
-        def artifacts = sh(returnStdout: true, script: 'ls -1 artifacts').trim().split("\\r?\\n")
+def uploadBuildArtifacts() {
+    withAWS(credentials: "aws_jenkins_user_credentials", region: "eu-west-2") {
+        def artifacts = sh(returnStdout: true, script: "ls -1 artifacts").trim().split("\\r?\\n")
         for (artifact in artifacts) {
             s3Upload(
                 bucket: "${params.ARTIFACTS_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/artifacts",
-                acl: 'PublicRead')
+                acl: "PublicRead")
         }
     }
 }
 
-def get_version() {
-    // For now we're just taking the version from either safe auth or safe app.
+def getVersion() {
+    // For now we"re just taking the version from either safe auth or safe app.
     // We may change this eventually to deploy each component separately, or possibly
     // even refactor into separate repos.
     return sh(
@@ -212,8 +205,8 @@ def get_version() {
         script: "grep '^version' < safe_app/Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
 }
 
-def upload_deploy_artifacts(type) {
-    withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
+def uploadDeployArtifacts(type) {
+    withAWS(credentials: "aws_jenkins_user_credentials", region: "eu-west-2") {
         def artifacts = sh(
             returnStdout: true, script: "ls -1 deploy/${type}").trim().split("\\r?\\n")
         for (artifact in artifacts) {
@@ -221,12 +214,12 @@ def upload_deploy_artifacts(type) {
                 bucket: "${params.DEPLOY_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/deploy/${type}",
-                acl: 'PublicRead')
+                acl: "PublicRead")
         }
     }
 }
 
-def create_tag(version) {
+def createTag(version) {
     withCredentials(
         [usernamePassword(
             credentialsId: "github_maidsafe_qa_user_credentials",
@@ -241,7 +234,7 @@ def create_tag(version) {
     }
 }
 
-def create_github_release(version) {
+def createGitHubRelease(version) {
     withCredentials(
         [usernamePassword(
             credentialsId: "github_maidsafe_token_credentials",
@@ -251,68 +244,66 @@ def create_github_release(version) {
     }
 }
 
-def publish_crate(name) {
-    withCredentials([string(
-        credentialsId: 'crates_io_token', variable: 'CRATES_IO_TOKEN')]) {
+def publishCrate(name) {
+    withCredentials(
+        [string(
+            credentialsId: "crates_io_token", variable: "CRATES_IO_TOKEN")]) {
         sh("make publish-${name}")
     }
 }
 
-def upload_binary_compatibility_test() {
+def uploadBinaryCompatibilityTests() {
     sh("mkdir -p ${env.WORKSPACE}/bct/${env.BUILD_NUMBER}")
-    def test_executable = sh(
+    def testExecutable = sh(
         returnStdout: true,
         script: $/eval "find target/release -maxdepth 1 -mindepth 1 -name 'tests-*' ! -name '*.d'" /$).trim()
-    sh("cp ${test_executable} ${env.WORKSPACE}/bct/${env.BUILD_NUMBER}/tests")
+    sh("cp ${testExecutable} ${env.WORKSPACE}/bct/${env.BUILD_NUMBER}/tests")
     sh("rm -rf target/release")
-    withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
+    withAWS(credentials: "aws_jenkins_user_credentials", region: "eu-west-2") {
         s3Upload(
             bucket: "${params.ARTIFACTS_BUCKET}",
             file: "bct/${env.BUILD_NUMBER}/tests",
             path: "bct/${env.BUILD_NUMBER}/tests",
             workingDir: "${env.WORKSPACE}",
-            acl: 'PublicRead')
+            acl: "PublicRead")
     }
 }
 
-def retrieve_build_artifacts(mode, os) {
-    command = "SCL_BUILD_NUMBER=${env.BUILD_NUMBER} "
-    command += "SCL_BUILD_OS=${os} "
-    if (mode == 'mock') {
-        command += "SCL_BUILD_MOCK=true "
-    } else {
-        command += "SCL_BUILD_MOCK=false "
+def retrieveBuildArtifacts(mode, os) {
+    def isMock = mode == "mock" ? "true" : "false"
+    withEnv(["SCL_BUILD_NUMBER=${env.BUILD_NUMBER}",
+             "SCL_BUILD_OS=${os}",
+             "SCL_BUILD_MOCK=${isMock}"]) {
+        sh("make retrieve-build-artifacts")
     }
-    command += "make retrieve-build-artifacts"
-    sh(command)
 }
 
 
-def run_binary_compatibility_tests() {
-    build_number = get_last_successful_build_number(currentBuild)
-    if (build_number != -1) {
-        echo("Running binary compatibility tests: build ${build_number} being used as previous set")
-        bct_test_path = "${env.WORKSPACE}/bct-${build_number}"
-        withAWS(credentials: 'aws_jenkins_user_credentials', region: 'eu-west-2') {
+def runBinaryCompatibilityTests() {
+    def buildNumber = getLastSuccessfulBuildNumber(currentBuild)
+    if (buildNumber != -1) {
+        echo("Running binary compatibility tests: build ${buildNumber} being used as previous set")
+        def bctTestPath = "${env.WORKSPACE}/bct-${buildNumber}"
+        withAWS(credentials: "aws_jenkins_user_credentials", region: "eu-west-2") {
             s3Download(
-                file: "${bct_test_path}",
+                file: "${bctTestPath}",
                 bucket: "${params.ARTIFACTS_BUCKET}",
-                path: "bct/${build_number}/tests",
+                path: "bct/${buildNumber}/tests",
                 force: true)
         }
-        run_tests('binary', bct_test_path)
+        runTests("binary", bctTestPath)
     } else {
         echo("Not running binary compatibility tests:  no previously successful builds found")
     }
 }
 
-def run_tests(mode, bct_test_path='') {
-    if (mode == 'mock') {
+def runTests(mode, bctTestPath="") {
+    if (mode == "mock") {
         sh("make tests")
-    } else if (mode == 'mock-file') {
+    } else if (mode == "mock-file") {
         sh("make test-with-mock-vault-file")
-    } else if (mode == 'binary') {
-        withEnv(["SCL_BCT_PATH=${bct_test_path}"]) {
+    } else if (mode == "binary") {
+        withEnv(["SCL_BCT_PATH=${bctTestPath}"]) {
             sh("make test-artifacts-binary")
         }
     } else {
@@ -320,12 +311,12 @@ def run_tests(mode, bct_test_path='') {
     }
 }
 
-def get_last_successful_build_number(build) {
+def getLastSuccessfulBuildNumber(build) {
     if (build == null) {
         return -1
     }
-    if (build.result == 'SUCCESS') {
+    if (build.result == "SUCCESS") {
         return build.number as Integer
     }
-    return get_last_successful_build_number(build.getPreviousBuild())
+    return getLastSuccessfulBuildNumber(build.getPreviousBuild())
 }


### PR DESCRIPTION
The standard libraries for Groovy use the Java camelCase style rather than the Python style, so I want these to be consistent with one another and I've started using the Java style for all the other repos. There are also some other minor things like consistently using the same type of quotes for string literals, rather than having an arbitrary mix of single and double.

I wanted to do this in a separate commit and PR so that the diffs on the next PR don't contain this stuff.

