### PR TITLE
Mobile Build and Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,28 +10,8 @@ USER_ID := $(shell id -u)
 GROUP_ID := $(shell id -g)
 UNAME_S := $(shell uname -s)
 S3_BUCKET := safe-jenkins-build-artifacts
-S3_SAFE_APP_LINUX_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_app-mock-${SAFE_APP_VERSION}-linux-x64.tar.gz
-S3_SAFE_APP_WIN_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_app-mock-${SAFE_APP_VERSION}-win-x64.tar.gz
-S3_SAFE_APP_MACOS_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_app-mock-${SAFE_APP_VERSION}-osx-x64.tar.gz
-S3_SAFE_AUTH_LINUX_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_authenticator-mock-${SAFE_AUTH_VERSION}-linux-x64.tar.gz
-S3_SAFE_AUTH_WIN_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_authenticator-mock-${SAFE_AUTH_VERSION}-win-x64.tar.gz
-S3_SAFE_AUTH_MACOS_DEPLOY_URL := https://safe-client-libs.s3.amazonaws.com/safe_authenticator-mock-${SAFE_AUTH_VERSION}-osx-x64.tar.gz
 GITHUB_REPO_OWNER := maidsafe
 GITHUB_REPO_NAME := safe_client_libs
-define GITHUB_RELEASE_DESCRIPTION
-SAFE Network client side Rust module(s)
-
-There are also development versions of this release:
-[Safe App Linux](${S3_SAFE_APP_LINUX_DEPLOY_URL})
-[Safe App macOS](${S3_SAFE_APP_MACOS_DEPLOY_URL})
-[Safe App Windows](${S3_SAFE_APP_WIN_DEPLOY_URL})
-[Safe Auth Linux](${S3_SAFE_AUTH_LINUX_DEPLOY_URL})
-[Safe Auth macOS](${S3_SAFE_AUTH_MACOS_DEPLOY_URL})
-[Safe Auth Windows](${S3_SAFE_AUTH_WIN_DEPLOY_URL})
-
-The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
-endef
-export GITHUB_RELEASE_DESCRIPTION
 
 build-container:
 	rm -rf target/
@@ -345,12 +325,12 @@ endif
 	( \
 		cd artifacts; \
 		tar -C real/universal -zcvf \
-			${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-ios-universal.tar.gz .; \
+			${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-apple-ios.tar.gz .; \
 	)
 	( \
 		cd artifacts; \
 		tar -C mock/universal -zcvf \
-			${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-ios-universal.tar.gz .; \
+			${SCL_BUILD_BRANCH}-${SCL_BUILD_NUMBER}-scl-mock-apple-ios.tar.gz .; \
 	)
 	rm -rf artifacts/real
 	rm -rf artifacts/mock
@@ -369,7 +349,7 @@ endif
 	./scripts/retrieve-build-artifacts \
 		"x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
 		"armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
-		"aarch64-apple-ios" "ios-universal"
+		"aarch64-apple-ios" "apple-ios"
 
 retrieve-ios-build-artifacts:
 ifndef SCL_BUILD_BRANCH
@@ -454,43 +434,80 @@ endif
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_APP_VERSION} \
 		--name "safe_client_libs" \
-		--description "$$GITHUB_RELEASE_DESCRIPTION"
+		--description "$$(./scripts/get-release-description ${SAFE_APP_VERSION})"
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_APP_VERSION} \
-		--name "safe_app-${SAFE_APP_VERSION}-linux-x64.tar.gz" \
-		--file deploy/real/safe_app-${SAFE_APP_VERSION}-linux-x64.tar.gz
+		--name "safe_app-${SAFE_APP_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-x86_64-unknown-linux-gnu.tar.gz
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_APP_VERSION} \
-		--name "safe_app-${SAFE_APP_VERSION}-osx-x64.tar.gz" \
-		--file deploy/real/safe_app-${SAFE_APP_VERSION}-osx-x64.tar.gz
+		--name "safe_app-${SAFE_APP_VERSION}-x86_64-apple-darwin.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-x86_64-apple-darwin.tar.gz
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_APP_VERSION} \
-		--name "safe_app-${SAFE_APP_VERSION}-win-x64.tar.gz" \
-		--file deploy/real/safe_app-${SAFE_APP_VERSION}-win-x64.tar.gz
+		--name "safe_app-${SAFE_APP_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-x86_64-pc-windows-gnu.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_APP_VERSION} \
+		--name "safe_app-${SAFE_APP_VERSION}-apple-ios.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-apple-ios.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_APP_VERSION} \
+		--name "safe_app-${SAFE_APP_VERSION}-armv7-linux-androideabi.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-armv7-linux-androideabi.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_APP_VERSION} \
+		--name "safe_app-${SAFE_APP_VERSION}-x86_64-linux-android.tar.gz" \
+		--file deploy/real/safe_app-${SAFE_APP_VERSION}-x86_64-linux-android.tar.gz
+
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_VERSION} \
-		--name "safe_authenticator-${SAFE_AUTH_VERSION}-linux-x64.tar.gz" \
-		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-linux-x64.tar.gz
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-unknown-linux-gnu.tar.gz
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_VERSION} \
-		--name "safe_authenticator-${SAFE_AUTH_VERSION}-osx-x64.tar.gz" \
-		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-osx-x64.tar.gz
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-apple-darwin.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-apple-darwin.tar.gz
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_AUTH_VERSION} \
-		--name "safe_authenticator-${SAFE_AUTH_VERSION}-win-x64.tar.gz" \
-		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-win-x64.tar.gz
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-pc-windows-gnu.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_VERSION} \
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-apple-ios.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-apple-ios.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_VERSION} \
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-armv7-linux-androideabi.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-armv7-linux-androideabi.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_AUTH_VERSION} \
+		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz" \
+		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz
 
 publish-safe_core:
 ifndef CRATES_IO_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -35,23 +35,67 @@ export GITHUB_RELEASE_DESCRIPTION
 
 build-container:
 	rm -rf target/
-	docker rmi -f maidsafe/safe-client-libs-build:build
+	docker rmi -f maidsafe/safe-client-libs-build:x86_64
 	docker build -f scripts/Dockerfile.build \
-		-t maidsafe/safe-client-libs-build:build \
+		-t maidsafe/safe-client-libs-build:x86_64 \
 		--build-arg build_type="real" .
 
 build-mock-container:
 	rm -rf target/
-	docker rmi -f maidsafe/safe-client-libs-build:build-mock
+	docker rmi -f maidsafe/safe-client-libs-build:x86_64-mock
 	docker build -f scripts/Dockerfile.build \
-		-t maidsafe/safe-client-libs-build:build-mock \
+		-t maidsafe/safe-client-libs-build:x86_64-mock \
 		--build-arg build_type="mock" .
 
+build-android-armv7-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-client-libs-build:android-armv7
+	docker build -f scripts/Dockerfile.android.armv7.build \
+		-t maidsafe/safe-client-libs-build:android-armv7 \
+		--build-arg build_type="real" \
+		--build-arg target="armv7-linux-androideabi" .
+
+build-android-armv7-mock-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-client-libs-build:android-armv7-mock
+	docker build -f scripts/Dockerfile.android.armv7.build \
+		-t maidsafe/safe-client-libs-build:android-armv7-mock \
+		--build-arg build_type="mock" \
+		--build-arg target="armv7-linux-androideabi" .
+
+build-android-x86_64-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-client-libs-build:android-x86_64
+	docker build -f scripts/Dockerfile.android.x86_64.build \
+		-t maidsafe/safe-client-libs-build:android-x86_64 \
+		--build-arg build_type="real" \
+		--build-arg target="x86_64-linux-android" .
+
+build-android-x86_64-mock-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-client-libs-build:android-x86_64-mock
+	docker build -f scripts/Dockerfile.android.x86_64.build \
+		-t maidsafe/safe-client-libs-build:android-x86_64-mock \
+		--build-arg build_type="mock" \
+		--build-arg target="x86_64-linux-android" .
+
 push-container:
-	docker push maidsafe/safe-client-libs-build:build
+	docker push maidsafe/safe-client-libs-build:x86_64
 
 push-mock-container:
-	docker push maidsafe/safe-client-libs-build:build-mock
+	docker push maidsafe/safe-client-libs-build:x86_64-mock
+
+push-android-armv7-container:
+	docker push maidsafe/safe-client-libs-build:android-armv7
+
+push-android-armv7-mock-container:
+	docker push maidsafe/safe-client-libs-build:android-armv7-mock
+
+push-android-x86_64-container:
+	docker push maidsafe/safe-client-libs-build:android-x86_64
+
+push-android-x86_64-mock-container:
+	docker push maidsafe/safe-client-libs-build:android-x86_64-mock
 
 build:
 	rm -rf artifacts
@@ -130,7 +174,7 @@ ifeq ($(UNAME_S),Linux)
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		scripts/clippy-all
 else
 	./scripts/clippy-all
@@ -141,7 +185,7 @@ ifeq ($(UNAME_S),Linux)
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		scripts/rustfmt
 else
 	./scripts/rustfmt
@@ -194,14 +238,14 @@ package-versioned-deploy-artifacts:
 	@rm -rf deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:build \
+		maidsafe/safe-client-libs-build:x86_64 \
 		scripts/package-runner-container "true"
 
 package-commit_hash-deploy-artifacts:
 	@rm -rf deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:build \
+		maidsafe/safe-client-libs-build:x86_64 \
 		scripts/package-runner-container "false"
 
 retrieve-cache:
@@ -327,7 +371,7 @@ endif
 		-e CARGO_TARGET_DIR=/target \
 		-e COMPAT_TESTS=/bct/tests \
 		-e SCL_TEST_SUITE=binary \
-		maidsafe/safe-client-libs-build:build \
+		maidsafe/safe-client-libs-build:x86_64 \
 		scripts/test-runner-container
 
 tests:
@@ -338,7 +382,7 @@ ifeq ($(UNAME_S),Linux)
 		-v "${PWD}":/usr/src/safe_client_libs \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		scripts/build-and-test-mock
 	docker cp "safe_app_tests-${UUID}":/target .
 	docker rm -f "safe_app_tests-${UUID}"
@@ -362,11 +406,11 @@ tests-integration:
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs \
 		-u ${USER_ID}:${GROUP_ID} \
 		-e CARGO_TARGET_DIR=/target \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		scripts/test-integration
 
 debug:
-	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:build /bin/bash
+	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/safe-client-libs-build:x86_64 /bin/bash
 
 copy-artifacts:
 	rm -rf artifacts
@@ -429,7 +473,7 @@ endif
 	rm -rf artifacts deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		/bin/bash -c "cd safe_core && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
 
 publish-safe_auth:
@@ -439,7 +483,7 @@ ifndef CRATES_IO_TOKEN
 endif
 	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		/bin/bash -c "cd safe_authenticator && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
 
 publish-safe_app:
@@ -449,5 +493,5 @@ ifndef CRATES_IO_TOKEN
 endif
 	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:build-mock \
+		maidsafe/safe-client-libs-build:x86_64-mock \
 		/bin/bash -c "cd safe_app && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ push-android-x86_64-mock-container:
 build:
 	rm -rf artifacts
 ifeq ($(UNAME_S),Linux)
-	./scripts/build-with-container "real"
+	./scripts/build-with-container "real" "x86_64"
 else
 	./scripts/build-real
 endif
@@ -110,7 +110,7 @@ endif
 build-mock:
 	rm -rf artifacts
 ifeq ($(UNAME_S),Linux)
-	./scripts/build-with-container "mock"
+	./scripts/build-with-container "mock" "x86_64-mock"
 else
 	./scripts/build-mock
 endif
@@ -168,6 +168,46 @@ build-ios-mock-x86_64:
 	rm -rf artifacts
 	mkdir artifacts
 	find target/x86_64-apple-ios/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+
+build-android-armv7:
+ifeq ($(UNAME_S),Linux)
+	rm -rf artifacts
+	./scripts/build-with-container "real" "android-armv7"
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+else
+	echo "Only Linux is supported for this target."
+endif
+
+build-android-mock-armv7:
+ifeq ($(UNAME_S),Linux)
+	rm -rf artifacts
+	./scripts/build-with-container "mock" "android-armv7-mock"
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+else
+	echo "Only Linux is supported for this target."
+endif
+
+build-android-x86_64:
+ifeq ($(UNAME_S),Linux)
+	rm -rf artifacts
+	./scripts/build-with-container "real" "android-x86_64"
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+else
+	echo "Only Linux is supported for this target."
+endif
+
+build-android-mock-x86_64:
+ifeq ($(UNAME_S),Linux)
+	rm -rf artifacts
+	./scripts/build-with-container "mock" "android-x86_64-mock"
+	mkdir artifacts
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+else
+	echo "Only Linux is supported for this target."
+endif
 
 clippy:
 ifeq ($(UNAME_S),Linux)

--- a/scripts/Dockerfile.android.armv7.build
+++ b/scripts/Dockerfile.android.armv7.build
@@ -1,0 +1,50 @@
+FROM rust:latest
+
+# These is only referenced in the build-android-cache script.
+ARG build_type
+ARG target
+
+RUN addgroup --gid 1001 maidsafe && \
+    adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+    # The parent container sets this to the 'staff' group, which causes problems
+    # with reading code stored in Cargo's registry.
+    chgrp -R maidsafe /usr/local
+
+# Install fixuid for dealing with permissions issues with mounted volumes.
+# We could perhaps put this into a base container at a later stage.
+RUN USER=maidsafe && \
+    GROUP=maidsafe && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+RUN apt-get update -y && \
+    apt-get install -y unzip && \
+    mkdir /target && \
+    chown maidsafe:maidsafe /target && \
+    mkdir /usr/src/safe_client_libs && \
+    chown maidsafe:maidsafe /usr/src/safe_client_libs && \
+    curl -L -O https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip && \
+    unzip android-ndk-r20-linux-x86_64.zip -d /usr/local/lib && \
+    mkdir /usr/local/bin/android-toolchains && \
+    /usr/local/lib/android-ndk-r20/build/tools/make_standalone_toolchain.py \
+        --arch arm \
+        --api 21 \
+        --install-dir /usr/local/bin/android-toolchains \
+        --force && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/safe_client_libs
+COPY . .
+
+USER maidsafe:maidsafe
+ENV CARGO_TARGET_DIR=/target \
+    CC_armv7_linux_androideabi=arm-linux-androideabi-clang \
+    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-clang \
+    PATH=$PATH:/usr/local/bin/android-toolchains/bin
+RUN rustup target add armv7-linux-androideabi && \
+    ./scripts/build-android-cache
+ENTRYPOINT ["fixuid"]

--- a/scripts/Dockerfile.android.x86_64.build
+++ b/scripts/Dockerfile.android.x86_64.build
@@ -1,0 +1,51 @@
+FROM rust:latest
+
+# These is only referenced in the build-android-cache script.
+ARG build_type
+ARG target
+
+RUN addgroup --gid 1001 maidsafe && \
+    adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+    # The parent container sets this to the 'staff' group, which causes problems
+    # with reading code stored in Cargo's registry.
+    chgrp -R maidsafe /usr/local
+
+# Install fixuid for dealing with permissions issues with mounted volumes.
+# We could perhaps put this into a base container at a later stage.
+RUN USER=maidsafe && \
+    GROUP=maidsafe && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+RUN apt-get update -y && \
+    apt-get install -y gcc gcc-multilib libssl-dev unzip && \
+    mkdir /target && \
+    chown maidsafe:maidsafe /target && \
+    mkdir /usr/src/safe_client_libs && \
+    chown maidsafe:maidsafe /usr/src/safe_client_libs && \
+    curl -L -O https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip && \
+    unzip android-ndk-r20-linux-x86_64.zip -d /usr/local/lib && \
+    mkdir /usr/local/bin/android-toolchains && \
+    /usr/local/lib/android-ndk-r20/build/tools/make_standalone_toolchain.py \
+        --arch x86_64 \
+        --api 21 \
+        --install-dir /usr/local/bin/android-toolchains \
+        --force && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/safe_client_libs
+COPY . .
+
+USER maidsafe:maidsafe
+ENV CARGO_TARGET_DIR=/target \
+    OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu \
+    OPENSSL_INCLUDE_DIR=/usr/include/openssl \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
+    PATH=$PATH:/usr/local/bin/android-toolchains/bin
+RUN rustup target add x86_64-linux-android && \
+    ./scripts/build-android-cache
+ENTRYPOINT ["fixuid"]

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -51,6 +51,22 @@ stage("build & test") {
             uploadBuildArtifacts()
         }
     },
+    mock_android_armv7: {
+        node("safe_client_libs") {
+            checkout(scm)
+            sh("make build-android-mock-armv7")
+            packageBuildArtifacts("mock", "android", "armv7")
+            uploadBuildArtifacts()
+        }
+    },
+    mock_android_x86_64: {
+        node("safe_client_libs") {
+            checkout(scm)
+            sh("make build-android-mock-x86_64")
+            packageBuildArtifacts("mock", "android", "x86_64")
+            uploadBuildArtifacts()
+        }
+    },
     real_linux: {
         node("safe_client_libs") {
             checkout(scm)
@@ -91,6 +107,22 @@ stage("build & test") {
             checkout(scm)
             sh("make build-ios-x86_64")
             packageBuildArtifacts("real", "ios", "x86_64")
+            uploadBuildArtifacts()
+        }
+    },
+    real_android_armv7: {
+        node("safe_client_libs") {
+            checkout(scm)
+            sh("make build-android-armv7")
+            packageBuildArtifacts("real", "android", "armv7")
+            uploadBuildArtifacts()
+        }
+    },
+    real_android_x86_64: {
+        node("safe_client_libs") {
+            checkout(scm)
+            sh("make build-android-x86_64")
+            packageBuildArtifacts("real", "android", "x86_64")
             uploadBuildArtifacts()
         }
     },

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -141,6 +141,19 @@ stage("build & test") {
     }
 }
 
+stage("build universal iOS lib") {
+    node("osx") {
+        checkout(scm)
+        def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
+        withEnv(["SCL_BUILD_BRANCH=${branch}",
+                 "SCL_BUILD_NUMBER=${env.BUILD_NUMBER}"]) {
+            sh("make universal-ios-lib")
+            sh("make package-universal-ios-lib")
+            uploadBuildArtifacts()
+        }
+    }
+}
+
 stage("deployment") {
     parallel deploy_artifacts: {
         node("safe_client_libs") {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -12,7 +12,7 @@ stage("build & test") {
             checkout(scm)
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "linux", "x86_64")
+            packageBuildArtifacts("mock", "x86_64-unknown-linux-gnu")
             uploadBuildArtifacts()
         }
     },
@@ -22,7 +22,7 @@ stage("build & test") {
             retrieveCache()
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "windows", "x86_64")
+            packageBuildArtifacts("mock", "x86_64-pc-windows-gnu")
             uploadBuildArtifacts()
         }
     },
@@ -31,7 +31,7 @@ stage("build & test") {
             checkout(scm)
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "osx", "x86_64")
+            packageBuildArtifacts("mock", "x86_64-apple-darwin")
             uploadBuildArtifacts()
         }
     },
@@ -39,7 +39,7 @@ stage("build & test") {
         node("osx") {
             checkout(scm)
             sh("make build-ios-mock-aarch64")
-            packageBuildArtifacts("mock", "ios", "aarch64")
+            packageBuildArtifacts("mock", "aarch64-apple-ios")
             uploadBuildArtifacts()
         }
     },
@@ -47,7 +47,7 @@ stage("build & test") {
         node("osx") {
             checkout(scm)
             sh("make build-ios-mock-x86_64")
-            packageBuildArtifacts("mock", "ios", "x86_64")
+            packageBuildArtifacts("mock", "x86_64-apple-ios")
             uploadBuildArtifacts()
         }
     },
@@ -55,7 +55,7 @@ stage("build & test") {
         node("safe_client_libs") {
             checkout(scm)
             sh("make build-android-mock-armv7")
-            packageBuildArtifacts("mock", "android", "armv7")
+            packageBuildArtifacts("mock", "armv7-linux-androideabi")
             uploadBuildArtifacts()
         }
     },
@@ -63,7 +63,7 @@ stage("build & test") {
         node("safe_client_libs") {
             checkout(scm)
             sh("make build-android-mock-x86_64")
-            packageBuildArtifacts("mock", "android", "x86_64")
+            packageBuildArtifacts("mock", "x86_64-linux-android")
             uploadBuildArtifacts()
         }
     },
@@ -72,7 +72,7 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "linux", "x86_64")
+            packageBuildArtifacts("real", "x86_64-unknown-linux-gnu")
             uploadBuildArtifacts()
         }
     },
@@ -81,7 +81,7 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "windows", "x86_64")
+            packageBuildArtifacts("real", "x86_64-pc-windows-gnu")
             uploadBuildArtifacts()
         }
     },
@@ -90,7 +90,7 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "osx", "x86_64")
+            packageBuildArtifacts("real", "x86_64-apple-darwin")
             uploadBuildArtifacts()
         }
     },
@@ -98,7 +98,7 @@ stage("build & test") {
         node("osx") {
             checkout(scm)
             sh("make build-ios-aarch64")
-            packageBuildArtifacts("real", "ios", "aarch64")
+            packageBuildArtifacts("real", "aarch64-apple-ios")
             uploadBuildArtifacts()
         }
     },
@@ -106,7 +106,7 @@ stage("build & test") {
         node("osx") {
             checkout(scm)
             sh("make build-ios-x86_64")
-            packageBuildArtifacts("real", "ios", "x86_64")
+            packageBuildArtifacts("real", "x86_64-apple-ios")
             uploadBuildArtifacts()
         }
     },
@@ -114,7 +114,7 @@ stage("build & test") {
         node("safe_client_libs") {
             checkout(scm)
             sh("make build-android-armv7")
-            packageBuildArtifacts("real", "android", "armv7")
+            packageBuildArtifacts("real", "armv7-linux-androideabi")
             uploadBuildArtifacts()
         }
     },
@@ -122,7 +122,7 @@ stage("build & test") {
         node("safe_client_libs") {
             checkout(scm)
             sh("make build-android-x86_64")
-            packageBuildArtifacts("real", "android", "x86_64")
+            packageBuildArtifacts("real", "x86_64-linux-android")
             uploadBuildArtifacts()
         }
     },
@@ -229,13 +229,12 @@ def isVersionChangeCommit() {
     return message.startsWith("Version change")
 }
 
-def packageBuildArtifacts(mode, os, arch) {
+def packageBuildArtifacts(mode, target) {
     def isMock = mode == "mock" ? "true" : "false"
     def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
     withEnv(["SCL_BUILD_NUMBER=${env.BUILD_NUMBER}",
              "SCL_BUILD_BRANCH=${branch}",
-             "SCL_BUILD_OS=${os}",
-             "SCL_BUILD_ARCH=${arch}",
+             "SCL_BUILD_TARGET=${target}",
              "SCL_BUILD_MOCK=${isMock}"]) {
         sh("make package-build-artifacts")
     }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -12,7 +12,7 @@ stage("build & test") {
             checkout(scm)
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "linux")
+            packageBuildArtifacts("mock", "linux", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -22,7 +22,7 @@ stage("build & test") {
             retrieveCache()
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "windows")
+            packageBuildArtifacts("mock", "windows", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -31,7 +31,23 @@ stage("build & test") {
             checkout(scm)
             runTests("mock")
             stripBuildArtifacts()
-            packageBuildArtifacts("mock", "osx")
+            packageBuildArtifacts("mock", "osx", "x86_64")
+            uploadBuildArtifacts()
+        }
+    },
+    mock_ios_aarch64: {
+        node("osx") {
+            checkout(scm)
+            sh("make build-ios-mock-aarch64")
+            packageBuildArtifacts("mock", "ios", "aarch64")
+            uploadBuildArtifacts()
+        }
+    },
+    mock_ios_x86_64: {
+        node("osx") {
+            checkout(scm)
+            sh("make build-ios-mock-x86_64")
+            packageBuildArtifacts("mock", "ios", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -40,7 +56,7 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "linux")
+            packageBuildArtifacts("real", "linux", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -49,7 +65,7 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "windows")
+            packageBuildArtifacts("real", "windows", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -58,7 +74,23 @@ stage("build & test") {
             checkout(scm)
             sh("make build")
             stripBuildArtifacts()
-            packageBuildArtifacts("real", "osx")
+            packageBuildArtifacts("real", "osx", "x86_64")
+            uploadBuildArtifacts()
+        }
+    },
+    real_ios_aarch64: {
+        node("osx") {
+            checkout(scm)
+            sh("make build-ios-aarch64")
+            packageBuildArtifacts("real", "ios", "aarch64")
+            uploadBuildArtifacts()
+        }
+    },
+    real_ios_x86_64: {
+        node("osx") {
+            checkout(scm)
+            sh("make build-ios-x86_64")
+            packageBuildArtifacts("real", "ios", "x86_64")
             uploadBuildArtifacts()
         }
     },
@@ -148,16 +180,17 @@ def isVersionChangeCommit() {
         script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
     def message = sh(
         returnStdout: true,
-        script: "git log --format=%B -n 1 ${short_commit_hash}").trim()
+        script: "git log --format=%B -n 1 ${shortCommitHash}").trim()
     return message.startsWith("Version change")
 }
 
-def packageBuildArtifacts(mode, os) {
+def packageBuildArtifacts(mode, os, arch) {
     def isMock = mode == "mock" ? "true" : "false"
     def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
     withEnv(["SCL_BUILD_NUMBER=${env.BUILD_NUMBER}",
              "SCL_BUILD_BRANCH=${branch}",
              "SCL_BUILD_OS=${os}",
+             "SCL_BUILD_ARCH=${arch}",
              "SCL_BUILD_MOCK=${isMock}"]) {
         sh("make package-build-artifacts")
     }
@@ -268,16 +301,6 @@ def uploadBinaryCompatibilityTests() {
             acl: "PublicRead")
     }
 }
-
-def retrieveBuildArtifacts(mode, os) {
-    def isMock = mode == "mock" ? "true" : "false"
-    withEnv(["SCL_BUILD_NUMBER=${env.BUILD_NUMBER}",
-             "SCL_BUILD_OS=${os}",
-             "SCL_BUILD_MOCK=${isMock}"]) {
-        sh("make retrieve-build-artifacts")
-    }
-}
-
 
 def runBinaryCompatibilityTests() {
     def buildNumber = getLastSuccessfulBuildNumber(currentBuild)

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -2,6 +2,8 @@ properties([
     parameters([
         string(name: "ARTIFACTS_BUCKET", defaultValue: "safe-jenkins-build-artifacts"),
         string(name: "CACHE_BRANCH", defaultValue: "master"),
+        string(name: "DEPLOY_BRANCH", defaultValue: "master"),
+        string(name: "PUBLISH_BRANCH", defaultValue: "master"),
         string(name: "DEPLOY_BUCKET", defaultValue: "safe-client-libs")
     ])
 ])
@@ -157,7 +159,7 @@ stage("build universal iOS lib") {
 stage("deployment") {
     parallel deploy_artifacts: {
         node("safe_client_libs") {
-            if (env.BRANCH_NAME == "master") {
+            if (env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
                 checkout(scm)
                 sh("git fetch --tags --force")
                 retrieveBuildArtifacts()
@@ -179,35 +181,35 @@ stage("deployment") {
     },
     publish_safe_core_crate: {
         node("safe_client_libs") {
-            if (env.BRANCH_NAME == "master") {
+            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
                 checkout(scm)
                 publishCrate("safe_core")
             } else {
-                echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
+                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
             }
         }
     },
     publish_safe_app_crate: {
         node("safe_client_libs") {
-            if (env.BRANCH_NAME == "master") {
+            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
                 checkout(scm)
                 publishCrate("safe_app")
             } else {
-                echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
+                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
             }
         }
     },
     publish_safe_auth_crate: {
         node("safe_client_libs") {
-            if (env.BRANCH_NAME == "master") {
+            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
                 checkout(scm)
                 publishCrate("safe_auth")
             } else {
-                echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
+                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
             }
         }
     }
-    if (env.BRANCH_NAME == "master") {
+    if (env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
         build(job: "../rust_cache_build-safe_client_libs-windows", wait: false)
         build(job: "../docker_build-safe_client_libs_build_container", wait: false)
     }

--- a/scripts/build-android-cache
+++ b/scripts/build-android-cache
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [[ -z "$build_type" ]]; then
+    echo "build_type must be set to dev or non-dev"
+    exit 1
+fi
+
+if [[ -z "$target" ]]; then
+    echo "target must be set to x86_64-linux-android or armv7-linux-androideabi"
+    exit 1
+fi
+
+if [[ "$build_type" == "mock" ]]; then
+    cargo build --features=mock-network \
+        --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$target"
+    cargo build --features=mock-network \
+        --release --lib --manifest-path=safe_app/Cargo.toml --target="$target"
+else
+    cargo build --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$target"
+    cargo build --release --lib --manifest-path=safe_app/Cargo.toml --target="$target"
+fi

--- a/scripts/build-with-container
+++ b/scripts/build-with-container
@@ -16,23 +16,26 @@ set -e -x
 
 build_mode=$1
 if [[ -z "$build_mode" ]]; then
-    echo "This script must be invoked with a build mode argument."
+    echo "This script must be invoked with a build_mode argument."
     echo "Valid values are 'mock' and 'real'."
     exit 1
 fi
 
-container_tag="x86_64"
-[[ "$build_mode" == "mock" ]] && container_tag="x86_64-mock"
+container_tag=$2
+if [[ -z "$container_tag" ]]; then
+    echo "This script must be invoked with a container_tag argument."
+    exit 1
+fi
 
 user_id=$(id -u)
 group_id=$(id -g)
 
 if [[ -z "$BUILD_NUMBER" ]]; then
     uid=$(uuidgen | sed 's/-//g')
-    container_name="safe_app_build_$build_mode$uid"
+    container_name="safe_app_build_$container_tag$build_mode$uid"
 else
     # BUILD_NUMBER will be defined in the context of a Jenkins build.
-    container_name="safe_app_build_$build_mode$BUILD_NUMBER"
+    container_name="safe_app_build_$container_tag$build_mode$BUILD_NUMBER"
 fi
 
 rm -rf target

--- a/scripts/build-with-container
+++ b/scripts/build-with-container
@@ -21,8 +21,8 @@ if [[ -z "$build_mode" ]]; then
     exit 1
 fi
 
-container_tag="build"
-[[ "$build_mode" == "mock" ]] && container_tag="build-mock"
+container_tag="x86_64"
+[[ "$build_mode" == "mock" ]] && container_tag="x86_64-mock"
 
 user_id=$(id -u)
 group_id=$(id -g)

--- a/scripts/get-release-description
+++ b/scripts/get-release-description
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+version=$1
+if [[ -z "$version" ]]; then
+    echo "You must supply a version number."
+    exit 1
+fi
+
+# The single quotes around EOF is to stop attempted variable and backtick expansion.
+read -r -d '' release_description << 'EOF'
+SAFE Network client side Rust module(s)
+
+## Development Builds
+
+There are also development versions of this release:
+[Safe App Linux](S3_SAFE_APP_LINUX_DEPLOY_URL)
+[Safe App macOS](S3_SAFE_APP_MACOS_DEPLOY_URL)
+[Safe App Windows](S3_SAFE_APP_WIN_DEPLOY_URL)
+[Safe App Android ARMv7](S3_SAFE_APP_ANDROID_ARMV7_DEPLOY_URL)
+[Safe App Android x86_64](S3_SAFE_APP_ANDROID_X86_64_DEPLOY_URL)
+[Safe App iOS](S3_SAFE_APP_IOS_DEPLOY_URL)
+[Safe Auth Linux](S3_SAFE_AUTH_LINUX_DEPLOY_URL)
+[Safe Auth macOS](S3_SAFE_AUTH_MACOS_DEPLOY_URL)
+[Safe Auth Windows](S3_SAFE_AUTH_WIN_DEPLOY_URL)
+[Safe Auth Android ARMv7](S3_SAFE_AUTH_ANDROID_ARMV7_DEPLOY_URL)
+[Safe Auth Android x86_64](S3_SAFE_AUTH_ANDROID_X86_64_DEPLOY_URL)
+[Safe Auth iOS](S3_SAFE_AUTH_IOS_DEPLOY_URL)
+
+The development version uses a mocked SAFE network, which allows you to work against a file that mimics the network, where SafeCoins are created for local use.
+
+## SHA-256 checksums for release versions:
+```
+Linux
+Safe App: TAR_SAFE_APP_LINUX_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_LINUX_CHECKSUM
+
+macOS
+Safe App: TAR_SAFE_APP_LINUX_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_LINUX_CHECKSUM
+
+Windows
+Safe App: TAR_SAFE_APP_WINDOWS_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_WINDOWS_CHECKSUM
+
+iOS
+Safe App: TAR_SAFE_APP_IOS_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_IOS_CHECKSUM
+
+Android ARMv7
+Safe App: TAR_SAFE_APP_ANDROID_ARMV7_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_ANDROID_ARMV7_CHECKSUM
+
+Android x86_64
+Safe App: TAR_SAFE_APP_ANDROID_X86_64_CHECKSUM
+Safe Auth: TAR_SAFE_AUTH_ANDROID_X86_64_CHECKSUM
+```
+EOF
+
+s3_safe_app_linux_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-x86_64-unknown-linux-gnu.tar.gz"
+s3_safe_app_win_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-x86_64-pc-windows-gnu.tar.gz"
+s3_safe_app_macos_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-x86_64-apple-darwin.tar.gz"
+s3_safe_app_ios_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-apple-ios.tar.gz"
+s3_safe_app_android_armv7_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-armv7-linux-androideabi.tar.gz"
+s3_safe_app_android_x86_64_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_app-mock-$version-x86_64-linux-android.tar.gz"
+
+s3_safe_auth_linux_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-x86_64-unknown-linux-gnu.tar.gz"
+s3_safe_auth_win_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-x86_64-pc-windows-gnu.tar.gz"
+s3_safe_auth_macos_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-x86_64-apple-darwin.tar.gz"
+s3_safe_auth_ios_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-apple-ios.tar.gz"
+s3_safe_auth_android_armv7_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-armv7-linux-androideabi.tar.gz"
+s3_safe_auth_android_x86_64_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-x86_64-linux-android.tar.gz"
+
+tar_safe_app_linux_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_app_macos_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_app_win_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_app_ios_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-apple-ios.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_app_android_armv7_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-armv7-linux-androideabi.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_app_android_x86_64_checksum=$(sha256sum \
+    "./deploy/real/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+
+tar_safe_auth_linux_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_auth_macos_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_auth_win_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_auth_ios_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-apple-ios.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_auth_android_armv7_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-armv7-linux-androideabi.tar.gz" | \
+    awk '{ print $1 }')
+tar_safe_auth_android_x86_64_checksum=$(sha256sum \
+    "./deploy/real/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+
+release_description=$(sed "s/S3_SAFE_APP_LINUX_DEPLOY_URL/$s3_safe_app_linux_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_APP_MACOS_DEPLOY_URL/$s3_safe_app_macos_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_APP_WIN_DEPLOY_URL/$s3_safe_app_win_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_APP_IOS_DEPLOY_URL/$s3_safe_app_ios_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_APP_ANDROID_ARMV7_DEPLOY_URL/$s3_safe_app_android_armv7_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_APP_ANDROID_X86_64_DEPLOY_URL/$s3_safe_app_android_x86_64_deploy_url/g" <<< "$release_description")
+
+release_description=$(sed "s/S3_SAFE_AUTH_LINUX_DEPLOY_URL/$s3_safe_auth_linux_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_AUTH_MACOS_DEPLOY_URL/$s3_safe_auth_macos_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_AUTH_WIN_DEPLOY_URL/$s3_safe_auth_win_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_AUTH_IOS_DEPLOY_URL/$s3_safe_auth_ios_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_AUTH_ANDROID_ARMV7_DEPLOY_URL/$s3_safe_auth_android_armv7_deploy_url/g" <<< "$release_description")
+release_description=$(sed "s/S3_SAFE_AUTH_ANDROID_X86_64_DEPLOY_URL/$s3_safe_auth_android_x86_64_deploy_url/g" <<< "$release_description")
+
+release_description=$(sed "s/TAR_SAFE_APP_LINUX_CHECKSUM/$tar_safe_app_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_APP_WINDOWS_CHECKSUM/$tar_safe_app_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_APP_MACOS_CHECKSUM/$tar_safe_app_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_APP_IOS_CHECKSUM/$tar_safe_app_ios_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_APP_ANDROID_ARMV7_CHECKSUM/$tar_safe_app_android_armv7_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_APP_ANDROID_X86_64_CHECKSUM/$tar_safe_app_android_x86_64_checksum/g" <<< "$release_description")
+
+release_description=$(sed "s/TAR_SAFE_AUTH_LINUX_CHECKSUM/$tar_safe_auth_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_AUTH_WINDOWS_CHECKSUM/$tar_safe_auth_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_AUTH_MACOS_CHECKSUM/$tar_safe_auth_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_AUTH_IOS_CHECKSUM/$tar_safe_auth_ios_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_AUTH_ANDROID_ARMV7_CHECKSUM/$tar_safe_auth_android_armv7_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_SAFE_AUTH_ANDROID_X86_64_CHECKSUM/$tar_safe_auth_android_x86_64_checksum/g" <<< "$release_description")
+echo "$release_description"

--- a/scripts/package-runner-container
+++ b/scripts/package-runner-container
@@ -3,7 +3,7 @@
 # This script is a wrapper for running the packaging in the context of a container.
 #
 # It is assuming there will be an 'artifacts' directory that contains all of the
-# pre-built versions of safe_authenticator and safe_app for Linux and OSX, and
+# pre-built versions of safe_authenticator and safe_app for Linux and targetX, and
 # hopefully Windows in the future.
 #
 # With all the artifacts available it will package everything into zip files.
@@ -18,65 +18,68 @@ fi
 
 if [[ ! -d "artifacts" ]]; then
     echo "This script is intended to be used with a docker container and a set of pre-built artifacts."
-    echo "Place these artifacts in an 'artifacts' folder at the root of the repository and perform the 'docker run' command again."
+    echo "Place these artifacts in an 'artifacts' folder at the root of the reptargetitory and perform the 'docker run' command again."
     exit 1
 fi
 
 export RUST_BACKTRACE=1
 [[ ! -d "deploy" ]] && mkdir -p deploy/real deploy/mock
 
-declare -a operating_systems=("linux" "win" "osx")
-for os in "${operating_systems[@]}"; do
+declare -a targets=(\
+    "x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
+    "armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
+    "aarch64-apple-ios" "ios-universal")
+for target in "${targets[@]}"; do
     pwd
     if [[ $is_versioned == "true" ]]; then
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/mock \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/mock" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/mock" \
             --mock
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/real \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/real"
+            --arch "$target" \
+            --artifacts "artifacts/$target/real"
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/mock \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/mock" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/mock" \
             --mock
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/real \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/real"
+            --arch "$target" \
+            --artifacts "artifacts/$target/real"
     else
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/mock \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/mock" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/mock" \
             --mock \
             --commit
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/real \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/real" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/real" \
             --commit
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/mock \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/mock" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/mock" \
             --mock \
             --commit
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/real \
-            --arch "$os-x64" \
-            --artifacts "artifacts/$os/real" \
+            --arch "$target" \
+            --artifacts "artifacts/$target/real" \
             --commit
     fi
 done

--- a/scripts/package-runner-container
+++ b/scripts/package-runner-container
@@ -28,58 +28,58 @@ export RUST_BACKTRACE=1
 declare -a targets=(\
     "x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
     "armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
-    "aarch64-apple-ios" "ios-universal")
+    "aarch64-apple-ios" "apple-ios")
 for target in "${targets[@]}"; do
     pwd
     if [[ $is_versioned == "true" ]]; then
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/mock \
-            --arch "$target" \
-            --artifacts "artifacts/$target/mock" \
+            --target "$target" \
+            --artifacts "artifacts/mock" \
             --mock
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/real \
-            --arch "$target" \
-            --artifacts "artifacts/$target/real"
+            --target "$target" \
+            --artifacts "artifacts/real"
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/mock \
-            --arch "$target" \
-            --artifacts "artifacts/$target/mock" \
+            --target "$target" \
+            --artifacts "artifacts/mock" \
             --mock
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/real \
-            --arch "$target" \
-            --artifacts "artifacts/$target/real"
+            --target "$target" \
+            --artifacts "artifacts/real"
     else
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/mock \
-            --arch "$target" \
-            --artifacts "artifacts/$target/mock" \
+            --target "$target" \
+            --artifacts "artifacts/mock" \
             --mock \
             --commit
         ./scripts/package.rs --lib \
             --name safe_app \
             --dest deploy/real \
-            --arch "$target" \
-            --artifacts "artifacts/$target/real" \
+            --target "$target" \
+            --artifacts "artifacts/real" \
             --commit
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/mock \
-            --arch "$target" \
-            --artifacts "artifacts/$target/mock" \
+            --target "$target" \
+            --artifacts "artifacts/mock" \
             --mock \
             --commit
         ./scripts/package.rs --lib \
             --name safe_authenticator \
             --dest deploy/real \
-            --arch "$target" \
-            --artifacts "artifacts/$target/real" \
+            --target "$target" \
+            --artifacts "artifacts/real" \
             --commit
     fi
 done

--- a/scripts/package.rs
+++ b/scripts/package.rs
@@ -45,6 +45,7 @@ const TARGET_WINDOWS_X64: &str = "x86_64-pc-windows-gnu";
 const TARGET_IOS_X64: &str = "x86_64-apple-ios";
 const TARGET_IOS_ARM64: &str = "aarch64-apple-ios";
 const TARGET_ANDROID_X86: &str = "i686-linux-android";
+const TARGET_ANDROID_X64: &str = "x86_64-linux-android";
 const TARGET_ANDROID_ARMEABIV7A: &str = "armv7-linux-androideabi";
 
 const CRATES: &[&str] = &["safe_app", "safe_authenticator"];
@@ -56,7 +57,7 @@ const ARCHS: &[Arch] = &[
         toolchain: "",
     },
     Arch {
-        name: "linux-x64",
+        name: "linux-x86_64",
         target: TARGET_LINUX_X64,
         toolchain: "",
     },
@@ -66,7 +67,7 @@ const ARCHS: &[Arch] = &[
         toolchain: "",
     },
     Arch {
-        name: "osx-x64",
+        name: "osx-x86_64",
         target: TARGET_OSX_X64,
         toolchain: "",
     },
@@ -76,7 +77,7 @@ const ARCHS: &[Arch] = &[
         toolchain: "",
     },
     Arch {
-        name: "win-x64",
+        name: "win-x86_64",
         target: TARGET_WINDOWS_X64,
         toolchain: "",
     },
@@ -91,6 +92,11 @@ const ARCHS: &[Arch] = &[
         toolchain: "i686-linux-android-",
     },
     Arch {
+        name: "android-x86_64",
+        target: TARGET_ANDROID_X86,
+        toolchain: "x86_64-linux-android-",
+    },
+    Arch {
         name: "ios-arm64",
         target: TARGET_IOS_ARM64,
         toolchain: "",
@@ -100,20 +106,25 @@ const ARCHS: &[Arch] = &[
         target: TARGET_IOS_X64,
         toolchain: "",
     },
+    Arch {
+        name: "ios-universal",
+        target: "",
+        toolchain: "",
+    },
 ];
 
 #[cfg(all(target_os = "linux", target_arch = "x86"))]
 const HOST_ARCH_NAME: &str = "linux-x86";
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "linux-x64";
+const HOST_ARCH_NAME: &str = "linux-x86_64";
 #[cfg(all(target_os = "macos", target_arch = "x86"))]
 const HOST_ARCH_NAME: &str = "osx-x86";
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "osx-x64";
+const HOST_ARCH_NAME: &str = "osx-x86_64";
 #[cfg(all(target_os = "windows", target_arch = "x86"))]
 const HOST_ARCH_NAME: &str = "win-x86";
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "win-x64";
+const HOST_ARCH_NAME: &str = "win-x86_64";
 
 const BINDINGS_LANGS: &[&str] = &["csharp"];
 

--- a/scripts/package.rs
+++ b/scripts/package.rs
@@ -44,96 +44,85 @@ const TARGET_WINDOWS_X86: &str = "i686-pc-windows-gnu";
 const TARGET_WINDOWS_X64: &str = "x86_64-pc-windows-gnu";
 const TARGET_IOS_X64: &str = "x86_64-apple-ios";
 const TARGET_IOS_ARM64: &str = "aarch64-apple-ios";
+const TARGET_IOS_UNIVERSAL: &str = "apple-ios";
 const TARGET_ANDROID_X86: &str = "i686-linux-android";
 const TARGET_ANDROID_X64: &str = "x86_64-linux-android";
 const TARGET_ANDROID_ARMEABIV7A: &str = "armv7-linux-androideabi";
 
 const CRATES: &[&str] = &["safe_app", "safe_authenticator"];
 
-const ARCHS: &[Arch] = &[
-    Arch {
-        name: "linux-x86",
-        target: TARGET_LINUX_X86,
+const TARGET_TRIPLES: &[TargetTriple] = &[
+    TargetTriple {
+        name: TARGET_LINUX_X86,
         toolchain: "",
     },
-    Arch {
-        name: "linux-x86_64",
-        target: TARGET_LINUX_X64,
+    TargetTriple {
+        name: TARGET_LINUX_X64,
         toolchain: "",
     },
-    Arch {
-        name: "osx-x86",
-        target: TARGET_OSX_X86,
+    TargetTriple {
+        name: TARGET_OSX_X86,
         toolchain: "",
     },
-    Arch {
-        name: "osx-x86_64",
-        target: TARGET_OSX_X64,
+    TargetTriple {
+        name: TARGET_OSX_X64,
         toolchain: "",
     },
-    Arch {
-        name: "win-x86",
-        target: TARGET_WINDOWS_X86,
+    TargetTriple {
+        name: TARGET_WINDOWS_X86,
         toolchain: "",
     },
-    Arch {
-        name: "win-x86_64",
-        target: TARGET_WINDOWS_X64,
+    TargetTriple {
+        name: TARGET_WINDOWS_X64,
         toolchain: "",
     },
-    Arch {
-        name: "android-armeabiv7a",
-        target: TARGET_ANDROID_ARMEABIV7A,
+    TargetTriple {
+        name: TARGET_ANDROID_ARMEABIV7A,
         toolchain: "arm-linux-androideabi-",
     },
-    Arch {
-        name: "android-x86",
-        target: TARGET_ANDROID_X86,
+    TargetTriple {
+        name: TARGET_ANDROID_X86,
         toolchain: "i686-linux-android-",
     },
-    Arch {
-        name: "android-x86_64",
-        target: TARGET_ANDROID_X86,
+    TargetTriple {
+        name: TARGET_ANDROID_X64,
         toolchain: "x86_64-linux-android-",
     },
-    Arch {
-        name: "ios-arm64",
-        target: TARGET_IOS_ARM64,
+    TargetTriple {
+        name: TARGET_IOS_ARM64,
         toolchain: "",
     },
-    Arch {
-        name: "ios-x86_64",
-        target: TARGET_IOS_X64,
+    TargetTriple {
+        name: TARGET_IOS_X64,
         toolchain: "",
     },
-    Arch {
-        name: "ios-universal",
-        target: "",
+    TargetTriple {
+        name: TARGET_IOS_UNIVERSAL,
         toolchain: "",
     },
 ];
 
 #[cfg(all(target_os = "linux", target_arch = "x86"))]
-const HOST_ARCH_NAME: &str = "linux-x86";
+const HOST_TARGET_TRIPLE: &str = "x86-unknown-linux-gnu";
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "linux-x86_64";
+const HOST_TARGET_TRIPLE: &str = "x86_64-unknown-linux-gnu";
 #[cfg(all(target_os = "macos", target_arch = "x86"))]
-const HOST_ARCH_NAME: &str = "osx-x86";
+const HOST_TARGET_TRIPLE: &str = "x86-apple-darwin";
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "osx-x86_64";
+const HOST_TARGET_TRIPLE: &str = "x86_64-apple-darwin";
 #[cfg(all(target_os = "windows", target_arch = "x86"))]
-const HOST_ARCH_NAME: &str = "win-x86";
+const HOST_TARGET_TRIPLE: &str = "x86-pc-windows-gnu";
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-const HOST_ARCH_NAME: &str = "win-x86_64";
+const HOST_TARGET_TRIPLE: &str = "x86_64-pc-windows-gnu";
 
 const BINDINGS_LANGS: &[&str] = &["csharp"];
 
 const COMMIT_HASH_LEN: usize = 7;
 
 fn main() {
-    let arch_names: Vec<_> = ARCHS
+    let target_names: Vec<_> = TARGET_TRIPLES
         .into_iter()
-        .map(|args| args.name)
+        .map(|target| target.name)
         .chain(iter::once("ios"))
         .collect();
 
@@ -157,15 +146,14 @@ fn main() {
                 .long("rebuild")
                 .takes_value(false)
                 .required(false)
-                .help("If true a cargo build will run and output the artifacts to target/<arch>")
+                .help("If true a cargo build will run and output the artifacts to target/<arch>."),
         )
         .arg(
-            Arg::with_name("ARCH")
-                .short("a")
-                .long("arch")
+            Arg::with_name("TARGET_TRIPLE")
+                .long("target")
                 .takes_value(true)
-                .possible_values(&arch_names)
-                .help("Target platform and architecture"),
+                .possible_values(&target_names)
+                .help("Specifies the target triple to package or build."),
         )
         .arg(Arg::with_name("LIB").short("l").long("lib").help(
             "Generates library package",
@@ -207,7 +195,8 @@ fn main() {
                 .takes_value(true)
                 .help("Directory containing the artifacts to package. If not specified, the CARGO_TARGET_DIR
                       variable will be queried for its value, and if that's not set, we will assume the 'target'
-                      directory in the current directory."),
+                      directory in the current directory. The artifacts directory should be structured as
+                      <target triple>/release, e.g. x86_64-unknown-linux-gnu/release."),
         )
         .get_matches();
 
@@ -215,8 +204,8 @@ fn main() {
     let rebuild = matches.is_present("REBUILD");
     let version_string = get_version_string(krate, matches.is_present("COMMIT"));
 
-    let arch_name = matches.value_of("ARCH").unwrap_or(HOST_ARCH_NAME);
-    let arch = find_arch(arch_name);
+    let target_name = matches.value_of("TARGET_TRIPLE").unwrap_or(HOST_TARGET_TRIPLE);
+    let target = find_target(target_name);
 
     let dest_dir = matches.value_of("DEST").unwrap_or(".");
     let bindings = matches.is_present("BINDINGS");
@@ -233,7 +222,7 @@ fn main() {
 
     let file_options = FileOptions::default();
 
-    setup_env(toolchain_path, arch);
+    setup_env(toolchain_path, target);
 
     // Gather features.
     let mut features = vec![];
@@ -245,18 +234,14 @@ fn main() {
         features.push("bindings");
     }
 
-    // Run the build.
     let mut libs = Vec::new();
-    if arch_name == "ios" {
-        // iOS fat library.
-        let mut arch_libs = ["ios-arm64", "ios-x86_64"]
+    if target_name.contains("ios") && HOST_TARGET_TRIPLE == TARGET_OSX_X64 {
+        let mut arch_libs = [TARGET_IOS_ARM64, TARGET_IOS_X64]
             .into_iter()
-            .flat_map(|arch_name| {
-                let arch = find_arch(arch_name).unwrap();
-                let target = &arch.target;
-
+            .flat_map(|target_name| {
+                let target = find_target(target_name);
                 if rebuild {
-                    if !build(krate, &features, Some(target)) {
+                    if !build(krate, &features, Some(target_name)) {
                         return Vec::new();
                     }
                 }
@@ -265,13 +250,9 @@ fn main() {
                     return Vec::new();
                 }
 
-                let libs = if rebuild {
-                    find_libs(krate, Some(target), &target_dir)
-                } else {
-                    find_libs(krate, None, &target_dir)
-                };
+                let libs = find_libs(krate, Some(target_name), &target_dir);
                 if strip {
-                    strip_libs(toolchain_path, Some(arch), &libs);
+                    strip_libs(toolchain_path, target, &libs);
                 }
                 libs
             }).peekable();
@@ -283,21 +264,17 @@ fn main() {
         }
     } else {
         // Normal library
-        let target = arch.map(|arch| arch.target);
+        let target_name = target.map(|target| target.name);
         if rebuild {
-            if !build(krate, &features, target) {
+            if !build(krate, &features, target_name) {
                 return;
             }
         }
 
         if lib {
-            let arch_libs = if rebuild {
-                find_libs(krate, target, &target_dir)
-            } else {
-                find_libs(krate, None, &target_dir)
-            };
+            let arch_libs = find_libs(krate, target_name, &target_dir);
             if strip {
-                strip_libs(toolchain_path, arch, &arch_libs);
+                strip_libs(toolchain_path, target, &arch_libs);
             }
             libs.extend_from_slice(&arch_libs)
         }
@@ -305,7 +282,7 @@ fn main() {
 
     if !libs.is_empty() {
         package_artifacts_as_zip(
-            &arch_name,
+            &target_name,
             &krate,
             &dest_dir,
             &libs,
@@ -313,7 +290,7 @@ fn main() {
             mock,
             file_options,
         );
-        package_artifacts_as_tar_gz(&arch_name, &krate, &dest_dir, &libs, &version_string, mock);
+        package_artifacts_as_tar_gz(&target_name, &krate, &dest_dir, &libs, &version_string, mock);
     }
 
     // Create bindings archive.
@@ -347,14 +324,13 @@ fn main() {
     }
 }
 
-struct Arch {
+struct TargetTriple {
     name: &'static str,
-    target: &'static str,
     toolchain: &'static str,
 }
 
 fn package_artifacts_as_zip(
-    arch_name: &str,
+    target_name: &str,
     krate: &str,
     dest_dir: &str,
     libs: &[PathBuf],
@@ -362,7 +338,7 @@ fn package_artifacts_as_zip(
     mock: bool,
     file_options: FileOptions,
 ) {
-    let archive_name = get_archive_name(&arch_name, &krate, "zip", &version_string, mock);
+    let archive_name = get_archive_name(&target_name, &krate, "zip", &version_string, mock);
     let path: PathBuf = [dest_dir, &archive_name].iter().collect();
     let file = File::create(path).unwrap();
     let mut archive = ZipWriter::new(file);
@@ -377,14 +353,14 @@ fn package_artifacts_as_zip(
 }
 
 fn package_artifacts_as_tar_gz(
-    arch_name: &str,
+    target_name: &str,
     krate: &str,
     dest_dir: &str,
     libs: &[PathBuf],
     version_string: &str,
     mock: bool,
 ) {
-    let archive_name = get_archive_name(&arch_name, &krate, "tar.gz", &version_string, mock);
+    let archive_name = get_archive_name(&target_name, &krate, "tar.gz", &version_string, mock);
     let path: PathBuf = [dest_dir, &archive_name].iter().collect();
     let file = File::create(path).unwrap();
     let enc = GzEncoder::new(file, Compression::default());
@@ -398,7 +374,7 @@ fn package_artifacts_as_tar_gz(
 }
 
 fn get_archive_name(
-    arch_name: &str,
+    target_name: &str,
     krate: &str,
     archive_type: &str,
     version_string: &str,
@@ -407,7 +383,7 @@ fn get_archive_name(
     let mock = if mock { "-mock" } else { "" };
     format!(
         "{}{}-{}-{}.{}",
-        krate, mock, version_string, arch_name, archive_type
+        krate, mock, version_string, target_name, archive_type
     )
 }
 
@@ -441,7 +417,7 @@ fn get_version_string(krate: &str, commit: bool) -> String {
     }
 }
 
-fn get_toolchain_bin(toolchain_path: Option<&str>, arch: Option<&Arch>, bin: &str) -> String {
+fn get_toolchain_bin(toolchain_path: Option<&str>, target: Option<&TargetTriple>, bin: &str) -> String {
     let mut result = PathBuf::new();
 
     if let Some(path) = toolchain_path {
@@ -449,23 +425,23 @@ fn get_toolchain_bin(toolchain_path: Option<&str>, arch: Option<&Arch>, bin: &st
         result.push("bin");
     }
 
-    let prefix = arch.map(|arch| arch.toolchain).unwrap_or("");
+    let prefix = target.map(|target| target.toolchain).unwrap_or("");
 
     result.push(format!("{}{}", prefix, bin));
     result.into_os_string().into_string().unwrap()
 }
 
-fn find_arch(name: &str) -> Option<&Arch> {
-    ARCHS.into_iter().find(|arch| arch.name == name)
+fn find_target(name: &str) -> Option<&TargetTriple> {
+    TARGET_TRIPLES.into_iter().find(|target| target.name == name)
 }
 
-fn setup_env(toolchain_path: Option<&str>, arch: Option<&Arch>) {
-    let arch = if let Some(arch) = arch { arch } else { return };
+fn setup_env(toolchain_path: Option<&str>, target: Option<&TargetTriple>) {
+    let target = if let Some(target) = target { target } else { return };
 
-    let name = format!("CARGO_TARGET_{}_LINKER", arch.target.to_shouty_snake_case());
+    let name = format!("CARGO_TARGET_{}_LINKER", target.name.to_shouty_snake_case());
 
     let value = if let Some(toolchain_path) = toolchain_path {
-        let value = get_toolchain_bin(Some(toolchain_path), Some(arch), "gcc");
+        let value = get_toolchain_bin(Some(toolchain_path), Some(target), "gcc");
 
         println!(
             "{}: setting environment variable {} to {}",
@@ -526,7 +502,6 @@ fn find_libs(krate: &str, target: Option<&str>, target_dir: &str) -> Vec<PathBuf
         prefix = prefix.join(target);
     }
     prefix = prefix.join("release");
-
     let mut result = Vec::with_capacity(1);
 
     // linux,osx - static
@@ -560,8 +535,8 @@ fn find_libs(krate: &str, target: Option<&str>, target_dir: &str) -> Vec<PathBuf
     result
 }
 
-fn strip_libs(toolchain_path: Option<&str>, arch: Option<&Arch>, libs: &[PathBuf]) {
-    let strip_bin = get_toolchain_bin(toolchain_path, arch, "strip");
+fn strip_libs(toolchain_path: Option<&str>, target: Option<&TargetTriple>, libs: &[PathBuf]) {
+    let strip_bin = get_toolchain_bin(toolchain_path, target, "strip");
 
     for path in libs {
         strip_lib(&strip_bin, path);
@@ -611,7 +586,7 @@ fn path_into_string(path: PathBuf) -> String {
 
 fn is_static_lib_required(target: Option<&str>) -> bool {
     match target {
-        Some(TARGET_IOS_ARM64) | Some(TARGET_IOS_X64) => true,
+        Some(TARGET_IOS_UNIVERSAL) | Some(TARGET_IOS_ARM64) | Some(TARGET_IOS_X64) => true,
         Some(_) | None => false,
     }
 }

--- a/scripts/retrieve-build-artifacts
+++ b/scripts/retrieve-build-artifacts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "$SCL_BUILD_NUMBER" ]]; then
+	echo "Please set SCL_BUILD_NUMBER to a valid build number."
+    exit 1
+fi
+
+if [[ -z "$SCL_BUILD_BRANCH" ]]; then
+	echo "Please set SCL_BUILD_BRANCH to a valid branch or PR reference."
+    exit 1
+fi
+
+S3_BUCKET=safe-jenkins-build-artifacts
+declare -a types=("mock" "real")
+
+rm -rf artifacts
+for target in "$@"; do
+    echo "Getting artifacts for $target"
+    for type in "${types[@]}"; do
+        mkdir -p "artifacts/$type/$target/release"
+        (
+            cd "artifacts/$type/$target/release"
+            if [[ "$type" == "mock" ]]; then
+                aws s3 cp \
+                    --no-sign-request \
+                    --region eu-west-2 \
+                    "s3://$S3_BUCKET/$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-mock-$target.tar.gz" .
+                tar -xvf "$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-mock-$target.tar.gz"
+                rm "$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-mock-$target.tar.gz"
+            else
+                aws s3 cp \
+                    --no-sign-request \
+                    --region eu-west-2 \
+                    "s3://$S3_BUCKET/$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-$target.tar.gz" .
+                tar -xvf "$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-$target.tar.gz"
+                rm "$SCL_BUILD_BRANCH-$SCL_BUILD_NUMBER-scl-$target.tar.gz"
+            fi
+        )
+    done
+done


### PR DESCRIPTION
Hi Lionel/Ravinder,

This enables builds for Android and iOS, both mock and real versions. They are all built in parallel during the first stage. There's a 2nd stage that combines the 2 iOS libraries into the universal library. The release process has also been extended to include these.

You can see an example release [here](https://github.com/jacderida/safe_client_libs/releases/tag/0.10.1) on my fork. [This](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-1037/26/pipeline/343/) was the build that produced that release.

You can see an example of a non-versioned deploy build [here](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-1037/23/pipeline/343/). Here are the artifacts uploaded to S3:
```
2019-09-25 00:08:00   16602387 safe_app-mock-eefee1e-aarch64-apple-ios.tar.gz
2019-09-25 00:08:01   33435129 safe_app-mock-eefee1e-apple-ios.tar.gz
2019-09-25 00:08:02    5523555 safe_app-mock-eefee1e-armv7-linux-androideabi.tar.gz
2019-09-25 00:08:03   16823704 safe_app-mock-eefee1e-x86_64-apple-ios.tar.gz
2019-09-25 00:08:03    4868415 safe_app-mock-eefee1e-x86_64-apple-darwin.tar.gz
2019-09-25 00:08:04    5523555 safe_app-mock-eefee1e-x86_64-linux-android.tar.gz
2019-09-25 00:08:05    9943320 safe_app-mock-eefee1e-x86_64-pc-windows-gnu.tar.gz
2019-09-25 00:08:08    4287039 safe_app-mock-eefee1e-x86_64-unknown-linux-gnu.tar.gz
2019-09-25 00:08:09   15383332 safe_authenticator-mock-eefee1e-aarch64-apple-ios.tar.gz
2019-09-25 00:08:09   30954986 safe_authenticator-mock-eefee1e-apple-ios.tar.gz
2019-09-25 00:08:10    4543383 safe_authenticator-mock-eefee1e-armv7-linux-androideabi.tar.gz
2019-09-25 00:08:11   15569913 safe_authenticator-mock-eefee1e-x86_64-apple-ios.tar.gz
2019-09-25 00:08:11    4023264 safe_authenticator-mock-eefee1e-x86_64-apple-darwin.tar.gz
2019-09-25 00:08:12    4543382 safe_authenticator-mock-eefee1e-x86_64-linux-android.tar.gz
2019-09-25 00:08:12    9042933 safe_authenticator-mock-eefee1e-x86_64-pc-windows-gnu.tar.gz
2019-09-25 00:08:13   14883521 safe_app-eefee1e-aarch64-apple-ios.tar.gz
2019-09-25 00:08:13    3440343 safe_authenticator-mock-eefee1e-x86_64-unknown-linux-gnu.tar.gz
2019-09-25 00:08:14   29937548 safe_app-eefee1e-apple-ios.tar.gz
2019-09-25 00:08:15    4868415 safe_app-eefee1e-x86_64-apple-darwin.tar.gz
2019-09-25 00:08:15    6686279 safe_app-eefee1e-armv7-linux-androideabi.tar.gz
2019-09-25 00:08:16   15051654 safe_app-eefee1e-x86_64-apple-ios.tar.gz
2019-09-25 00:08:17   10021568 safe_app-eefee1e-x86_64-pc-windows-gnu.tar.gz
2019-09-25 00:08:17    5281824 safe_app-eefee1e-x86_64-unknown-linux-gnu.tar.gz
2019-09-25 00:08:17    6686281 safe_app-eefee1e-x86_64-linux-android.tar.gz
2019-09-25 00:08:18   14632422 safe_authenticator-eefee1e-aarch64-apple-ios.tar.gz
2019-09-25 00:08:19   29434866 safe_authenticator-eefee1e-apple-ios.tar.gz
2019-09-25 00:08:20   14792939 safe_authenticator-eefee1e-x86_64-apple-ios.tar.gz
2019-09-25 00:08:20    4023264 safe_authenticator-eefee1e-x86_64-apple-darwin.tar.gz
2019-09-25 00:08:20    5697865 safe_authenticator-eefee1e-armv7-linux-androideabi.tar.gz
2019-09-25 00:08:21    5697865 safe_authenticator-eefee1e-x86_64-linux-android.tar.gz
2019-09-25 00:08:22    4421908 safe_authenticator-eefee1e-x86_64-unknown-linux-gnu.tar.gz
2019-09-25 00:08:22    9088515 safe_authenticator-eefee1e-x86_64-pc-windows-gnu.tar.gz
```

*Important note*: the filenames for the artifacts have been changed intentionally. They are now using the official Rust 'target triple' that's [referred to in the documentation](https://forge.rust-lang.org/release/platform-support.html). This is to have consistency with the [safe-cli](https://github.com/maidsafe/safe-cli/releases/tag/0.4.0), [safe-authenticator-cli](https://github.com/maidsafe/safe-authenticator-cli/releases/tag/0.3.0) and [safe_vault](
https://github.com/maidsafe/safe_vault/releases/tag/0.19.2) releases. The self update feature actually requires them to be in this format, and I just think there's not really a good reason for safe_client_libs to be different.

Btw, there are serialisation tests failing on Travis. I haven't touched anything in that area so I don't think that has anything to do with me.

Cheers,

Chris