### PR TITLE
WIP refactor/ffi: move safe_app and safe_auth errors into ffi modules

### DIFF
--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -7,7 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::{App, AppError};
+use crate::ffi::errors::AppError;
+use crate::App;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK};
 use futures::Future;
 use safe_core::ffi::ipc::req::ContainerPermissions;

--- a/safe_app/src/ffi/errors.rs
+++ b/safe_app/src/ffi/errors.rs
@@ -12,6 +12,7 @@ use config_file_handler::Error as ConfigFileHandlerError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
 use maidsafe_utilities::serialisation::SerialisationError;
+pub use safe_core::ffi::errors::shared_codes::*;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::{CoreError, SelfEncryptionStorageError};
@@ -26,24 +27,6 @@ use std::sync::mpsc::{RecvError, RecvTimeoutError};
 
 #[allow(missing_docs)]
 mod codes {
-    // Core errors
-    pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
-    pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
-    pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
-    pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
-    pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
-    pub const ERR_VERSION_CACHE_MISS: i32 = -6;
-    pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
-    pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
-    pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
-    pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
-    pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
-    pub const ERR_OPERATION_ABORTED: i32 = -12;
-    pub const ERR_SELF_ENCRYPTION: i32 = -13;
-    pub const ERR_REQUEST_TIMEOUT: i32 = -14;
-    pub const ERR_CONFIG_FILE: i32 = -15;
-    pub const ERR_IO: i32 = -16;
-
     // Data type errors
     pub const ERR_ACCESS_DENIED: i32 = -100;
     pub const ERR_NO_SUCH_ACCOUNT: i32 = -101;
@@ -67,22 +50,6 @@ mod codes {
     pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -119;
     pub const ERR_KEYS_EXIST: i32 = -120;
 
-    // IPC errors.
-    pub const ERR_AUTH_DENIED: i32 = -200;
-    pub const ERR_CONTAINERS_DENIED: i32 = -201;
-    pub const ERR_INVALID_MSG: i32 = -202;
-    pub const ERR_ALREADY_AUTHORISED: i32 = -203;
-    pub const ERR_UNKNOWN_APP: i32 = -204;
-    pub const ERR_STRING_ERROR: i32 = -205;
-    pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
-    pub const ERR_INVALID_OWNER: i32 = -207;
-    pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
-
-    // NFS errors.
-    pub const ERR_FILE_EXISTS: i32 = -300;
-    pub const ERR_FILE_NOT_FOUND: i32 = -301;
-    pub const ERR_INVALID_RANGE: i32 = -302;
-
     // App errors
     pub const ERR_NO_SUCH_CONTAINER: i32 = -1002;
     pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = -1003;
@@ -95,38 +62,12 @@ mod codes {
     pub const ERR_INVALID_SELF_ENCRYPTOR_HANDLE: i32 = -1010;
     pub const ERR_INVALID_SIGN_PUB_KEY_HANDLE: i32 = -1011;
     pub const ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS: i32 = -1012;
-    pub const ERR_IO_ERROR: i32 = -1013;
     pub const ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE: i32 = -1014;
     pub const ERR_INVALID_FILE_CONTEXT_HANDLE: i32 = -1015;
     pub const ERR_INVALID_FILE_MODE: i32 = -1016;
     pub const ERR_INVALID_SIGN_SEC_KEY_HANDLE: i32 = -1017;
     pub const ERR_UNREGISTERED_CLIENT_ACCESS: i32 = -1018;
     pub const ERR_INVALID_PUB_KEY_HANDLE: i32 = -1019;
-
-    pub const ERR_UNEXPECTED: i32 = -2000;
-
-    // Identity & permission errors.
-    pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
-    pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
-    pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
-    pub const ERR_INVALID_SIGNATURE: i32 = -3004;
-
-    // Coin errors.
-    pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
-    pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
-    pub const ERR_FAILED_TO_PARSE: i32 = -4002;
-    pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
-    pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
-    pub const ERR_BALANCE_EXISTS: i32 = -4005;
-    pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
-
-    // Login packet errors.
-    pub const ERR_EXCEEDED_SIZE: i32 = -5001;
-    pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
-    pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
-
-    // QuicP2P errors.
-    pub const ERR_QUIC_P2P: i32 = -6000;
 }
 
 /// App error.

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -17,6 +17,8 @@ pub mod access_container;
 pub mod cipher_opt;
 /// Crypto-related routines.
 pub mod crypto;
+/// Authentication Errors
+pub mod errors;
 /// Low level manipulation of `ImmutableData`.
 pub mod immutable_data;
 /// IPC utilities.

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -108,7 +108,6 @@ pub use crate::ffi::*;
 
 pub mod cipher_opt;
 mod client;
-mod errors;
 pub mod object_cache;
 pub mod permissions;
 
@@ -119,7 +118,7 @@ mod tests;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
-pub use self::errors::*;
+pub use self::ffi::errors::*;
 pub use client::AppClient;
 
 use self::object_cache::ObjectCache;

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -935,17 +935,16 @@ mod tests {
                 })
                 // Re-insert to check for refunds for a failed insert_login_packet_for operation
                 .then(|result| match result {
-                    Err(CoreError::DataError(SndError::LoginPacketExists)) => Ok::<_, CoreError>(()),
+                    Err(CoreError::DataError(SndError::LoginPacketExists)) => {
+                        Ok::<_, CoreError>(())
+                    }
                     res => panic!("Unexpected {:?}", res),
                 })
                 // Check if coins are refunded
                 .and_then(move |_| c2.get_balance(None))
                 .and_then(move |balance| {
                     let expected = calculate_new_balance(start_bal, Some(2), Some(five_coins));
-                    assert_eq!(
-                        balance,
-                        expected
-                    );
+                    assert_eq!(balance, expected);
                     Ok(())
                 })
         });

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn auth_apps_accessing_mutable_data(
 mod tests {
     use crate::app_auth::{app_state, AppState};
     use crate::app_container::fetch;
-    use crate::errors::{ERR_UNEXPECTED, ERR_UNKNOWN_APP};
+    use crate::ffi::errors::{ERR_UNEXPECTED, ERR_UNKNOWN_APP};
     use crate::revocation::revoke_app;
     use crate::test_utils::{
         create_account_and_login, create_file, fetch_file, get_app_or_err, rand_app, register_app,

--- a/safe_authenticator/src/ffi/errors.rs
+++ b/safe_authenticator/src/ffi/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2019 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
@@ -6,13 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! Errors thrown by Authenticator routines.
-
 pub use self::codes::*;
 use config_file_handler::Error as ConfigFileHandlerError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
 use maidsafe_utilities::serialisation::SerialisationError;
+pub use safe_core::ffi::errors::shared_codes::*;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::CoreError;
@@ -27,24 +26,6 @@ use std::sync::mpsc::RecvError;
 
 #[allow(missing_docs)]
 mod codes {
-    // Core errors
-    pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
-    pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
-    pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
-    pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
-    pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
-    pub const ERR_VERSION_CACHE_MISS: i32 = -6;
-    pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
-    pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
-    pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
-    pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
-    pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
-    pub const ERR_OPERATION_ABORTED: i32 = -12;
-    pub const ERR_SELF_ENCRYPTION: i32 = -13;
-    pub const ERR_REQUEST_TIMEOUT: i32 = -14;
-    pub const ERR_CONFIG_FILE: i32 = -15;
-    pub const ERR_IO: i32 = -16;
-
     // Data type errors
     pub const ERR_ACCESS_DENIED: i32 = -100;
     pub const ERR_NO_SUCH_DATA: i32 = -101;
@@ -61,51 +42,10 @@ mod codes {
     pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -112;
     pub const ERR_KEYS_EXIST: i32 = -113;
 
-    // IPC errors.
-    pub const ERR_AUTH_DENIED: i32 = -200;
-    pub const ERR_CONTAINERS_DENIED: i32 = -201;
-    pub const ERR_INVALID_MSG: i32 = -202;
-    pub const ERR_ALREADY_AUTHORISED: i32 = -203;
-    pub const ERR_UNKNOWN_APP: i32 = -204;
-    pub const ERR_STRING_ERROR: i32 = -205;
-    pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
-    pub const ERR_INVALID_OWNER: i32 = -207;
-    pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
-
-    // NFS errors.
-    pub const ERR_FILE_EXISTS: i32 = -300;
-    pub const ERR_FILE_NOT_FOUND: i32 = -301;
-    pub const ERR_INVALID_RANGE: i32 = -302;
-
     // Authenticator errors.
-    pub const ERR_IO_ERROR: i32 = -1013;
     pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
     pub const ERR_NO_SUCH_CONTAINER: i32 = -1015;
     pub const ERR_PENDING_REVOCATION: i32 = -1016;
-    pub const ERR_UNEXPECTED: i32 = -2000;
-
-    // Identity & permission errors.
-    pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
-    pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
-    pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
-    pub const ERR_INVALID_SIGNATURE: i32 = -3004;
-
-    // Coin errors.
-    pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
-    pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
-    pub const ERR_FAILED_TO_PARSE: i32 = -4002;
-    pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
-    pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
-    pub const ERR_BALANCE_EXISTS: i32 = -4005;
-    pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
-
-    // Login packet errors.
-    pub const ERR_EXCEEDED_SIZE: i32 = -5001;
-    pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
-    pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
-
-    // Quic P2P errors.
-    pub const ERR_QUIC_P2P: i32 = -6000;
 }
 
 /// Authenticator errors.
@@ -266,6 +206,7 @@ impl From<StringError> for AuthError {
 
 impl ErrorCode for AuthError {
     fn error_code(&self) -> i32 {
+        use codes::*;
         match *self {
             Self::CoreError(ref err) => core_error_code(err),
             Self::SndError(ref err) => safe_nd_error_core(err),

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -10,6 +10,8 @@
 
 /// Apps management
 pub mod apps;
+/// Authentication Errors
+pub mod errors;
 /// Authenticator communication with apps
 pub mod ipc;
 /// Logging utilities

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -76,7 +76,6 @@ pub mod app_auth;
 pub mod app_container;
 pub mod apps;
 pub mod config;
-pub mod errors;
 pub mod ffi;
 pub mod ipc;
 pub mod revocation;

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -13,8 +13,8 @@ mod utils;
 
 use crate::access_container as access_container_tools;
 use crate::config::{self, KEY_APPS};
-use crate::errors::{AuthError, ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
 use crate::ffi::apps::*;
+use crate::ffi::errors::{AuthError, ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
 use crate::ffi::ipc::{
     auth_revoke_app, encode_auth_resp, encode_containers_resp, encode_unregistered_resp,
 };

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -6,8 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::errors::{AuthError, ERR_INVALID_OWNER, ERR_NO_SUCH_DATA};
 use crate::ffi::apps::*;
+use crate::ffi::errors::{AuthError, ERR_INVALID_OWNER, ERR_NO_SUCH_DATA};
 use crate::ffi::ipc::encode_share_mdata_resp;
 use crate::run;
 use crate::test_utils::{self, Payload};

--- a/safe_core/src/ffi/errors.rs
+++ b/safe_core/src/ffi/errors.rs
@@ -1,0 +1,75 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#[allow(missing_docs)]
+#[allow(dead_code)]
+pub mod shared_codes {
+    // Core errors
+    pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
+    pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
+    pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
+    pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
+    pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
+    pub const ERR_VERSION_CACHE_MISS: i32 = -6;
+    pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
+    pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
+    pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
+    pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
+    pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
+    pub const ERR_OPERATION_ABORTED: i32 = -12;
+    pub const ERR_SELF_ENCRYPTION: i32 = -13;
+    pub const ERR_REQUEST_TIMEOUT: i32 = -14;
+    pub const ERR_CONFIG_FILE: i32 = -15;
+    pub const ERR_IO: i32 = -16;
+
+    // IPC errors.
+    pub const ERR_AUTH_DENIED: i32 = -200;
+    pub const ERR_CONTAINERS_DENIED: i32 = -201;
+    pub const ERR_INVALID_MSG: i32 = -202;
+    pub const ERR_ALREADY_AUTHORISED: i32 = -203;
+    pub const ERR_UNKNOWN_APP: i32 = -204;
+    pub const ERR_STRING_ERROR: i32 = -205;
+    pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
+    pub const ERR_INVALID_OWNER: i32 = -207;
+    pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
+
+    // NFS errors.
+    pub const ERR_FILE_EXISTS: i32 = -300;
+    pub const ERR_FILE_NOT_FOUND: i32 = -301;
+    pub const ERR_INVALID_RANGE: i32 = -302;
+
+    // IO error.
+    pub const ERR_IO_ERROR: i32 = -1013;
+
+    // Unexpected error.
+    pub const ERR_UNEXPECTED: i32 = -2000;
+
+    // Identity & permission errors.
+    pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
+    pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
+    pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
+    pub const ERR_INVALID_SIGNATURE: i32 = -3004;
+
+    // Coin errors.
+    pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
+    pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
+    pub const ERR_FAILED_TO_PARSE: i32 = -4002;
+    pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
+    pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
+    pub const ERR_BALANCE_EXISTS: i32 = -4005;
+    pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
+
+    // Login packet errors.
+    pub const ERR_EXCEEDED_SIZE: i32 = -5001;
+    pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
+    pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
+
+    // QuicP2P errors.
+    pub const ERR_QUIC_P2P: i32 = -6000;
+}

--- a/safe_core/src/ffi/mod.rs
+++ b/safe_core/src/ffi/mod.rs
@@ -12,11 +12,12 @@
 
 /// Type definitions for arrays that are FFI input params.
 pub mod arrays;
+/// Error codes.
+pub mod errors;
 /// IPC utilities.
 pub mod ipc;
 /// NFS API.
 pub mod nfs;
-
 use self::arrays::*;
 use safe_nd::MDataKind as NativeMDataKind;
 


### PR DESCRIPTION
This PR moves FFI-specific error codes into ffi module.
Common error codes have been moved to safe_core.

Resolves https://github.com/maidsafe/safe_client_libs/issues/1055