### PR TITLE
chore/lints: remove explicitly-listed non-warn lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - RUST_BACKTRACE=1
-    - RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
+    - RUSTFLAGS="-C opt-level=2 -C codegen-units=8 -D warnings"
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust
 rust:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   global:
     RUST_BACKTRACE: 1
+    RUSTFLAGS: "-D warnings"
   matrix:
     - RUST_TOOLCHAIN: stable
 

--- a/safe_app/examples/client_stress_test.rs
+++ b/safe_app/examples/client_stress_test.rs
@@ -9,52 +9,16 @@
 
 //! Safe client example.
 
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 #[macro_use]

--- a/safe_app/examples/self_authentication.rs
+++ b/safe_app/examples/self_authentication.rs
@@ -9,52 +9,16 @@
 
 //! Self-authentication example.
 
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 #[macro_use]

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -15,40 +15,10 @@ maidsafe_logo.png",
     html_favicon_url = "http://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -56,12 +26,9 @@ maidsafe_logo.png",
     unused_qualifications,
     unused_results
 )]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
-)]
+// Our unsafe FFI functions are missing safety documentation. It is probably not necessary for us to
+// provide this for every single function as that would be repetitive and verbose.
+#![allow(clippy::missing_safety_doc)]
 
 #[macro_use]
 extern crate ffi_utils;

--- a/safe_authenticator/src/apps.rs
+++ b/safe_authenticator/src/apps.rs
@@ -62,6 +62,7 @@ impl ReprC for RegisteredApp {
     type C = *const ffi::RegisteredApp;
     type Error = IpcError;
 
+    #[allow(unsafe_code)]
     unsafe fn clone_from_repr_c(repr_c: Self::C) -> Result<Self, Self::Error> {
         Ok(Self {
             app_info: AppExchangeInfo::clone_from_repr_c(&(*repr_c).app_info)?,

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -935,17 +935,16 @@ mod tests {
                 })
                 // Re-insert to check for refunds for a failed insert_login_packet_for operation
                 .then(|result| match result {
-                    Err(CoreError::DataError(SndError::LoginPacketExists)) => Ok::<_, CoreError>(()),
+                    Err(CoreError::DataError(SndError::LoginPacketExists)) => {
+                        Ok::<_, CoreError>(())
+                    }
                     res => panic!("Unexpected {:?}", res),
                 })
                 // Check if coins are refunded
                 .and_then(move |_| c2.get_balance(None))
                 .and_then(move |balance| {
                     let expected = calculate_new_balance(start_bal, Some(2), Some(five_coins));
-                    assert_eq!(
-                        balance,
-                        expected
-                    );
+                    assert_eq!(balance, expected);
                     Ok(())
                 })
         });

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -8,6 +8,8 @@
 
 //! FFI routines.
 
+#![allow(unsafe_code)]
+
 /// Apps management
 pub mod apps;
 /// Authenticator communication with apps

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -13,39 +13,10 @@
     html_favicon_url = "http://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -53,12 +24,9 @@
     unused_qualifications,
     unused_results
 )]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
-)]
+// Our unsafe FFI functions are missing safety documentation. It is probably not necessary for us to
+// provide this for every single function as that would be repetitive and verbose.
+#![allow(clippy::missing_safety_doc)]
 
 #[macro_use]
 extern crate ffi_utils;

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -8,7 +8,7 @@
 
 //! Provides utilities to test the authenticator functionality.
 
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(clippy::not_unsafe_ptr_arg_deref, unsafe_code)]
 
 use crate::client::AuthClient;
 use crate::errors::AuthError;

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![allow(unsafe_code)]
+
 mod revocation;
 mod serialisation;
 mod share_mdata;

--- a/safe_core/src/ipc/req/mod.rs
+++ b/safe_core/src/ipc/req/mod.rs
@@ -165,6 +165,14 @@ where
 ///
 /// After calling this function, the raw pointer is owned by the resulting
 /// object.
+///
+/// # Safety
+///
+/// This function is unsafe as there is no guarantee that the given pointer is valid for len
+/// elements, nor whether the lifetime inferred is a suitable lifetime for the returned slice.
+///
+/// This function also assumes the provided `ffi::ContainerPermissions` is valid, i.e. it was
+/// constructed by calling `containers_into_vec`.
 pub unsafe fn containers_from_repr_c(
     raw: *const FfiContainerPermissions,
     len: usize,

--- a/safe_core/src/ipc/resp.rs
+++ b/safe_core/src/ipc/resp.rs
@@ -268,6 +268,13 @@ pub fn access_container_entry_into_repr_c(
 }
 
 /// Convert FFI representation of `AccessContainerEntry` to native rust representation by cloning.
+///
+/// # Safety
+///
+/// This function dereferences the provided raw pointer, which must be valid.
+///
+/// This function also assumes the provided `ffi::AccessContainerEntry` is valid, i.e. it was
+/// constructed by calling `access_container_into_repr_c`.
 pub unsafe fn access_container_entry_clone_from_repr_c(
     entry: *const ffi::AccessContainerEntry,
 ) -> Result<AccessContainerEntry, IpcError> {

--- a/safe_core/src/lib.rs
+++ b/safe_core/src/lib.rs
@@ -19,53 +19,16 @@
     html_favicon_url = "http://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.
-// com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 #[macro_use]

--- a/scripts/clippy-all
+++ b/scripts/clippy-all
@@ -2,5 +2,8 @@
 
 set -x;
 
+# Deny any warnings that occur.
+export RUSTFLAGS="-D warnings"
+
 scripts/clippy-real &&
   scripts/clippy-mock

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,52 +9,16 @@
 //! Integration tests for Safe Client Libs.
 
 #![cfg(test)]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.
-// com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true,
-    clippy::all,
-    clippy::option_unwrap_used,
-    clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 mod real_network;

--- a/tests/src/real_network.rs
+++ b/tests/src/real_network.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#![allow(unsafe_code)]
+
 use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec};
 use ffi_utils::{from_c_str, FfiResult, ReprC, StringError};
 use safe_app::ffi::app_registered;


### PR DESCRIPTION
We've already done this in `safe_vault`, now trying it here. This change was
prompted by the new `clippy::missing_safety_doc` lint in 1.39.0 breaking our
compiles.

See https://hackmd.io/8odS50_AQV6U1wCHBfbeuw for further motivation.

- Removed all `forbid` items: most are already `deny` by the compiler, not clear
what explicitly forbidding them gives us.

- `unsafe_code` stayed `deny`, other `deny` items removed as they are all `warn`
and will be caught by CI. The `bad_style` lint was deprecated in favor of
`nonstandard_style`, which is also `warn`.

- Existing `warn` items mostly unchanged, except that a couple were added. These
are all `allow` by the compiler, but useful to get warnings about.

- Removed all `allow` items: they are already `allow` by the compiler.

Also explicitly allowed `clippy::missing_safety_doc` with a reason why.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
