### PR TITLE
Tagging, Publishing and Nightly Builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,8 +1868,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safe-nd"
-version = "0.3.2"
-source = "git+https://github.com/maidsafe/safe-nd#73317767350292b1e32ef2f92ad1bf4945d32d66"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1900,7 +1900,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.2 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_authenticator 0.10.0",
  "safe_bindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.33.0",
@@ -1943,7 +1943,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.2 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_bindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_core 0.33.0",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2005,7 +2005,7 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.2 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_encryption 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2351,7 +2351,7 @@ version = "0.1.0"
 dependencies = [
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.2 (git+https://github.com/maidsafe/safe-nd)",
+ "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_app 0.10.0",
  "safe_authenticator 0.10.0",
  "safe_core 0.33.0",
@@ -3062,7 +3062,7 @@ dependencies = [
 "checksum rustfmt 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec940eed814db0fb7ab928c5f5025f97dc55d1c0e345e39dda2ce9f945557500"
 "checksum rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f271e3552cd835fa28c541c34a7e8fdd8cdff09d77fe4eb8f6c42e87a11b096e"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safe-nd 0.3.2 (git+https://github.com/maidsafe/safe-nd)" = "<none>"
+"checksum safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a3e30058c32d76a167a1e081837d105ac878d35ef5abe490dd7cf8c8055b9720"
 "checksum safe_bindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e85de5ed32661702ad780caa5be7d229dd0fc84efef17de045a41d7969cfdd"
 "checksum safemem 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e133ccc4f4d1cd4f89cc8a7ff618287d56dc7f638b8e38fc32c5fdcadc339dd5"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ USER_ID := $(shell id -u)
 GROUP_ID := $(shell id -g)
 UNAME_S := $(shell uname -s)
 S3_BUCKET := safe-jenkins-build-artifacts
-GITHUB_REPO_OWNER := maidsafe
+GITHUB_REPO_OWNER := jacderida
 GITHUB_REPO_NAME := safe_client_libs
 
 build-container:
@@ -394,6 +394,7 @@ ifeq ($(UNAME_S),Linux)
 	docker cp "safe_app_tests-${UUID}":/target .
 	docker rm -f "safe_app_tests-${UUID}"
 else
+	./scripts/build-mock
 	./scripts/test-mock
 endif
 	make copy-artifacts
@@ -509,33 +510,7 @@ endif
 		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz" \
 		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz
 
-publish-safe_core:
-ifndef CRATES_IO_TOKEN
-	@echo "A login token for crates.io must be provided."
-	@exit 1
-endif
-	rm -rf artifacts deploy
-	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
-		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:x86_64-mock \
-		/bin/bash -c "cd safe_core && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
-
-publish-safe_auth:
-ifndef CRATES_IO_TOKEN
-	@echo "A login token for crates.io must be provided."
-	@exit 1
-endif
-	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
-		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:x86_64-mock \
-		/bin/bash -c "cd safe_authenticator && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
-
-publish-safe_app:
-ifndef CRATES_IO_TOKEN
-	@echo "A login token for crates.io must be provided."
-	@exit 1
-endif
-	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
-		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-client-libs-build:x86_64-mock \
-		/bin/bash -c "cd safe_app && cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
+publish:
+	./scripts/publish "safe_core"
+	./scripts/publish "safe_authenticator"
+	./scripts/publish "safe_app"

--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,11 @@ endif
 		--name "safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz" \
 		--file deploy/real/safe_authenticator-${SAFE_AUTH_VERSION}-x86_64-linux-android.tar.gz
 
-publish:
+publish-safe_core:
 	./scripts/publish "safe_core"
+
+publish-safe_authenticator:
 	./scripts/publish "safe_authenticator"
+
+publish-safe_app:
 	./scripts/publish "safe_app"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ USER_ID := $(shell id -u)
 GROUP_ID := $(shell id -g)
 UNAME_S := $(shell uname -s)
 S3_BUCKET := safe-jenkins-build-artifacts
-GITHUB_REPO_OWNER := jacderida
+GITHUB_REPO_OWNER := maidsafe
 GITHUB_REPO_NAME := safe_client_libs
 
 build-container:

--- a/Makefile
+++ b/Makefile
@@ -254,14 +254,22 @@ package-versioned-deploy-artifacts:
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-client-libs-build:x86_64 \
-		scripts/package-runner-container "true"
+		scripts/package-runner-container "versioned"
 
 package-commit_hash-deploy-artifacts:
 	@rm -rf deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-client-libs-build:x86_64 \
-		scripts/package-runner-container "false"
+		scripts/package-runner-container "commit_hash"
+
+package-nightly-deploy-artifacts:
+	@rm -rf deploy
+	docker run --rm -v "${PWD}":/usr/src/safe_client_libs:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-client-libs-build:x86_64 \
+		scripts/package-runner-container "nightly"
+	find . -name "*.zip" -exec rm "{}" \;
 
 retrieve-cache:
 ifndef SCL_BUILD_BRANCH

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -26,8 +26,7 @@ new_rand = { package = "rand", version = "0.6" }
 rust_sodium = "~0.10.2"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", optional = true }
 safe_core = { path = "../safe_core", version = "~0.33.0" }
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 self_encryption = "~0.15.0"
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
@@ -47,8 +46,7 @@ ffi_utils = "~0.12.0"
 jni = "~0.12.0"
 rust_sodium = "~0.10.2"
 safe_bindgen = { version = "~0.13.1", optional = true }
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -25,8 +25,7 @@ new_rand = { package = "rand", version = "0.6" }
 quic-p2p = "~0.2.1"
 rust_sodium = "~0.10.2"
 safe_core = { path = "../safe_core", version = "~0.33.0" }
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 serde = { version = "~1.0.97", features = ["derive"] }
 threshold_crypto = "~0.3.2"
 tiny-keccak = "~1.5.0"
@@ -43,8 +42,7 @@ ffi_utils = "~0.12.0"
 jni = "~0.12.0"
 rust_sodium = "~0.10.2"
 safe_bindgen = { version = "~0.13.1", optional = true }
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 unwrap = "~1.2.0"
 
 [features]

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -29,8 +29,7 @@ new_rand = { package = "rand", version = "0.6" }
 quic-p2p = "~0.2.1"
 rand = "~0.3.18"
 rust_sodium = "~0.10.2"
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 self_encryption = "~0.15.0"
 serde = { version = "~1.0.97", features = ["derive"] }
 serde_json = "~1.0.40"

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -167,7 +167,6 @@ stage("deployment") {
             sh("git fetch --tags --force")
             retrieveBuildArtifacts()
             if (isVersionChangeCommit()) {
-                def version = getVersion("safe_app")
                 packageDeployArtifacts(true)
                 createTags()
                 createGitHubRelease()
@@ -191,13 +190,17 @@ stage("publishing") {
     node("safe_client_libs") {
         if (shouldPublish()) {
             checkout(scm)
+            def components = getComponentsWithVersionChanges()
             def dryRun = isNightlyBuild() ? "true" : "false"
             withEnv(["SCL_PUBLISH_DRY_RUN=${dryRun}"]) {
-                withCredentials(
-                    [string(
-                        credentialsId: "crates_io_token", variable: "CRATES_IO_TOKEN")]) {
-                    sh("make publish")
-                }
+                components.each({
+                    publishCrate(it)
+                    // The next crate may have references to the one that was just published,
+                    // and sometimes it's possible the next publishing process will complain
+                    // that the one that was just published doesn't exist. We can sleep for a
+                    // few seconds to give it a chance to register on crates.io.
+                    sh("sleep 10")
+                })
             }
         } else {
             echo("Not publishing.")
@@ -224,13 +227,18 @@ def retrieveCache() {
 }
 
 def isVersionChangeCommit() {
+    def message = getLatestCommitMessage()
+    return message.startsWith("Version change")
+}
+
+def getLatestCommitMessage() {
     def shortCommitHash = sh(
         returnStdout: true,
         script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
     def message = sh(
         returnStdout: true,
         script: "git log --format=%B -n 1 ${shortCommitHash}").trim()
-    return message.startsWith("Version change")
+    return message
 }
 
 def packageBuildArtifacts(mode, target) {
@@ -298,12 +306,13 @@ def uploadDeployArtifacts(type) {
 }
 
 def createTags() {
+    def components = getComponentsWithVersionChanges()
     withCredentials(
         [usernamePassword(
             credentialsId: "github_maidsafe_qa_user_credentials",
             usernameVariable: "GIT_USER",
             passwordVariable: "GIT_PASSWORD")]) {
-        ["safe_app", "safe_authenticator", "safe_core"].each({
+        components.each({
             def version = getVersion(it)
             def tag_name = "${it}-${version}"
             sh("git config --global user.name \$GIT_USER")
@@ -314,6 +323,21 @@ def createTags() {
             sh("GIT_ASKPASS=true git push origin --tags")
         })
     }
+}
+
+def getComponentsWithVersionChanges() {
+    def components = []
+    def message = getLatestCommitMessage()
+    if (message.contains("safe_core")) {
+        components.add("safe_core")
+    }
+    if (message.contains("safe_authenticator")) {
+        components.add("safe_authenticator")
+    }
+    if (message.contains("safe_app")) {
+        components.add("safe_app")
+    }
+    return components
 }
 
 def createGitHubRelease() {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,11 +1,15 @@
+import hudson.triggers.TimerTrigger.TimerTriggerCause
+
 properties([
     parameters([
         string(name: "ARTIFACTS_BUCKET", defaultValue: "safe-jenkins-build-artifacts"),
         string(name: "CACHE_BRANCH", defaultValue: "master"),
         string(name: "DEPLOY_BRANCH", defaultValue: "master"),
         string(name: "PUBLISH_BRANCH", defaultValue: "master"),
-        string(name: "DEPLOY_BUCKET", defaultValue: "safe-client-libs")
-    ])
+        string(name: "DEPLOY_BUCKET", defaultValue: "safe-client-libs"),
+        string(name: "DEPLOY_NIGHTLY", defaultValue: "false")
+    ]),
+    pipelineTriggers([cron(env.BRANCH_NAME == "master" ? "0 2 * * *" : "")])
 ])
 
 stage("build & test") {
@@ -157,62 +161,60 @@ stage("build universal iOS lib") {
 }
 
 stage("deployment") {
-    parallel deploy_artifacts: {
-        node("safe_client_libs") {
-            if (env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
-                checkout(scm)
-                sh("git fetch --tags --force")
-                retrieveBuildArtifacts()
-                if (isVersionChangeCommit()) {
-                    def version = getVersion('safe_app')
-                    packageDeployArtifacts(true)
-                    createTags()
-                    createGitHubRelease()
-                    uploadDeployArtifacts("mock")
-                } else {
-                    packageDeployArtifacts(false)
-                    uploadDeployArtifacts("mock")
-                    uploadDeployArtifacts("real")
-                }
+    node("safe_client_libs") {
+        if (env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
+            checkout(scm)
+            sh("git fetch --tags --force")
+            retrieveBuildArtifacts()
+            if (isVersionChangeCommit()) {
+                def version = getVersion("safe_app")
+                packageDeployArtifacts(true)
+                createTags()
+                createGitHubRelease()
+                uploadDeployArtifacts("mock")
             } else {
-                echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
+                packageDeployArtifacts(false)
+                uploadDeployArtifacts("mock")
+                uploadDeployArtifacts("real")
             }
-        }
-    },
-    publish_safe_core_crate: {
-        node("safe_client_libs") {
-            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
-                checkout(scm)
-                publishCrate("safe_core")
-            } else {
-                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
-            }
-        }
-    },
-    publish_safe_app_crate: {
-        node("safe_client_libs") {
-            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
-                checkout(scm)
-                publishCrate("safe_app")
-            } else {
-                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
-            }
-        }
-    },
-    publish_safe_auth_crate: {
-        node("safe_client_libs") {
-            if (env.BRANCH_NAME == "${params.PUBLISH_BRANCH}") {
-                checkout(scm)
-                publishCrate("safe_auth")
-            } else {
-                echo("${env.BRANCH_NAME} does not match the publish branch. Nothing to do.")
-            }
+        } else {
+            echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
         }
     }
-    if (env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
+    if (isNightlyBuild() && env.BRANCH_NAME == "${params.DEPLOY_BRANCH}") {
         build(job: "../rust_cache_build-safe_client_libs-windows", wait: false)
         build(job: "../docker_build-safe_client_libs_build_container", wait: false)
     }
+}
+
+stage("publishing") {
+    node("safe_client_libs") {
+        if (shouldPublish()) {
+            checkout(scm)
+            def dryRun = isNightlyBuild() ? "true" : "false"
+            withEnv(["SCL_PUBLISH_DRY_RUN=${dryRun}"]) {
+                withCredentials(
+                    [string(
+                        credentialsId: "crates_io_token", variable: "CRATES_IO_TOKEN")]) {
+                    sh("make publish")
+                }
+            }
+        } else {
+            echo("Not publishing.")
+            echo("Not a version change commit or the publish branch doesn't match.")
+        }
+    }
+}
+
+@NonCPS
+def isNightlyBuild() {
+    return "${params.DEPLOY_NIGHTLY}" == "true" ||
+        null != currentBuild.getRawBuild().getCause(TimerTriggerCause.class)
+}
+
+def shouldPublish() {
+    return (isNightlyBuild() || isVersionChangeCommit()) &&
+        env.BRANCH_NAME == "${params.PUBLISH_BRANCH}"
 }
 
 def retrieveCache() {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -164,10 +164,10 @@ stage("deployment") {
                 sh("git fetch --tags --force")
                 retrieveBuildArtifacts()
                 if (isVersionChangeCommit()) {
-                    def version = getVersion()
+                    def version = getVersion('safe_app')
                     packageDeployArtifacts(true)
-                    createTag(version)
-                    createGitHubRelease(version)
+                    createTags()
+                    createGitHubRelease()
                     uploadDeployArtifacts("mock")
                 } else {
                     packageDeployArtifacts(false)
@@ -275,13 +275,10 @@ def uploadBuildArtifacts() {
     }
 }
 
-def getVersion() {
-    // For now we"re just taking the version from either safe auth or safe app.
-    // We may change this eventually to deploy each component separately, or possibly
-    // even refactor into separate repos.
+def getVersion(crate) {
     return sh(
         returnStdout: true,
-        script: "grep '^version' < safe_app/Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
+        script: "grep '^version' < ${crate}/Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
 }
 
 def uploadDeployArtifacts(type) {
@@ -298,22 +295,26 @@ def uploadDeployArtifacts(type) {
     }
 }
 
-def createTag(version) {
+def createTags() {
     withCredentials(
         [usernamePassword(
             credentialsId: "github_maidsafe_qa_user_credentials",
             usernameVariable: "GIT_USER",
             passwordVariable: "GIT_PASSWORD")]) {
-        sh("git config --global user.name \$GIT_USER")
-        sh("git config --global user.email qa@maidsafe.net")
-        sh("git config credential.username \$GIT_USER")
-        sh("git config credential.helper '!f() { echo password=\$GIT_PASSWORD; }; f'")
-        sh("git tag -a ${version} -m 'Creating tag for ${version}'")
-        sh("GIT_ASKPASS=true git push origin --tags")
+        ["safe_app", "safe_authenticator", "safe_core"].each({
+            def version = getVersion(it)
+            def tag_name = "${it}-${version}"
+            sh("git config --global user.name \$GIT_USER")
+            sh("git config --global user.email qa@maidsafe.net")
+            sh("git config credential.username \$GIT_USER")
+            sh("git config credential.helper '!f() { echo password=\$GIT_PASSWORD; }; f'")
+            sh("git tag -a ${tag_name} -m 'Creating tag for ${tag_name}'")
+            sh("GIT_ASKPASS=true git push origin --tags")
+        })
     }
 }
 
-def createGitHubRelease(version) {
+def createGitHubRelease() {
     withCredentials(
         [usernamePassword(
             credentialsId: "github_maidsafe_token_credentials",

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -166,13 +166,19 @@ stage("deployment") {
             checkout(scm)
             sh("git fetch --tags --force")
             retrieveBuildArtifacts()
-            if (isVersionChangeCommit()) {
-                packageDeployArtifacts(true)
+            if (isNightlyBuild()) {
+                packageDeployArtifacts("nightly")
+                deletePreviousNightly()
+                uploadDeployArtifacts("mock")
+                uploadDeployArtifacts("real")
+            } else if (isVersionChangeCommit()) {
+                packageDeployArtifacts("versioned")
                 createTags()
                 createGitHubRelease()
                 uploadDeployArtifacts("mock")
+                uploadDeployArtifacts("real")
             } else {
-                packageDeployArtifacts(false)
+                packageDeployArtifacts("commit_hash")
                 uploadDeployArtifacts("mock")
                 uploadDeployArtifacts("real")
             }
@@ -260,11 +266,19 @@ def retrieveBuildArtifacts() {
     }
 }
 
-def packageDeployArtifacts(isVersionChangeCommit) {
-    if (isVersionChangeCommit) {
-        sh("make package-versioned-deploy-artifacts")
-    } else {
-        sh("make package-commit_hash-deploy-artifacts")
+def packageDeployArtifacts(type) {
+    switch (type) {
+        case "versioned":
+            sh("make package-versioned-deploy-artifacts")
+            break
+        case "commit_hash":
+            sh("make package-commit_hash-deploy-artifacts")
+            break
+        case "nightly":
+            sh("make package-nightly-deploy-artifacts")
+            break
+        default:
+            error("The deployment type ${type} is not supported. Please extend for support.")
     }
 }
 
@@ -289,6 +303,21 @@ def getVersion(crate) {
     return sh(
         returnStdout: true,
         script: "grep '^version' < ${crate}/Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
+}
+
+def deletePreviousNightly() {
+    withAWS(credentials: "aws_jenkins_user_credentials", region: "eu-west-2") {
+        ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "x86_64-apple-darwin",
+         "armv7-linux-androideabi", "x86_64-linux-android", "x86_64-apple-ios",
+         "aarch64-apple-ios", "apple-ios"].each({
+            s3Delete(
+                bucket: "${params.DEPLOY_BUCKET}",
+                path: "safe_app-nightly-${it}.tar.gz")
+            s3Delete(
+                bucket: "${params.DEPLOY_BUCKET}",
+                path: "safe_authenticator-nightly-${it}.tar.gz")
+        })
+    }
 }
 
 def uploadDeployArtifacts(type) {
@@ -326,6 +355,10 @@ def createTags() {
 }
 
 def getComponentsWithVersionChanges() {
+    if (isNightlyBuild()) {
+        // For a nightly we want to run a dry run publish on all components.
+        return ["safe_core", "safe_authenticator", "safe_app"]
+    }
     def components = []
     def message = getLatestCommitMessage()
     if (message.contains("safe_core")) {

--- a/scripts/package-runner-container
+++ b/scripts/package-runner-container
@@ -10,9 +10,10 @@
 
 set -e -x
 
-is_versioned=$1
-if [[ -z "$is_versioned" ]]; then
-    echo "A true/false argument must be passed indicating to package for a versioned deployment."
+deployment_type=$1
+if [[ -z "$deployment_type" ]]; then
+    echo "An argument indicating the type of the deployment must be supplied."
+    echo "Valid values are 'versioned', 'commit_hash' or 'nightly'."
     exit 1
 fi
 
@@ -29,57 +30,26 @@ declare -a targets=(\
     "x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
     "armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
     "aarch64-apple-ios" "apple-ios")
+
+function run_packaging() {
+    local name=$1
+    local deployment_type=$2
+    local target=$3
+    local build_type=$4
+
+    local package_args="--lib --name $name --dest deploy/$build_type"
+    package_args="$package_args --target $target --artifacts artifacts/$build_type"
+    [[ "$deployment_type" == "nightly" ]] && package_args="$package_args --nightly"
+    [[ "$deployment_type" == "commit_hash" ]] && package_args="$package_args --commit"
+    [[ "$build_type" == "mock" ]] && package_args="$package_args --mock"
+
+    package_command=(./scripts/package.rs $package_args)
+    "${package_command[@]}"
+}
+
 for target in "${targets[@]}"; do
-    pwd
-    if [[ $is_versioned == "true" ]]; then
-        ./scripts/package.rs --lib \
-            --name safe_app \
-            --dest deploy/mock \
-            --target "$target" \
-            --artifacts "artifacts/mock" \
-            --mock
-        ./scripts/package.rs --lib \
-            --name safe_app \
-            --dest deploy/real \
-            --target "$target" \
-            --artifacts "artifacts/real"
-        ./scripts/package.rs --lib \
-            --name safe_authenticator \
-            --dest deploy/mock \
-            --target "$target" \
-            --artifacts "artifacts/mock" \
-            --mock
-        ./scripts/package.rs --lib \
-            --name safe_authenticator \
-            --dest deploy/real \
-            --target "$target" \
-            --artifacts "artifacts/real"
-    else
-        ./scripts/package.rs --lib \
-            --name safe_app \
-            --dest deploy/mock \
-            --target "$target" \
-            --artifacts "artifacts/mock" \
-            --mock \
-            --commit
-        ./scripts/package.rs --lib \
-            --name safe_app \
-            --dest deploy/real \
-            --target "$target" \
-            --artifacts "artifacts/real" \
-            --commit
-        ./scripts/package.rs --lib \
-            --name safe_authenticator \
-            --dest deploy/mock \
-            --target "$target" \
-            --artifacts "artifacts/mock" \
-            --mock \
-            --commit
-        ./scripts/package.rs --lib \
-            --name safe_authenticator \
-            --dest deploy/real \
-            --target "$target" \
-            --artifacts "artifacts/real" \
-            --commit
-    fi
+    run_packaging "safe_app" "$deployment_type" "$target" "mock"
+    run_packaging "safe_app" "$deployment_type" "$target" "real"
+    run_packaging "safe_authenticator" "$deployment_type" "$target" "mock"
+    run_packaging "safe_authenticator" "$deployment_type" "$target" "real"
 done

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+crate_name=$1
+if [[ -z "$crate_name" ]]; then
+    echo "A crate name must be provided for publishing."
+    echo "Please set SCL_CRATE_NAME to 'safe_app', 'safe_authenticator', or 'safe_core'"
+    exit 1
+fi
+
+if [[ -z "$CRATES_IO_TOKEN" ]]; then
+    echo "A login token for crates.io must be provided. Please set CRATES_IO_TOKEN to a valid token."
+    exit 1
+fi
+
+if [[ -z "$SCL_PUBLISH_DRY_RUN" ]]; then
+    echo "Please set $SCL_PUBLISH_DRY_RUN to 'true'or 'false'"
+    exit 1
+fi
+
+publish_command="cd $crate_name && cargo login $CRATES_IO_TOKEN && cargo package && cargo publish"
+[[ "$SCL_PUBLISH_DRY_RUN" == "true" ]] && publish_command="$publish_command --dry-run"
+
+rm -rf artifacts deploy
+docker run --rm -v "$(pwd)":/usr/src/safe_client_libs:Z \
+    -u "$(id -u)":"$(id -g)" \
+    maidsafe/safe-client-libs-build:x86_64 \
+    /bin/bash -c "$publish_command"

--- a/scripts/publish
+++ b/scripts/publish
@@ -15,12 +15,15 @@ if [[ -z "$CRATES_IO_TOKEN" ]]; then
 fi
 
 if [[ -z "$SCL_PUBLISH_DRY_RUN" ]]; then
-    echo "Please set $SCL_PUBLISH_DRY_RUN to 'true'or 'false'"
+    echo "Please set SCL_PUBLISH_DRY_RUN to 'true'or 'false'"
     exit 1
 fi
 
 publish_command="cd $crate_name && cargo login $CRATES_IO_TOKEN && cargo package && cargo publish"
-[[ "$SCL_PUBLISH_DRY_RUN" == "true" ]] && publish_command="$publish_command --dry-run"
+if [[ "$SCL_PUBLISH_DRY_RUN" == "true" ]]; then
+    echo "Running publish with --dry-run"
+    publish_command="$publish_command --dry-run"
+fi
 
 rm -rf artifacts deploy
 docker run --rm -v "$(pwd)":/usr/src/safe_client_libs:Z \

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,8 +14,7 @@ futures = "~0.1.17"
 safe_app = { path = "../safe_app", version = "~0.10.0", features = ["testing"] }
 safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", features = ["testing"] }
 safe_core = { path = "../safe_core", version = "~0.33.0", features = ["testing"] }
-#safe-nd = "~0.3.0"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd" }
+safe-nd = "~0.4.0"
 serde = "~1.0.24"
 serde_derive = "~1.0.24"
 serde_json = "~1.0.2"


### PR DESCRIPTION
This implements:

* Publishing in its own stage, in a sequential manner.
* For a version change build, each component in the workspace is tagged, deployed and published separately.
* A nightly build that will run at 2AM:
  - Does a 'dry run' publish
  - Deploys all components to S3 in the form `safe_app-nightly-<target triple>.tar.gz`
  
It felt more correct for publishing to be in its own stage because the publish should only occur if the deployment has been completely successful.
 
[This](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-1038/11/pipeline/) build demonstrates a successful deploy and publish.

You can [see](https://github.com/maidsafe/safe_client_libs/tags) the individual component tags for these test publish runs. I'll delete these once this PR is merged.

[This](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-1038/22/pipeline) build simulates a nightly by using the `DEPLOY_NIGHTLY` parameter (this is used for running a nightly build at any point in time, if there is some requirement for that, which we seen on another project):
```
2019-09-30 17:02:51   16587718 safe_app-mock-nightly-aarch64-apple-ios.tar.gz
2019-09-30 17:02:51   33391091 safe_app-mock-nightly-apple-ios.tar.gz
2019-09-30 17:02:52   16804105 safe_app-mock-nightly-x86_64-apple-ios.tar.gz
2019-09-30 17:02:52    4000859 safe_app-mock-nightly-x86_64-apple-darwin.tar.gz
2019-09-30 17:02:52    5518221 safe_app-mock-nightly-armv7-linux-androideabi.tar.gz
2019-09-30 17:02:53    4283887 safe_app-mock-nightly-x86_64-unknown-linux-gnu.tar.gz
2019-09-30 17:02:53    5518218 safe_app-mock-nightly-x86_64-linux-android.tar.gz
2019-09-30 17:02:53    9911401 safe_app-mock-nightly-x86_64-pc-windows-gnu.tar.gz
2019-09-30 17:02:54   15366678 safe_authenticator-mock-nightly-aarch64-apple-ios.tar.gz
2019-09-30 17:02:54   30931727 safe_authenticator-mock-nightly-apple-ios.tar.gz
2019-09-30 17:02:55   15558143 safe_authenticator-mock-nightly-x86_64-apple-ios.tar.gz
2019-09-30 17:02:55    3160181 safe_authenticator-mock-nightly-x86_64-apple-darwin.tar.gz
2019-09-30 17:02:55    4542106 safe_authenticator-mock-nightly-x86_64-linux-android.tar.gz
2019-09-30 17:02:55    4542110 safe_authenticator-mock-nightly-armv7-linux-androideabi.tar.gz
2019-09-30 17:02:56   14878731 safe_app-nightly-aarch64-apple-ios.tar.gz
2019-09-30 17:02:56    3438905 safe_authenticator-mock-nightly-x86_64-unknown-linux-gnu.tar.gz
2019-09-30 17:02:56    8994271 safe_authenticator-mock-nightly-x86_64-pc-windows-gnu.tar.gz
2019-09-30 17:02:57   29920621 safe_app-nightly-apple-ios.tar.gz
2019-09-30 17:02:57    6685542 safe_app-nightly-armv7-linux-androideabi.tar.gz
2019-09-30 17:02:58   15041989 safe_app-nightly-x86_64-apple-ios.tar.gz
2019-09-30 17:02:58    4894060 safe_app-nightly-x86_64-apple-darwin.tar.gz
2019-09-30 17:02:58    6685539 safe_app-nightly-x86_64-linux-android.tar.gz
2019-09-30 17:02:59   14646811 safe_authenticator-nightly-aarch64-apple-ios.tar.gz
2019-09-30 17:02:59    5280874 safe_app-nightly-x86_64-unknown-linux-gnu.tar.gz
2019-09-30 17:02:59    9994404 safe_app-nightly-x86_64-pc-windows-gnu.tar.gz
2019-09-30 17:03:00   29466711 safe_authenticator-nightly-apple-ios.tar.gz
2019-09-30 17:03:00    4051081 safe_authenticator-nightly-x86_64-apple-darwin.tar.gz
2019-09-30 17:03:00    5693341 safe_authenticator-nightly-armv7-linux-androideabi.tar.gz
2019-09-30 17:03:01   14814276 safe_authenticator-nightly-x86_64-apple-ios.tar.gz
2019-09-30 17:03:01    5693341 safe_authenticator-nightly-x86_64-linux-android.tar.gz
2019-09-30 17:03:01    9059592 safe_authenticator-nightly-x86_64-pc-windows-gnu.tar.gz
2019-09-30 17:03:02    4415146 safe_authenticator-nightly-x86_64-unknown-linux-gnu.tar.gz
```

The dry run publish for this build failed, but with the help of Marcin, he's determined this should be resolved with a version change, which we will do as a separate PR. This is why the Jenkins build here is marked as failed.

Cheers,

Chris