### PR TITLE
refactor/ffi: FFI-specific Result types for Safe App and Safe Auth

### DIFF
--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -176,6 +176,12 @@ impl From<Utf8Error> for AppError {
     }
 }
 
+impl From<crate::ffi::errors::Error> for AppError {
+    fn from(err: crate::ffi::errors::Error) -> Self {
+        err.into()
+    }
+}
+
 impl From<StringError> for AppError {
     fn from(_err: StringError) -> Self {
         Self::EncodeDecodeError
@@ -228,5 +234,11 @@ impl From<RecvTimeoutError> for AppError {
     fn from(_err: RecvTimeoutError) -> Self {
         // TODO: change this to err.description() once that lands in stable.
         Self::from("mpsc receive error")
+    }
+}
+
+impl From<FromBytesError> for AppError {
+    fn from(err: FromBytesError) -> Self {
+        Self::from(err.to_string())
     }
 }

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -7,14 +7,12 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-pub use self::codes::*;
 use bincode::Error as SerialisationError;
-use ffi_utils::{ErrorCode, StringError};
+use ffi_utils::StringError;
 use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::{CoreError, SelfEncryptionStorageError};
-use safe_nd::Error as SndError;
 use self_encryption::SelfEncryptionError;
 use std::error::Error;
 use std::ffi::NulError;
@@ -23,111 +21,6 @@ use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::sync::mpsc::{RecvError, RecvTimeoutError};
 use threshold_crypto::error::FromBytesError;
-
-#[allow(missing_docs)]
-mod codes {
-    // Core errors
-    pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
-    pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
-    pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
-    pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
-    pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
-    pub const ERR_VERSION_CACHE_MISS: i32 = -6;
-    pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
-    pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
-    pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
-    pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
-    pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
-    pub const ERR_OPERATION_ABORTED: i32 = -12;
-    pub const ERR_SELF_ENCRYPTION: i32 = -13;
-    pub const ERR_REQUEST_TIMEOUT: i32 = -14;
-    pub const ERR_CONFIG_FILE: i32 = -15;
-    pub const ERR_IO: i32 = -16;
-
-    // Data type errors
-    pub const ERR_ACCESS_DENIED: i32 = -100;
-    pub const ERR_NO_SUCH_ACCOUNT: i32 = -101;
-    pub const ERR_ACCOUNT_EXISTS: i32 = -102;
-    pub const ERR_NO_SUCH_DATA: i32 = -103;
-    pub const ERR_DATA_EXISTS: i32 = -104;
-    pub const ERR_DATA_TOO_LARGE: i32 = -105;
-    pub const ERR_NO_SUCH_ENTRY: i32 = -106;
-    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -107;
-    pub const ERR_TOO_MANY_ENTRIES: i32 = -108;
-    pub const ERR_NO_SUCH_KEY: i32 = -109;
-    pub const ERR_INVALID_OWNERS: i32 = -110;
-    pub const ERR_INVALID_SUCCESSOR: i32 = -111;
-    pub const ERR_INVALID_OPERATION: i32 = -112;
-    pub const ERR_LOW_BALANCE: i32 = -113;
-    pub const ERR_NETWORK_FULL: i32 = -114;
-    pub const ERR_NETWORK_OTHER: i32 = -115;
-    pub const ERR_INVALID_INVITATION: i32 = -116;
-    pub const ERR_INVITATION_ALREADY_CLAIMED: i32 = -117;
-    pub const ERR_DUPLICATE_MSG_ID: i32 = -118;
-    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -119;
-    pub const ERR_KEYS_EXIST: i32 = -120;
-
-    // IPC errors.
-    pub const ERR_AUTH_DENIED: i32 = -200;
-    pub const ERR_CONTAINERS_DENIED: i32 = -201;
-    pub const ERR_INVALID_MSG: i32 = -202;
-    pub const ERR_ALREADY_AUTHORISED: i32 = -203;
-    pub const ERR_UNKNOWN_APP: i32 = -204;
-    pub const ERR_STRING_ERROR: i32 = -205;
-    pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
-    pub const ERR_INVALID_OWNER: i32 = -207;
-    pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
-
-    // NFS errors.
-    pub const ERR_FILE_EXISTS: i32 = -300;
-    pub const ERR_FILE_NOT_FOUND: i32 = -301;
-    pub const ERR_INVALID_RANGE: i32 = -302;
-
-    // App errors
-    pub const ERR_NO_SUCH_CONTAINER: i32 = -1002;
-    pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = -1003;
-    pub const ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE: i32 = -1004;
-    pub const ERR_INVALID_MDATA_INFO_HANDLE: i32 = -1005;
-    pub const ERR_INVALID_MDATA_ENTRIES_HANDLE: i32 = -1006;
-    pub const ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE: i32 = -1007;
-    pub const ERR_INVALID_MDATA_PERMISSIONS_HANDLE: i32 = -1008;
-    pub const ERR_INVALID_MDATA_PERMISSION_SET_HANDLE: i32 = -1009;
-    pub const ERR_INVALID_SELF_ENCRYPTOR_HANDLE: i32 = -1010;
-    pub const ERR_INVALID_SIGN_PUB_KEY_HANDLE: i32 = -1011;
-    pub const ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS: i32 = -1012;
-    pub const ERR_IO_ERROR: i32 = -1013;
-    pub const ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE: i32 = -1014;
-    pub const ERR_INVALID_FILE_CONTEXT_HANDLE: i32 = -1015;
-    pub const ERR_INVALID_FILE_MODE: i32 = -1016;
-    pub const ERR_INVALID_SIGN_SEC_KEY_HANDLE: i32 = -1017;
-    pub const ERR_UNREGISTERED_CLIENT_ACCESS: i32 = -1018;
-    pub const ERR_INVALID_PUB_KEY_HANDLE: i32 = -1019;
-
-    pub const ERR_UNEXPECTED: i32 = -2000;
-
-    // Identity & permission errors.
-    pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
-    pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
-    pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
-    pub const ERR_INVALID_SIGNATURE: i32 = -3004;
-
-    // Coin errors.
-    pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
-    pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
-    pub const ERR_FAILED_TO_PARSE: i32 = -4002;
-    pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
-    pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
-    pub const ERR_BALANCE_EXISTS: i32 = -4005;
-    pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
-
-    // Login packet errors.
-    pub const ERR_EXCEEDED_SIZE: i32 = -5001;
-    pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
-    pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
-
-    // QuicP2P errors.
-    pub const ERR_QUIC_P2P: i32 = -6000;
-}
 
 /// App error.
 #[derive(Debug)]
@@ -335,114 +228,5 @@ impl From<RecvTimeoutError> for AppError {
     fn from(_err: RecvTimeoutError) -> Self {
         // TODO: change this to err.description() once that lands in stable.
         Self::from("mpsc receive error")
-    }
-}
-
-impl From<FromBytesError> for AppError {
-    fn from(err: FromBytesError) -> Self {
-        Self::from(err.to_string())
-    }
-}
-
-impl ErrorCode for AppError {
-    fn error_code(&self) -> i32 {
-        match *self {
-            Self::CoreError(ref err) => core_error_code(err),
-            Self::IpcError(ref err) => match *err {
-                IpcError::AuthDenied => ERR_AUTH_DENIED,
-                IpcError::ContainersDenied => ERR_CONTAINERS_DENIED,
-                IpcError::InvalidMsg => ERR_INVALID_MSG,
-                IpcError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
-                IpcError::AlreadyAuthorised => ERR_ALREADY_AUTHORISED,
-                IpcError::UnknownApp => ERR_UNKNOWN_APP,
-                IpcError::Unexpected(_) => ERR_UNEXPECTED,
-                IpcError::StringError(_) => ERR_STRING_ERROR,
-                IpcError::ShareMDataDenied => ERR_SHARE_MDATA_DENIED,
-                IpcError::InvalidOwner(..) => ERR_INVALID_OWNER,
-                IpcError::IncompatibleMockStatus => ERR_INCOMPATIBLE_MOCK_STATUS,
-            },
-            Self::NfsError(ref err) => match *err {
-                NfsError::CoreError(ref err) => core_error_code(err),
-                NfsError::FileExists => ERR_FILE_EXISTS,
-                NfsError::FileNotFound => ERR_FILE_NOT_FOUND,
-                NfsError::InvalidRange => ERR_INVALID_RANGE,
-                NfsError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
-                NfsError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
-                NfsError::Unexpected(_) => ERR_UNEXPECTED,
-            },
-            Self::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
-            Self::OperationForbidden => ERR_OPERATION_FORBIDDEN,
-            Self::NoSuchContainer(_) => ERR_NO_SUCH_CONTAINER,
-            Self::InvalidCipherOptHandle => ERR_INVALID_CIPHER_OPT_HANDLE,
-            Self::InvalidEncryptPubKeyHandle => ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE,
-            Self::InvalidMDataEntriesHandle => ERR_INVALID_MDATA_ENTRIES_HANDLE,
-            Self::InvalidMDataEntryActionsHandle => ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE,
-            Self::InvalidMDataPermissionsHandle => ERR_INVALID_MDATA_PERMISSIONS_HANDLE,
-            Self::InvalidSelfEncryptorHandle => ERR_INVALID_SELF_ENCRYPTOR_HANDLE,
-            Self::InvalidSignPubKeyHandle => ERR_INVALID_SIGN_PUB_KEY_HANDLE,
-            Self::InvalidSignSecKeyHandle => ERR_INVALID_SIGN_SEC_KEY_HANDLE,
-            Self::InvalidEncryptSecKeyHandle => ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE,
-            Self::InvalidPubKeyHandle => ERR_INVALID_PUB_KEY_HANDLE,
-            Self::InvalidFileContextHandle => ERR_INVALID_FILE_CONTEXT_HANDLE,
-            Self::InvalidFileMode => ERR_INVALID_FILE_MODE,
-            Self::UnregisteredClientAccess => ERR_UNREGISTERED_CLIENT_ACCESS,
-            Self::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
-            Self::InvalidSelfEncryptorReadOffsets => ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS,
-            Self::IoError(_) => ERR_IO_ERROR,
-            Self::Unexpected(_) => ERR_UNEXPECTED,
-        }
-    }
-}
-
-fn core_error_code(err: &CoreError) -> i32 {
-    match *err {
-        CoreError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
-        CoreError::AsymmetricDecipherFailure => ERR_ASYMMETRIC_DECIPHER_FAILURE,
-        CoreError::SymmetricDecipherFailure => ERR_SYMMETRIC_DECIPHER_FAILURE,
-        CoreError::ReceivedUnexpectedData => ERR_RECEIVED_UNEXPECTED_DATA,
-        CoreError::ReceivedUnexpectedEvent => ERR_RECEIVED_UNEXPECTED_EVENT,
-        CoreError::VersionCacheMiss => ERR_VERSION_CACHE_MISS,
-        CoreError::RootDirectoryExists => ERR_ROOT_DIRECTORY_EXISTS,
-        CoreError::RandomDataGenerationFailure => ERR_RANDOM_DATA_GENERATION_FAILURE,
-        CoreError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
-        CoreError::DataError(ref err) => match *err {
-            SndError::AccessDenied => ERR_ACCESS_DENIED,
-            SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
-            SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,
-            SndError::NoSuchData => ERR_NO_SUCH_DATA,
-            SndError::DataExists => ERR_DATA_EXISTS,
-            SndError::NoSuchEntry => ERR_NO_SUCH_ENTRY,
-            SndError::TooManyEntries => ERR_TOO_MANY_ENTRIES,
-            SndError::InvalidEntryActions(_) => ERR_INVALID_ENTRY_ACTIONS,
-            SndError::NoSuchKey => ERR_NO_SUCH_KEY,
-            SndError::KeysExist(_) => ERR_KEYS_EXIST,
-            SndError::DuplicateEntryKeys => ERR_DUPLICATE_ENTRY_KEYS,
-            SndError::DuplicateMessageId => ERR_DUPLICATE_MSG_ID,
-            SndError::InvalidOwners => ERR_INVALID_OWNERS,
-            SndError::InvalidSuccessor(_) => ERR_INVALID_SUCCESSOR,
-            SndError::InvalidOperation => ERR_INVALID_OPERATION,
-            SndError::NetworkOther(_) => ERR_NETWORK_OTHER,
-            SndError::InvalidOwnersSuccessor(_) => ERR_INVALID_OWNERS_SUCCESSOR,
-            SndError::InvalidPermissionsSuccessor(_) => ERR_INVALID_PERMISSIONS_SUCCESSOR,
-            SndError::SigningKeyTypeMismatch => ERR_SIGN_KEYTYPE_MISMATCH,
-            SndError::InvalidSignature => ERR_INVALID_SIGNATURE,
-            SndError::LossOfPrecision => ERR_LOSS_OF_PRECISION,
-            SndError::ExcessiveValue => ERR_EXCESSIVE_VALUE,
-            SndError::NoSuchBalance => ERR_NO_SUCH_BALANCE,
-            SndError::BalanceExists => ERR_BALANCE_EXISTS,
-            SndError::FailedToParse(_) => ERR_FAILED_TO_PARSE,
-            SndError::TransactionIdExists => ERR_TRANSACTION_ID_EXISTS,
-            SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
-            SndError::ExceededSize => ERR_EXCEEDED_SIZE,
-        },
-        CoreError::QuicP2p(ref _error) => ERR_QUIC_P2P, // FIXME: use proper error codes
-        CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
-        CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
-        CoreError::OperationAborted => ERR_OPERATION_ABORTED,
-        CoreError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
-        CoreError::RequestTimeout => ERR_REQUEST_TIMEOUT,
-        CoreError::ConfigError(_) => ERR_CONFIG_FILE,
-        CoreError::IoError(_) => ERR_IO,
-        CoreError::Unexpected(_) => ERR_UNEXPECTED,
     }
 }

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -176,12 +176,6 @@ impl From<Utf8Error> for AppError {
     }
 }
 
-impl From<crate::ffi::errors::Error> for AppError {
-    fn from(err: crate::ffi::errors::Error) -> Self {
-        err.into()
-    }
-}
-
 impl From<StringError> for AppError {
     fn from(_err: StringError) -> Self {
         Self::EncodeDecodeError

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -13,6 +13,7 @@ use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::{CoreError, SelfEncryptionStorageError};
+use safe_nd::Error as SndError;
 use self_encryption::SelfEncryptionError;
 use std::error::Error;
 use std::ffi::NulError;
@@ -28,6 +29,8 @@ use threshold_crypto::error::FromBytesError;
 pub enum AppError {
     /// Error from safe_core.
     CoreError(CoreError),
+    /// Error from safe-nd
+    SndError(SndError),
     /// IPC error.
     IpcError(IpcError),
     /// NFS error.
@@ -81,6 +84,7 @@ impl Display for AppError {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match *self {
             Self::CoreError(ref error) => write!(formatter, "Core error: {}", error),
+            Self::SndError(ref error) => write!(formatter, "Safe ND error: {}", error),
             Self::IpcError(ref error) => write!(formatter, "IPC error: {:?}", error),
             Self::NfsError(ref error) => write!(formatter, "NFS error: {}", error),
             Self::EncodeDecodeError => write!(formatter, "Serialisation error"),
@@ -191,6 +195,12 @@ impl From<SelfEncryptionError<SelfEncryptionStorageError>> for AppError {
 impl From<IoError> for AppError {
     fn from(err: IoError) -> Self {
         Self::IoError(err)
+    }
+}
+
+impl From<SndError> for AppError {
+    fn from(error: SndError) -> Self {
+        Self::SndError(error)
     }
 }
 

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn access_container_fetch(
         container_perms_len: usize,
     ),
 ) {
-    let f = || {
+    catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
         (*app).send(move |client, context| {
@@ -81,8 +81,7 @@ pub unsafe extern "C" fn access_container_fetch(
                 .into_box()
                 .into()
         })
-    };
-    catch_unwind_cb(user_data, o_cb, f)
+    });
 }
 
 /// Retrieve `MDataInfo` for the given container name from the access container.
@@ -97,7 +96,7 @@ pub unsafe extern "C" fn access_container_get_container_mdata_info(
         mdata_info: *const MDataInfo,
     ),
 ) {
-    let f = || {
+    catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
         let name = String::clone_from_repr_c(name)?;
 
@@ -122,8 +121,7 @@ pub unsafe extern "C" fn access_container_get_container_mdata_info(
                 .into_box()
                 .into()
         })
-    };
-    catch_unwind_cb(user_data, o_cb, f)
+    });
 }
 
 #[cfg(test)]

--- a/safe_app/src/ffi/access_container.rs
+++ b/safe_app/src/ffi/access_container.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn access_container_refresh_access_info(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
-    let f = || {
+    catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
         (*app)
@@ -40,8 +40,7 @@ pub unsafe extern "C" fn access_container_refresh_access_info(
                     .into()
             })
             .map_err(Error::from)
-    };
-    catch_unwind_cb(user_data, o_cb, f)
+    });
 }
 
 /// Retrieve a list of container names that an app has access to.

--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -8,6 +8,7 @@
 // Software.
 
 use crate::cipher_opt::CipherOpt;
+use crate::ffi::errors::Error;
 use crate::ffi::object_cache::{CipherOptHandle, EncryptPubKeyHandle};
 use crate::App;
 use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, FFI_RESULT_OK};
@@ -23,13 +24,15 @@ pub unsafe extern "C" fn cipher_opt_new_plaintext(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app).send(move |_, context| {
-            let handle = context
-                .object_cache()
-                .insert_cipher_opt(CipherOpt::PlainText);
-            o_cb(user_data.0, FFI_RESULT_OK, handle);
-            None
-        })
+        (*app)
+            .send(move |_, context| {
+                let handle = context
+                    .object_cache()
+                    .insert_cipher_opt(CipherOpt::PlainText);
+                o_cb(user_data.0, FFI_RESULT_OK, handle);
+                None
+            })
+            .map_err(Error::from)
     });
 }
 
@@ -42,13 +45,15 @@ pub unsafe extern "C" fn cipher_opt_new_symmetric(
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
-        (*app).send(move |_, context| {
-            let handle = context
-                .object_cache()
-                .insert_cipher_opt(CipherOpt::Symmetric);
-            o_cb(user_data.0, FFI_RESULT_OK, handle);
-            None
-        })
+        (*app)
+            .send(move |_, context| {
+                let handle = context
+                    .object_cache()
+                    .insert_cipher_opt(CipherOpt::Symmetric);
+                o_cb(user_data.0, FFI_RESULT_OK, handle);
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -63,20 +68,25 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app).send(move |_, context| {
-            let pk = try_cb!(
-                context.object_cache().get_encrypt_key(peer_encrypt_key_h),
-                user_data,
-                o_cb
-            );
-            let handle = context
-                .object_cache()
-                .insert_cipher_opt(CipherOpt::Asymmetric {
-                    peer_encrypt_key: *pk,
-                });
-            o_cb(user_data.0, FFI_RESULT_OK, handle);
-            None
-        })
+        (*app)
+            .send(move |_, context| {
+                let pk = try_cb!(
+                    context
+                        .object_cache()
+                        .get_encrypt_key(peer_encrypt_key_h)
+                        .map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
+                let handle = context
+                    .object_cache()
+                    .insert_cipher_opt(CipherOpt::Asymmetric {
+                        peer_encrypt_key: *pk,
+                    });
+                o_cb(user_data.0, FFI_RESULT_OK, handle);
+                None
+            })
+            .map_err(Error::from)
     });
 }
 
@@ -91,11 +101,16 @@ pub unsafe extern "C" fn cipher_opt_free(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app).send(move |_, context| {
-            let res = context.object_cache().remove_cipher_opt(handle);
-            call_result_cb!(res, user_data, o_cb);
-            None
-        })
+        (*app)
+            .send(move |_, context| {
+                let res = context
+                    .object_cache()
+                    .remove_cipher_opt(handle)
+                    .map_err(Error::from);
+                call_result_cb!(res, user_data, o_cb);
+                None
+            })
+            .map_err(Error::from)
     });
 }
 
@@ -103,12 +118,13 @@ pub unsafe extern "C" fn cipher_opt_free(
 mod tests {
     use super::*;
     use crate::client::AppClient;
-    use crate::errors::AppError;
+    use crate::ffi::errors::codes::{
+        ERR_INVALID_CIPHER_OPT_HANDLE, ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE,
+    };
     use crate::ffi::object_cache::CipherOptHandle;
     use crate::test_utils::create_app;
     use crate::{run, App, AppContext};
     use ffi_utils::test_utils::{call_0, call_1};
-    use ffi_utils::ErrorCode;
     use safe_core::{utils, Client};
 
     // Test plaintext "encryption" and decryption.
@@ -254,7 +270,7 @@ mod tests {
         let cipher_opt_handle_sym =
             unsafe { unwrap!(call_1(|ud, cb| cipher_opt_new_symmetric(&app, ud, cb))) };
         let cipher_opt_handle_asym = unsafe {
-            let err_code = AppError::InvalidEncryptPubKeyHandle.error_code();
+            let err_code = ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE;
             let res: Result<CipherOptHandle, _> =
                 call_1(|ud, cb| cipher_opt_new_asymmetric(&app, 29_293_290, ud, cb));
             assert_eq!(unwrap!(res.err()), err_code);
@@ -279,7 +295,7 @@ mod tests {
         assert_free(&app, cipher_opt_handle_sym, 0);
         assert_free(&app, cipher_opt_handle_asym, 0);
 
-        let err_code = AppError::InvalidCipherOptHandle.error_code();
+        let err_code = ERR_INVALID_CIPHER_OPT_HANDLE;
         assert_free(&app, cipher_opt_handle_pt, err_code);
         assert_free(&app, cipher_opt_handle_sym, err_code);
         assert_free(&app, cipher_opt_handle_asym, err_code);

--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -24,15 +24,13 @@ pub unsafe extern "C" fn cipher_opt_new_plaintext(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app)
-            .send(move |_, context| {
-                let handle = context
-                    .object_cache()
-                    .insert_cipher_opt(CipherOpt::PlainText);
-                o_cb(user_data.0, FFI_RESULT_OK, handle);
-                None
-            })
-            .map_err(Error::from)
+        (*app).send(move |_, context| {
+            let handle = context
+                .object_cache()
+                .insert_cipher_opt(CipherOpt::PlainText);
+            o_cb(user_data.0, FFI_RESULT_OK, handle);
+            None
+        })
     });
 }
 
@@ -45,15 +43,13 @@ pub unsafe extern "C" fn cipher_opt_new_symmetric(
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
-        (*app)
-            .send(move |_, context| {
-                let handle = context
-                    .object_cache()
-                    .insert_cipher_opt(CipherOpt::Symmetric);
-                o_cb(user_data.0, FFI_RESULT_OK, handle);
-                None
-            })
-            .map_err(Error::from)
+        (*app).send(move |_, context| {
+            let handle = context
+                .object_cache()
+                .insert_cipher_opt(CipherOpt::Symmetric);
+            o_cb(user_data.0, FFI_RESULT_OK, handle);
+            None
+        })
     })
 }
 
@@ -68,25 +64,23 @@ pub unsafe extern "C" fn cipher_opt_new_asymmetric(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app)
-            .send(move |_, context| {
-                let pk = try_cb!(
-                    context
-                        .object_cache()
-                        .get_encrypt_key(peer_encrypt_key_h)
-                        .map_err(Error::from),
-                    user_data,
-                    o_cb
-                );
-                let handle = context
+        (*app).send(move |_, context| {
+            let pk = try_cb!(
+                context
                     .object_cache()
-                    .insert_cipher_opt(CipherOpt::Asymmetric {
-                        peer_encrypt_key: *pk,
-                    });
-                o_cb(user_data.0, FFI_RESULT_OK, handle);
-                None
-            })
-            .map_err(Error::from)
+                    .get_encrypt_key(peer_encrypt_key_h)
+                    .map_err(Error::from),
+                user_data,
+                o_cb
+            );
+            let handle = context
+                .object_cache()
+                .insert_cipher_opt(CipherOpt::Asymmetric {
+                    peer_encrypt_key: *pk,
+                });
+            o_cb(user_data.0, FFI_RESULT_OK, handle);
+            None
+        })
     });
 }
 

--- a/safe_app/src/ffi/cipher_opt.rs
+++ b/safe_app/src/ffi/cipher_opt.rs
@@ -95,16 +95,14 @@ pub unsafe extern "C" fn cipher_opt_free(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app)
-            .send(move |_, context| {
-                let res = context
-                    .object_cache()
-                    .remove_cipher_opt(handle)
-                    .map_err(Error::from);
-                call_result_cb!(res, user_data, o_cb);
-                None
-            })
-            .map_err(Error::from)
+        (*app).send(move |_, context| {
+            let res = context
+                .object_cache()
+                .remove_cipher_opt(handle)
+                .map_err(Error::from);
+            call_result_cb!(res, user_data, o_cb);
+            None
+        })
     });
 }
 

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -8,6 +8,7 @@
 // Software.
 
 use crate::errors::AppError;
+use crate::ffi::errors::{Error, Result};
 use crate::ffi::helper::send_sync;
 use crate::ffi::object_cache::{
     EncryptPubKeyHandle, EncryptSecKeyHandle, SignPubKeyHandle, SignSecKeyHandle,
@@ -65,19 +66,21 @@ pub unsafe extern "C" fn sign_generate_key_pair(
         let public_key = *full_id.public_id().public_key();
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_, context| {
-            let public_key_handle = context.object_cache().insert_pub_sign_key(public_key);
-            let secret_key_handle = context.object_cache().insert_sec_sign_key(full_id);
+        (*app)
+            .send(move |_, context| {
+                let public_key_handle = context.object_cache().insert_pub_sign_key(public_key);
+                let secret_key_handle = context.object_cache().insert_sec_sign_key(full_id);
 
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                public_key_handle,
-                secret_key_handle,
-            );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    public_key_handle,
+                    secret_key_handle,
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -255,19 +258,21 @@ pub unsafe extern "C" fn enc_generate_key_pair(
         let (our_public_key, our_secret_key) = shared_box::gen_keypair();
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_, context| {
-            let public_key_handle = context.object_cache().insert_encrypt_key(our_public_key);
-            let secret_key_handle = context.object_cache().insert_secret_key(our_secret_key);
+        (*app)
+            .send(move |_, context| {
+                let public_key_handle = context.object_cache().insert_encrypt_key(our_public_key);
+                let secret_key_handle = context.object_cache().insert_secret_key(our_secret_key);
 
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                public_key_handle,
-                secret_key_handle,
-            );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    public_key_handle,
+                    secret_key_handle,
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -421,26 +426,28 @@ pub unsafe extern "C" fn sign(
         let plaintext = vec_clone_from_raw_parts(data, data_len);
 
         let user_data = OpaqueCtx(user_data);
-        (*app).send(move |client, context| {
-            let signature = if sign_sk_h == SIGN_WITH_APP {
-                let safe_key = client.full_id();
-                safe_key.sign(&plaintext)
-            } else {
-                let sign_sk = try_cb!(
-                    context.object_cache().get_sec_sign_key(sign_sk_h),
-                    user_data,
-                    o_cb
-                );
-                sign_sk.sign(&plaintext)
-            };
-            match serialize(&signature) {
-                Ok(result) => o_cb(user_data.0, FFI_RESULT_OK, result.as_ptr(), result.len()),
-                res @ Err(..) => {
-                    call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+        (*app)
+            .send(move |client, context| {
+                let signature = if sign_sk_h == SIGN_WITH_APP {
+                    let safe_key = client.full_id();
+                    safe_key.sign(&plaintext)
+                } else {
+                    let sign_sk = try_cb!(
+                        context.object_cache().get_sec_sign_key(sign_sk_h),
+                        user_data,
+                        o_cb
+                    );
+                    sign_sk.sign(&plaintext)
+                };
+                match serialize(&signature) {
+                    Ok(result) => o_cb(user_data.0, FFI_RESULT_OK, result.as_ptr(), result.len()),
+                    res @ Err(..) => {
+                        call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                    }
                 }
-            }
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -464,22 +471,24 @@ pub unsafe extern "C" fn verify(
         let signature_array = vec_clone_from_raw_parts(signature, signature_len);
         let signature: Signature = deserialize(&signature_array)?;
 
-        (*app).send(move |client, context| {
-            let sign_pk: PublicKey = if sign_pk_h == VERIFY_WITH_APP {
-                client.public_key()
-            } else {
-                let sign_pk = try_cb!(
-                    context.object_cache().get_pub_sign_key(sign_pk_h),
-                    user_data,
-                    o_cb
-                );
-                *sign_pk
-            };
-            let result = sign_pk.verify(&signature, &signed);
+        (*app)
+            .send(move |client, context| {
+                let sign_pk: PublicKey = if sign_pk_h == VERIFY_WITH_APP {
+                    client.public_key()
+                } else {
+                    let sign_pk = try_cb!(
+                        context.object_cache().get_pub_sign_key(sign_pk_h),
+                        user_data,
+                        o_cb
+                    );
+                    *sign_pk
+                };
+                let result = sign_pk.verify(&signature, &signed);
 
-            o_cb(user_data.0, FFI_RESULT_OK, result.is_ok() as u32);
-            None
-        })
+                o_cb(user_data.0, FFI_RESULT_OK, result.is_ok() as u32);
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -522,10 +531,10 @@ pub unsafe extern "C" fn encrypt(
                 res @ Err(..) => {
                     call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
                 }
-            }
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -575,10 +584,10 @@ pub unsafe extern "C" fn decrypt(
                 res @ Err(..) => {
                     call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
                 }
-            }
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }*/
 
@@ -603,21 +612,23 @@ pub unsafe extern "C" fn encrypt_sealed_box(
         let plaintext = vec_clone_from_raw_parts(data, data_len);
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_, context| {
-            let pk: AsymEncryptKey = *try_cb!(
-                context.object_cache().get_encrypt_key(public_key_h),
-                user_data,
-                o_cb
-            );
+        (*app)
+            .send(move |_, context| {
+                let pk: AsymEncryptKey = *try_cb!(
+                    context.object_cache().get_encrypt_key(public_key_h),
+                    user_data,
+                    o_cb
+                );
 
-            match serialize(&pk.encrypt(plaintext)) {
-                Ok(result) => o_cb(user_data.0, FFI_RESULT_OK, result.as_ptr(), result.len()),
-                res @ Err(..) => {
-                    call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                match serialize(&pk.encrypt(plaintext)) {
+                    Ok(result) => o_cb(user_data.0, FFI_RESULT_OK, result.as_ptr(), result.len()),
+                    res @ Err(..) => {
+                        call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
+                    }
                 }
-            }
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -642,28 +653,30 @@ pub unsafe extern "C" fn decrypt_sealed_box(
         let user_data = OpaqueCtx(user_data);
         let plaintext = vec_clone_from_raw_parts(data, data_len);
         let deserialized: Ciphertext = deserialize(plaintext.as_slice()).map_err(AppError::from)?;
-        (*app).send(move |_, context| {
-            let sk = try_cb!(
-                context.object_cache().get_secret_key(secret_key_h),
-                user_data,
-                o_cb
-            );
+        (*app)
+            .send(move |_, context| {
+                let sk = try_cb!(
+                    context.object_cache().get_secret_key(secret_key_h),
+                    user_data,
+                    o_cb
+                );
 
-            let plaintext = try_cb!(
-                sk.decrypt(&deserialized)
-                    .ok_or_else(|| AppError::EncodeDecodeError),
-                user_data,
-                o_cb
-            );
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                plaintext.as_ptr(),
-                plaintext.len(),
-            );
+                let plaintext = try_cb!(
+                    sk.decrypt(&deserialized)
+                        .ok_or_else(|| AppError::EncodeDecodeError),
+                    user_data,
+                    o_cb
+                );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    plaintext.as_ptr(),
+                    plaintext.len(),
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -680,7 +693,7 @@ pub unsafe extern "C" fn sha3_hash(
         hash_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let plaintext = slice::from_raw_parts(data, data_len);
 
         let hash = sha3_256(plaintext);
@@ -693,7 +706,7 @@ pub unsafe extern "C" fn sha3_hash(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::errors::ERR_INVALID_SIGN_PUB_KEY_HANDLE;
+    use crate::ffi::errors::ERR_INVALID_SIGN_PUB_KEY_HANDLE;
     use crate::ffi::mutable_data::permissions::USER_ANYONE;
     use crate::run;
     use crate::test_utils::create_app;

--- a/safe_app/src/ffi/errors.rs
+++ b/safe_app/src/ffi/errors.rs
@@ -1,0 +1,297 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+pub use crate::ffi::errors::codes::*;
+pub use safe_core::ffi::error_codes::*;
+
+use crate::errors::AppError;
+use config_file_handler::Error as ConfigFileHandlerError;
+use ffi_utils::{ErrorCode, StringError};
+use futures::sync::mpsc::SendError;
+use maidsafe_utilities::serialisation::SerialisationError;
+use safe_core::ipc::IpcError;
+use safe_core::nfs::NfsError;
+use safe_core::{CoreError, SelfEncryptionStorageError};
+use safe_nd::Error as SndError;
+use self_encryption::SelfEncryptionError;
+use std::ffi::NulError;
+use std::fmt::{self, Display, Formatter};
+use std::io::Error as IoError;
+use std::str::Utf8Error;
+use std::sync::mpsc::{RecvError, RecvTimeoutError};
+
+#[allow(missing_docs)]
+pub mod codes {
+    // Data type errors
+    pub const ERR_NO_SUCH_ACCOUNT: i32 = -101;
+    pub const ERR_ACCOUNT_EXISTS: i32 = -102;
+    pub const ERR_NO_SUCH_DATA: i32 = -103;
+    pub const ERR_DATA_EXISTS: i32 = -104;
+    pub const ERR_DATA_TOO_LARGE: i32 = -105;
+    pub const ERR_NO_SUCH_ENTRY: i32 = -106;
+    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -107;
+    pub const ERR_TOO_MANY_ENTRIES: i32 = -108;
+    pub const ERR_NO_SUCH_KEY: i32 = -109;
+    pub const ERR_INVALID_OWNERS: i32 = -110;
+    pub const ERR_INVALID_SUCCESSOR: i32 = -111;
+    pub const ERR_INVALID_OPERATION: i32 = -112;
+    pub const ERR_LOW_BALANCE: i32 = -113;
+    pub const ERR_NETWORK_FULL: i32 = -114;
+    pub const ERR_NETWORK_OTHER: i32 = -115;
+    pub const ERR_INVALID_INVITATION: i32 = -116;
+    pub const ERR_INVITATION_ALREADY_CLAIMED: i32 = -117;
+    pub const ERR_DUPLICATE_MSG_ID: i32 = -118;
+    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -119;
+    pub const ERR_KEYS_EXIST: i32 = -120;
+
+    // App errors
+    pub const ERR_NO_SUCH_CONTAINER: i32 = -1002;
+    pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = -1003;
+    pub const ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE: i32 = -1004;
+    pub const ERR_INVALID_MDATA_INFO_HANDLE: i32 = -1005;
+    pub const ERR_INVALID_MDATA_ENTRIES_HANDLE: i32 = -1006;
+    pub const ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE: i32 = -1007;
+    pub const ERR_INVALID_MDATA_PERMISSIONS_HANDLE: i32 = -1008;
+    pub const ERR_INVALID_MDATA_PERMISSION_SET_HANDLE: i32 = -1009;
+    pub const ERR_INVALID_SELF_ENCRYPTOR_HANDLE: i32 = -1010;
+    pub const ERR_INVALID_SIGN_PUB_KEY_HANDLE: i32 = -1011;
+    pub const ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS: i32 = -1012;
+    pub const ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE: i32 = -1014;
+    pub const ERR_INVALID_FILE_CONTEXT_HANDLE: i32 = -1015;
+    pub const ERR_INVALID_FILE_MODE: i32 = -1016;
+    pub const ERR_INVALID_SIGN_SEC_KEY_HANDLE: i32 = -1017;
+    pub const ERR_UNREGISTERED_CLIENT_ACCESS: i32 = -1018;
+    pub const ERR_INVALID_PUB_KEY_HANDLE: i32 = -1019;
+}
+
+/// FFI Result type
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// FFI Error type
+#[derive(Debug)]
+pub struct Error(AppError);
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<AppError> for Error {
+    fn from(error: AppError) -> Self {
+        Self(error)
+    }
+}
+
+impl From<CoreError> for Error {
+    fn from(err: CoreError) -> Self {
+        match err {
+            CoreError::Unexpected(reason) => Self(AppError::Unexpected(reason)),
+            _ => Self(AppError::CoreError(err)),
+        }
+    }
+}
+
+impl From<IpcError> for Error {
+    fn from(err: IpcError) -> Self {
+        match err {
+            IpcError::EncodeDecodeError => Self(AppError::EncodeDecodeError),
+            IpcError::Unexpected(reason) => Self(AppError::Unexpected(reason)),
+            _ => Self(AppError::IpcError(err)),
+        }
+    }
+}
+
+impl From<ConfigFileHandlerError> for Error {
+    fn from(err: ConfigFileHandlerError) -> Self {
+        Self(AppError::Unexpected(err.to_string()))
+    }
+}
+
+impl From<NfsError> for Error {
+    fn from(err: NfsError) -> Self {
+        match err {
+            NfsError::CoreError(err) => Self(AppError::CoreError(err)),
+            NfsError::EncodeDecodeError(_) => Self(AppError::EncodeDecodeError),
+            NfsError::SelfEncryption(err) => Self(AppError::SelfEncryption(err)),
+            NfsError::Unexpected(reason) => Self(AppError::Unexpected(reason)),
+            _ => Self(AppError::NfsError(err)),
+        }
+    }
+}
+
+impl From<SerialisationError> for Error {
+    fn from(_err: SerialisationError) -> Self {
+        Self(AppError::EncodeDecodeError)
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_err: Utf8Error) -> Self {
+        Self(AppError::EncodeDecodeError)
+    }
+}
+
+impl From<StringError> for Error {
+    fn from(_err: StringError) -> Self {
+        Self(AppError::EncodeDecodeError)
+    }
+}
+
+impl From<SelfEncryptionError<SelfEncryptionStorageError>> for Error {
+    fn from(err: SelfEncryptionError<SelfEncryptionStorageError>) -> Self {
+        Self(AppError::SelfEncryption(err))
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Self {
+        Self(AppError::IoError(err))
+    }
+}
+
+impl<'a> From<&'a str> for Error {
+    fn from(s: &'a str) -> Self {
+        Self(AppError::Unexpected(s.to_string()))
+    }
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Self(AppError::Unexpected(s))
+    }
+}
+
+impl<T: 'static> From<SendError<T>> for Error {
+    fn from(err: SendError<T>) -> Self {
+        Self(AppError::from(err))
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(err: NulError) -> Self {
+        Self(AppError::from(err))
+    }
+}
+
+impl From<RecvError> for Error {
+    fn from(err: RecvError) -> Self {
+        Self(AppError::from(err))
+    }
+}
+
+impl From<RecvTimeoutError> for Error {
+    fn from(_err: RecvTimeoutError) -> Self {
+        // TODO: change this to err.description() once that lands in stable.
+        Self(AppError::from("mpsc receive error"))
+    }
+}
+
+impl ErrorCode for Error {
+    fn error_code(&self) -> i32 {
+        match (*self).0 {
+            AppError::CoreError(ref err) => core_error_code(err),
+            AppError::IpcError(ref err) => match *err {
+                IpcError::AuthDenied => ERR_AUTH_DENIED,
+                IpcError::ContainersDenied => ERR_CONTAINERS_DENIED,
+                IpcError::InvalidMsg => ERR_INVALID_MSG,
+                IpcError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
+                IpcError::AlreadyAuthorised => ERR_ALREADY_AUTHORISED,
+                IpcError::UnknownApp => ERR_UNKNOWN_APP,
+                IpcError::Unexpected(_) => ERR_UNEXPECTED,
+                IpcError::StringError(_) => ERR_STRING_ERROR,
+                IpcError::ShareMDataDenied => ERR_SHARE_MDATA_DENIED,
+                IpcError::InvalidOwner(..) => ERR_INVALID_OWNER,
+                IpcError::IncompatibleMockStatus => ERR_INCOMPATIBLE_MOCK_STATUS,
+            },
+            AppError::NfsError(ref err) => match *err {
+                NfsError::CoreError(ref err) => core_error_code(err),
+                NfsError::FileExists => ERR_FILE_EXISTS,
+                NfsError::FileNotFound => ERR_FILE_NOT_FOUND,
+                NfsError::InvalidRange => ERR_INVALID_RANGE,
+                NfsError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
+                NfsError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
+                NfsError::Unexpected(_) => ERR_UNEXPECTED,
+            },
+            AppError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
+            AppError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
+            AppError::NoSuchContainer(_) => ERR_NO_SUCH_CONTAINER,
+            AppError::InvalidCipherOptHandle => ERR_INVALID_CIPHER_OPT_HANDLE,
+            AppError::InvalidEncryptPubKeyHandle => ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE,
+            AppError::InvalidMDataEntriesHandle => ERR_INVALID_MDATA_ENTRIES_HANDLE,
+            AppError::InvalidMDataEntryActionsHandle => ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE,
+            AppError::InvalidMDataPermissionsHandle => ERR_INVALID_MDATA_PERMISSIONS_HANDLE,
+            AppError::InvalidSelfEncryptorHandle => ERR_INVALID_SELF_ENCRYPTOR_HANDLE,
+            AppError::InvalidSignPubKeyHandle => ERR_INVALID_SIGN_PUB_KEY_HANDLE,
+            AppError::InvalidSignSecKeyHandle => ERR_INVALID_SIGN_SEC_KEY_HANDLE,
+            AppError::InvalidEncryptSecKeyHandle => ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE,
+            AppError::InvalidPubKeyHandle => ERR_INVALID_PUB_KEY_HANDLE,
+            AppError::InvalidFileContextHandle => ERR_INVALID_FILE_CONTEXT_HANDLE,
+            AppError::InvalidFileMode => ERR_INVALID_FILE_MODE,
+            AppError::UnregisteredClientAccess => ERR_UNREGISTERED_CLIENT_ACCESS,
+            AppError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
+            AppError::InvalidSelfEncryptorReadOffsets => ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS,
+            AppError::IoError(_) => ERR_IO_ERROR,
+            AppError::Unexpected(_) => ERR_UNEXPECTED,
+        }
+    }
+}
+
+fn core_error_code(err: &CoreError) -> i32 {
+    match *err {
+        CoreError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
+        CoreError::AsymmetricDecipherFailure => ERR_ASYMMETRIC_DECIPHER_FAILURE,
+        CoreError::SymmetricDecipherFailure => ERR_SYMMETRIC_DECIPHER_FAILURE,
+        CoreError::ReceivedUnexpectedData => ERR_RECEIVED_UNEXPECTED_DATA,
+        CoreError::ReceivedUnexpectedEvent => ERR_RECEIVED_UNEXPECTED_EVENT,
+        CoreError::VersionCacheMiss => ERR_VERSION_CACHE_MISS,
+        CoreError::RootDirectoryExists => ERR_ROOT_DIRECTORY_EXISTS,
+        CoreError::RandomDataGenerationFailure => ERR_RANDOM_DATA_GENERATION_FAILURE,
+        CoreError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
+        CoreError::DataError(ref err) => match *err {
+            SndError::AccessDenied => ERR_ACCESS_DENIED,
+            SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
+            SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,
+            SndError::NoSuchData => ERR_NO_SUCH_DATA,
+            SndError::DataExists => ERR_DATA_EXISTS,
+            SndError::NoSuchEntry => ERR_NO_SUCH_ENTRY,
+            SndError::TooManyEntries => ERR_TOO_MANY_ENTRIES,
+            SndError::InvalidEntryActions(_) => ERR_INVALID_ENTRY_ACTIONS,
+            SndError::NoSuchKey => ERR_NO_SUCH_KEY,
+            SndError::KeysExist(_) => ERR_KEYS_EXIST,
+            SndError::DuplicateEntryKeys => ERR_DUPLICATE_ENTRY_KEYS,
+            SndError::DuplicateMessageId => ERR_DUPLICATE_MSG_ID,
+            SndError::InvalidOwners => ERR_INVALID_OWNERS,
+            SndError::InvalidSuccessor(_) => ERR_INVALID_SUCCESSOR,
+            SndError::InvalidOperation => ERR_INVALID_OPERATION,
+            SndError::NetworkOther(_) => ERR_NETWORK_OTHER,
+            SndError::InvalidOwnersSuccessor(_) => ERR_INVALID_OWNERS_SUCCESSOR,
+            SndError::InvalidPermissionsSuccessor(_) => ERR_INVALID_PERMISSIONS_SUCCESSOR,
+            SndError::SigningKeyTypeMismatch => ERR_SIGN_KEYTYPE_MISMATCH,
+            SndError::InvalidSignature => ERR_INVALID_SIGNATURE,
+            SndError::LossOfPrecision => ERR_LOSS_OF_PRECISION,
+            SndError::ExcessiveValue => ERR_EXCESSIVE_VALUE,
+            SndError::NoSuchBalance => ERR_NO_SUCH_BALANCE,
+            SndError::BalanceExists => ERR_BALANCE_EXISTS,
+            SndError::FailedToParse(_) => ERR_FAILED_TO_PARSE,
+            SndError::TransactionIdExists => ERR_TRANSACTION_ID_EXISTS,
+            SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
+            SndError::ExceededSize => ERR_EXCEEDED_SIZE,
+        },
+        CoreError::QuicP2p(ref _err) => ERR_QUIC_P2P, // FIXME: use proper error codes
+        CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
+        CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
+        CoreError::OperationAborted => ERR_OPERATION_ABORTED,
+        CoreError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
+        CoreError::RequestTimeout => ERR_REQUEST_TIMEOUT,
+        CoreError::ConfigError(_) => ERR_CONFIG_FILE,
+        CoreError::IoError(_) => ERR_IO,
+        CoreError::Unexpected(_) => ERR_UNEXPECTED,
+    }
+}

--- a/safe_app/src/ffi/errors.rs
+++ b/safe_app/src/ffi/errors.rs
@@ -50,7 +50,6 @@ pub mod codes {
     pub const ERR_KEYS_EXIST: i32 = -120;
 
     // App errors
-    pub const ERR_NO_SUCH_CONTAINER: i32 = -1002;
     pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = -1003;
     pub const ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE: i32 = -1004;
     pub const ERR_INVALID_MDATA_INFO_HANDLE: i32 = -1005;

--- a/safe_app/src/ffi/errors.rs
+++ b/safe_app/src/ffi/errors.rs
@@ -11,10 +11,9 @@ pub use crate::ffi::errors::codes::*;
 pub use safe_core::ffi::error_codes::*;
 
 use crate::errors::AppError;
-use config_file_handler::Error as ConfigFileHandlerError;
+use bincode::Error as SerialisationError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
-use maidsafe_utilities::serialisation::SerialisationError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::{CoreError, SelfEncryptionStorageError};
@@ -105,12 +104,6 @@ impl From<IpcError> for Error {
             IpcError::Unexpected(reason) => Self(AppError::Unexpected(reason)),
             _ => Self(AppError::IpcError(err)),
         }
-    }
-}
-
-impl From<ConfigFileHandlerError> for Error {
-    fn from(err: ConfigFileHandlerError) -> Self {
-        Self(AppError::Unexpected(err.to_string()))
     }
 }
 

--- a/safe_app/src/ffi/errors/codes.rs
+++ b/safe_app/src/ffi/errors/codes.rs
@@ -1,0 +1,29 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#![allow(missing_docs)]
+
+// These error codes are positive so as not to conflict with the shared error codes, which are
+// negative.
+pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = 1;
+pub const ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE: i32 = 2;
+pub const ERR_INVALID_MDATA_INFO_HANDLE: i32 = 3;
+pub const ERR_INVALID_MDATA_ENTRIES_HANDLE: i32 = 4;
+pub const ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE: i32 = 5;
+pub const ERR_INVALID_MDATA_PERMISSIONS_HANDLE: i32 = 6;
+pub const ERR_INVALID_MDATA_PERMISSION_SET_HANDLE: i32 = 7;
+pub const ERR_INVALID_SELF_ENCRYPTOR_HANDLE: i32 = 8;
+pub const ERR_INVALID_SIGN_PUB_KEY_HANDLE: i32 = 9;
+pub const ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS: i32 = 10;
+pub const ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE: i32 = 11;
+pub const ERR_INVALID_FILE_CONTEXT_HANDLE: i32 = 12;
+pub const ERR_INVALID_FILE_MODE: i32 = 13;
+pub const ERR_INVALID_SIGN_SEC_KEY_HANDLE: i32 = 14;
+pub const ERR_UNREGISTERED_CLIENT_ACCESS: i32 = 15;
+pub const ERR_INVALID_PUB_KEY_HANDLE: i32 = 16;

--- a/safe_app/src/ffi/errors/mod.rs
+++ b/safe_app/src/ffi/errors/mod.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+pub mod codes;
+
 pub use crate::ffi::errors::codes::*;
 pub use safe_core::ffi::error_codes::*;
 
@@ -24,49 +26,6 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::sync::mpsc::{RecvError, RecvTimeoutError};
-
-#[allow(missing_docs)]
-pub mod codes {
-    // Data type errors
-    pub const ERR_NO_SUCH_ACCOUNT: i32 = -101;
-    pub const ERR_ACCOUNT_EXISTS: i32 = -102;
-    pub const ERR_NO_SUCH_DATA: i32 = -103;
-    pub const ERR_DATA_EXISTS: i32 = -104;
-    pub const ERR_DATA_TOO_LARGE: i32 = -105;
-    pub const ERR_NO_SUCH_ENTRY: i32 = -106;
-    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -107;
-    pub const ERR_TOO_MANY_ENTRIES: i32 = -108;
-    pub const ERR_NO_SUCH_KEY: i32 = -109;
-    pub const ERR_INVALID_OWNERS: i32 = -110;
-    pub const ERR_INVALID_SUCCESSOR: i32 = -111;
-    pub const ERR_INVALID_OPERATION: i32 = -112;
-    pub const ERR_LOW_BALANCE: i32 = -113;
-    pub const ERR_NETWORK_FULL: i32 = -114;
-    pub const ERR_NETWORK_OTHER: i32 = -115;
-    pub const ERR_INVALID_INVITATION: i32 = -116;
-    pub const ERR_INVITATION_ALREADY_CLAIMED: i32 = -117;
-    pub const ERR_DUPLICATE_MSG_ID: i32 = -118;
-    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -119;
-    pub const ERR_KEYS_EXIST: i32 = -120;
-
-    // App errors
-    pub const ERR_INVALID_CIPHER_OPT_HANDLE: i32 = -1003;
-    pub const ERR_INVALID_ENCRYPT_PUB_KEY_HANDLE: i32 = -1004;
-    pub const ERR_INVALID_MDATA_INFO_HANDLE: i32 = -1005;
-    pub const ERR_INVALID_MDATA_ENTRIES_HANDLE: i32 = -1006;
-    pub const ERR_INVALID_MDATA_ENTRY_ACTIONS_HANDLE: i32 = -1007;
-    pub const ERR_INVALID_MDATA_PERMISSIONS_HANDLE: i32 = -1008;
-    pub const ERR_INVALID_MDATA_PERMISSION_SET_HANDLE: i32 = -1009;
-    pub const ERR_INVALID_SELF_ENCRYPTOR_HANDLE: i32 = -1010;
-    pub const ERR_INVALID_SIGN_PUB_KEY_HANDLE: i32 = -1011;
-    pub const ERR_INVALID_SELF_ENCRYPTOR_READ_OFFSETS: i32 = -1012;
-    pub const ERR_INVALID_ENCRYPT_SEC_KEY_HANDLE: i32 = -1014;
-    pub const ERR_INVALID_FILE_CONTEXT_HANDLE: i32 = -1015;
-    pub const ERR_INVALID_FILE_MODE: i32 = -1016;
-    pub const ERR_INVALID_SIGN_SEC_KEY_HANDLE: i32 = -1017;
-    pub const ERR_UNREGISTERED_CLIENT_ACCESS: i32 = -1018;
-    pub const ERR_INVALID_PUB_KEY_HANDLE: i32 = -1019;
-}
 
 /// FFI Result type
 pub type Result<T> = std::result::Result<T, Error>;
@@ -189,6 +148,7 @@ impl ErrorCode for Error {
     fn error_code(&self) -> i32 {
         match (*self).0 {
             AppError::CoreError(ref err) => core_error_code(err),
+            AppError::SndError(ref err) => safe_nd_error_core(err),
             AppError::IpcError(ref err) => match *err {
                 IpcError::AuthDenied => ERR_AUTH_DENIED,
                 IpcError::ContainersDenied => ERR_CONTAINERS_DENIED,
@@ -232,6 +192,39 @@ impl ErrorCode for Error {
             AppError::IoError(_) => ERR_IO_ERROR,
             AppError::Unexpected(_) => ERR_UNEXPECTED,
         }
+    }
+}
+
+fn safe_nd_error_core(err: &SndError) -> i32 {
+    match *err {
+        SndError::AccessDenied => ERR_ACCESS_DENIED,
+        SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
+        SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,
+        SndError::NoSuchData => ERR_NO_SUCH_DATA,
+        SndError::DataExists => ERR_DATA_EXISTS,
+        SndError::NoSuchEntry => ERR_NO_SUCH_ENTRY,
+        SndError::TooManyEntries => ERR_TOO_MANY_ENTRIES,
+        SndError::InvalidEntryActions(_) => ERR_INVALID_ENTRY_ACTIONS,
+        SndError::NoSuchKey => ERR_NO_SUCH_KEY,
+        SndError::KeysExist(_) => ERR_KEYS_EXIST,
+        SndError::DuplicateEntryKeys => ERR_DUPLICATE_ENTRY_KEYS,
+        SndError::DuplicateMessageId => ERR_DUPLICATE_MSG_ID,
+        SndError::InvalidOwners => ERR_INVALID_OWNERS,
+        SndError::InvalidSuccessor(_) => ERR_INVALID_SUCCESSOR,
+        SndError::InvalidOperation => ERR_INVALID_OPERATION,
+        SndError::NetworkOther(_) => ERR_NETWORK_OTHER,
+        SndError::InvalidOwnersSuccessor(_) => ERR_INVALID_OWNERS_SUCCESSOR,
+        SndError::InvalidPermissionsSuccessor(_) => ERR_INVALID_PERMISSIONS_SUCCESSOR,
+        SndError::SigningKeyTypeMismatch => ERR_SIGN_KEYTYPE_MISMATCH,
+        SndError::InvalidSignature => ERR_INVALID_SIGNATURE,
+        SndError::LossOfPrecision => ERR_LOSS_OF_PRECISION,
+        SndError::ExcessiveValue => ERR_EXCESSIVE_VALUE,
+        SndError::NoSuchBalance => ERR_NO_SUCH_BALANCE,
+        SndError::BalanceExists => ERR_BALANCE_EXISTS,
+        SndError::FailedToParse(_) => ERR_FAILED_TO_PARSE,
+        SndError::TransactionIdExists => ERR_TRANSACTION_ID_EXISTS,
+        SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
+        SndError::ExceededSize => ERR_EXCEEDED_SIZE,
     }
 }
 

--- a/safe_app/src/ffi/helper.rs
+++ b/safe_app/src/ffi/helper.rs
@@ -9,6 +9,7 @@
 
 use crate::client::AppClient;
 use crate::errors::AppError;
+use crate::ffi::errors::{Error, Result};
 use crate::ffi_utils::callback::Callback;
 use crate::ffi_utils::{OpaqueCtx, FFI_RESULT_OK};
 use crate::{App, AppContext};
@@ -20,37 +21,29 @@ use std::os::raw::c_void;
 // Convenience wrapper around `App::send` which automatically handles the callback
 // boilerplate.
 // Use this if the lambda never returns future.
-pub unsafe fn send_sync<C, F>(
-    app: *const App,
-    user_data: *mut c_void,
-    o_cb: C,
-    f: F,
-) -> Result<(), AppError>
+pub unsafe fn send_sync<C, F>(app: *const App, user_data: *mut c_void, o_cb: C, f: F) -> Result<()>
 where
     C: Callback + Copy + Send + 'static,
-    F: FnOnce(&AppClient, &AppContext) -> Result<C::Args, AppError> + Send + 'static,
+    F: FnOnce(&AppClient, &AppContext) -> Result<C::Args> + Send + 'static,
 {
     let user_data = OpaqueCtx(user_data);
 
-    (*app).send(move |client, context| {
-        match f(client, context) {
-            Ok(args) => o_cb.call(user_data.0, FFI_RESULT_OK, args),
-            res @ Err(..) => {
-                call_result_cb!(res, user_data, o_cb);
+    (*app)
+        .send(move |client, context| {
+            match f(client, context) {
+                Ok(args) => o_cb.call(user_data.0, FFI_RESULT_OK, args),
+                res @ Err(..) => {
+                    call_result_cb!(res, user_data, o_cb);
+                }
             }
-        }
-        None
-    })
+            None
+        })
+        .map_err(Error::from)
 }
 
 // Helper to reduce boilerplate when sending asynchronous operations to the app
 // event loop.
-pub unsafe fn send<C, F, U, E>(
-    app: *const App,
-    user_data: *mut c_void,
-    o_cb: C,
-    f: F,
-) -> Result<(), AppError>
+pub unsafe fn send<C, F, U, E>(app: *const App, user_data: *mut c_void, o_cb: C, f: F) -> Result<()>
 where
     C: Callback + Copy + Send + 'static,
     F: FnOnce(&AppClient, &AppContext) -> U + Send + 'static,
@@ -60,14 +53,16 @@ where
 {
     let user_data = OpaqueCtx(user_data);
 
-    (*app).send(move |client, context| {
-        f(client, context)
-            .map(move |args| o_cb.call(user_data.0, FFI_RESULT_OK, args))
-            .map_err(AppError::from)
-            .map_err(move |err| {
-                call_result_cb!(Err::<(), _>(err), user_data, o_cb);
-            })
-            .into_box()
-            .into()
-    })
+    (*app)
+        .send(move |client, context| {
+            f(client, context)
+                .map(move |args| o_cb.call(user_data.0, FFI_RESULT_OK, args))
+                .map_err(|e| Error::from(AppError::from(e)))
+                .map_err(move |err| {
+                    call_result_cb!(Err::<(), _>(err), user_data, o_cb);
+                })
+                .into_box()
+                .into()
+        })
+        .map_err(Error::from)
 }

--- a/safe_app/src/ffi/helper.rs
+++ b/safe_app/src/ffi/helper.rs
@@ -28,17 +28,15 @@ where
 {
     let user_data = OpaqueCtx(user_data);
 
-    (*app)
-        .send(move |client, context| {
-            match f(client, context) {
-                Ok(args) => o_cb.call(user_data.0, FFI_RESULT_OK, args),
-                res @ Err(..) => {
-                    call_result_cb!(res, user_data, o_cb);
-                }
+    (*app).send(move |client, context| {
+        match f(client, context) {
+            Ok(args) => o_cb.call(user_data.0, FFI_RESULT_OK, args),
+            res @ Err(..) => {
+                call_result_cb!(res, user_data, o_cb);
             }
-            None
-        })
-        .map_err(Error::from)
+        }
+        None
+    })
 }
 
 // Helper to reduce boilerplate when sending asynchronous operations to the app
@@ -53,16 +51,14 @@ where
 {
     let user_data = OpaqueCtx(user_data);
 
-    (*app)
-        .send(move |client, context| {
-            f(client, context)
-                .map(move |args| o_cb.call(user_data.0, FFI_RESULT_OK, args))
-                .map_err(|e| Error::from(AppError::from(e)))
-                .map_err(move |err| {
-                    call_result_cb!(Err::<(), _>(err), user_data, o_cb);
-                })
-                .into_box()
-                .into()
-        })
-        .map_err(Error::from)
+    (*app).send(move |client, context| {
+        f(client, context)
+            .map(move |args| o_cb.call(user_data.0, FFI_RESULT_OK, args))
+            .map_err(|e| Error::from(AppError::from(e)))
+            .map_err(move |err| {
+                call_result_cb!(Err::<(), _>(err), user_data, o_cb);
+            })
+            .into_box()
+            .into()
+    })
 }

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -11,7 +11,8 @@
 //! This module is exactly the same as `safe_authenticator::ffi::logging`, therefore changes to
 //! either one of them should also be reflected to the other to stay in sync.
 
-use super::errors::Result;
+use super::errors::{Error, Result};
+use crate::errors::AppError;
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
 use safe_core::utils::logging;
 use std::ffi::CString;
@@ -50,7 +51,8 @@ pub unsafe extern "C" fn app_config_dir_path(
             config_dir
                 .into_os_string()
                 .into_string()
-                .map_err(|_| AppError::Unexpected("Couldn't convert OsString".to_string()))?
+                .map_err(|_| AppError::Unexpected("Couldn't convert OsString".to_string()))
+                .map_err(Error::from)?
                 .into_bytes(),
         )?;
         o_cb(user_data, FFI_RESULT_OK, config_dir_path.as_ptr());

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -11,7 +11,7 @@
 //! This module is exactly the same as `safe_authenticator::ffi::logging`, therefore changes to
 //! either one of them should also be reflected to the other to stay in sync.
 
-use super::AppError;
+use super::errors::Result;
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
 use safe_core::utils::logging;
 use std::ffi::CString;
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn app_init_logging(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         if output_file_name_override.is_null() {
             logging::init(false)?;
         } else {
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn app_config_dir_path(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let config_dir = safe_core::config_dir()?;
         let config_dir_path = CString::new(
             config_dir

--- a/safe_app/src/ffi/mdata_info.rs
+++ b/safe_app/src/ffi/mdata_info.rs
@@ -8,6 +8,7 @@
 // Software.
 
 use crate::errors::AppError;
+use crate::ffi::errors::Result;
 use bincode::{deserialize, serialize};
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, SafePtr, FFI_RESULT_OK};
 use safe_core::crypto::shared_secretbox;
@@ -34,7 +35,7 @@ pub unsafe extern "C" fn mdata_info_new_private(
         mdata_info: *const MDataInfo,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let name = XorName(*name);
         let sk = shared_secretbox::Key::from_raw(&*secret_key);
 
@@ -61,7 +62,7 @@ pub unsafe extern "C" fn mdata_info_random_public(
         mdata_info: *const MDataInfo,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let md_kind = md_kind_clone_from_repr_c(md_seq);
         let info = NativeMDataInfo::random_public(md_kind, type_tag)?;
         let info = info.into_repr_c();
@@ -83,7 +84,7 @@ pub unsafe extern "C" fn mdata_info_random_private(
         mdata_info: *const MDataInfo,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let md_kind = md_kind_clone_from_repr_c(md_seq);
         let info = NativeMDataInfo::random_private(md_kind, type_tag)?;
         let info = info.into_repr_c();
@@ -107,7 +108,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_key(
         enc_entry_key_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
         let input = slice::from_raw_parts(input, input_len);
         let encoded = info.enc_entry_key(input).map_err(AppError::from)?;
@@ -136,7 +137,7 @@ pub unsafe extern "C" fn mdata_info_encrypt_entry_value(
         enc_entry_value_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
         let input = slice::from_raw_parts(input, input_len);
         let encoded = info.enc_entry_value(input).map_err(AppError::from)?;
@@ -165,7 +166,7 @@ pub unsafe extern "C" fn mdata_info_decrypt(
         mdata_info_decrypt_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
         let encoded = slice::from_raw_parts(input, input_len);
         let decoded = info.decrypt(encoded).map_err(AppError::from)?;
@@ -192,7 +193,7 @@ pub unsafe extern "C" fn mdata_info_serialise(
         encoded_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
         let encoded = serialize(&info).map_err(AppError::from)?;
 
@@ -218,7 +219,7 @@ pub unsafe extern "C" fn mdata_info_deserialise(
         mdata_info: *const MDataInfo,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let encoded = slice::from_raw_parts(encoded_ptr, encoded_len);
         let info: NativeMDataInfo = deserialize(encoded)?;
         let info = info.into_repr_c();

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -116,17 +116,15 @@ pub unsafe extern "C" fn app_reconnect(
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let user_data = OpaqueCtx(user_data);
-        (*app)
-            .send(move |client, _| {
-                try_cb!(
-                    client.restart_network().map_err(Error::from),
-                    user_data.0,
-                    o_cb
-                );
-                o_cb(user_data.0, FFI_RESULT_OK);
-                None
-            })
-            .map_err(Error::from)
+        (*app).send(move |client, _| {
+            try_cb!(
+                client.restart_network().map_err(Error::from),
+                user_data.0,
+                o_cb
+            );
+            o_cb(user_data.0, FFI_RESULT_OK);
+            None
+        })
     })
 }
 
@@ -164,13 +162,11 @@ pub unsafe extern "C" fn app_reset_object_cache(
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let user_data = OpaqueCtx(user_data);
-        (*app)
-            .send(move |_, context| {
-                context.object_cache().reset();
-                o_cb(user_data.0, FFI_RESULT_OK);
-                None
-            })
-            .map_err(Error::from)
+        (*app).send(move |_, context| {
+            context.object_cache().reset();
+            o_cb(user_data.0, FFI_RESULT_OK);
+            None
+        })
     })
 }
 

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -10,6 +10,7 @@
 //! FFI for mutable data entries, keys and values.
 
 use crate::errors::AppError;
+use crate::ffi::errors::{Error, Result};
 use crate::ffi::helper::send_sync;
 use crate::ffi::object_cache::MDataEntriesHandle;
 use crate::App;
@@ -22,7 +23,7 @@ use safe_core::ipc::resp::{
     MDataEntry as NativeMDataEntry, MDataKey as NativeMDataKey, MDataValue as NativeMDataValue,
 };
 use safe_core::CoreError;
-use safe_nd::{Error, MDataSeqValue};
+use safe_nd::{Error as NdError, MDataSeqValue};
 use std::collections::BTreeMap;
 use std::os::raw::c_void;
 
@@ -110,30 +111,35 @@ pub unsafe extern "C" fn seq_mdata_entries_get(
         let user_data = OpaqueCtx(user_data);
         let key = vec_clone_from_raw_parts(key, key_len);
 
-        (*app).send(move |_, context| {
-            let entries = try_cb!(
-                context.object_cache().get_seq_mdata_entries(entries_h),
-                user_data,
-                o_cb
-            );
+        (*app)
+            .send(move |_, context| {
+                let entries = try_cb!(
+                    context
+                        .object_cache()
+                        .get_seq_mdata_entries(entries_h)
+                        .map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
 
-            let value = entries
-                .get(&key)
-                .ok_or(Error::NoSuchEntry)
-                .map_err(CoreError::from)
-                .map_err(AppError::from);
-            let value = try_cb!(value, user_data, o_cb);
+                let value = entries
+                    .get(&key)
+                    .ok_or(NdError::NoSuchEntry)
+                    .map_err(CoreError::from)
+                    .map_err(AppError::from);
+                let value = try_cb!(value.map_err(Error::from), user_data, o_cb);
 
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                value.data.as_safe_ptr(),
-                value.data.len(),
-                value.version,
-            );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    value.data.as_safe_ptr(),
+                    value.data.len(),
+                    value.version,
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -153,33 +159,38 @@ pub unsafe extern "C" fn seq_mdata_list_entries(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app).send(move |_client, context| {
-            let entries = try_cb!(
-                context.object_cache().get_seq_mdata_entries(entries_h),
-                user_data.0,
-                o_cb
-            );
+        (*app)
+            .send(move |_client, context| {
+                let entries = try_cb!(
+                    context
+                        .object_cache()
+                        .get_seq_mdata_entries(entries_h)
+                        .map_err(Error::from),
+                    user_data.0,
+                    o_cb
+                );
 
-            let entries_vec: Vec<MDataEntry> = entries
-                .iter()
-                .map(|(key, value)| {
-                    NativeMDataEntry {
-                        key: NativeMDataKey(key.clone()),
-                        value: NativeMDataValue::from_routing(value.clone()),
-                    }
-                    .into_repr_c()
-                })
-                .collect();
+                let entries_vec: Vec<MDataEntry> = entries
+                    .iter()
+                    .map(|(key, value)| {
+                        NativeMDataEntry {
+                            key: NativeMDataKey(key.clone()),
+                            value: NativeMDataValue::from_routing(value.clone()),
+                        }
+                        .into_repr_c()
+                    })
+                    .collect();
 
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                entries_vec.as_safe_ptr(),
-                entries_vec.len(),
-            );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    entries_vec.as_safe_ptr(),
+                    entries_vec.len(),
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -207,10 +218,10 @@ unsafe fn with_entries<C, F>(
     user_data: *mut c_void,
     o_cb: C,
     f: F,
-) -> Result<(), AppError>
+) -> Result<()>
 where
     C: Callback + Copy + Send + 'static,
-    F: FnOnce(&mut BTreeMap<Vec<u8>, MDataSeqValue>) -> Result<C::Args, AppError> + Send + 'static,
+    F: FnOnce(&mut BTreeMap<Vec<u8>, MDataSeqValue>) -> Result<C::Args> + Send + 'static,
 {
     send_sync(app, user_data, o_cb, move |_, context| {
         let mut entries = context.object_cache().get_seq_mdata_entries(entries_h)?;

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -111,35 +111,33 @@ pub unsafe extern "C" fn seq_mdata_entries_get(
         let user_data = OpaqueCtx(user_data);
         let key = vec_clone_from_raw_parts(key, key_len);
 
-        (*app)
-            .send(move |_, context| {
-                let entries = try_cb!(
-                    context
-                        .object_cache()
-                        .get_seq_mdata_entries(entries_h)
-                        .map_err(Error::from),
-                    user_data,
-                    o_cb
-                );
+        (*app).send(move |_, context| {
+            let entries = try_cb!(
+                context
+                    .object_cache()
+                    .get_seq_mdata_entries(entries_h)
+                    .map_err(Error::from),
+                user_data,
+                o_cb
+            );
 
-                let value = entries
-                    .get(&key)
-                    .ok_or(NdError::NoSuchEntry)
-                    .map_err(CoreError::from)
-                    .map_err(AppError::from);
-                let value = try_cb!(value.map_err(Error::from), user_data, o_cb);
+            let value = entries
+                .get(&key)
+                .ok_or(NdError::NoSuchEntry)
+                .map_err(CoreError::from)
+                .map_err(AppError::from);
+            let value = try_cb!(value.map_err(Error::from), user_data, o_cb);
 
-                o_cb(
-                    user_data.0,
-                    FFI_RESULT_OK,
-                    value.data.as_safe_ptr(),
-                    value.data.len(),
-                    value.version,
-                );
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                value.data.as_safe_ptr(),
+                value.data.len(),
+                value.version,
+            );
 
-                None
-            })
-            .map_err(Error::from)
+            None
+        })
     })
 }
 
@@ -159,38 +157,36 @@ pub unsafe extern "C" fn seq_mdata_list_entries(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app)
-            .send(move |_client, context| {
-                let entries = try_cb!(
-                    context
-                        .object_cache()
-                        .get_seq_mdata_entries(entries_h)
-                        .map_err(Error::from),
-                    user_data.0,
-                    o_cb
-                );
+        (*app).send(move |_client, context| {
+            let entries = try_cb!(
+                context
+                    .object_cache()
+                    .get_seq_mdata_entries(entries_h)
+                    .map_err(Error::from),
+                user_data.0,
+                o_cb
+            );
 
-                let entries_vec: Vec<MDataEntry> = entries
-                    .iter()
-                    .map(|(key, value)| {
-                        NativeMDataEntry {
-                            key: NativeMDataKey(key.clone()),
-                            value: NativeMDataValue::from_routing(value.clone()),
-                        }
-                        .into_repr_c()
-                    })
-                    .collect();
+            let entries_vec: Vec<MDataEntry> = entries
+                .iter()
+                .map(|(key, value)| {
+                    NativeMDataEntry {
+                        key: NativeMDataKey(key.clone()),
+                        value: NativeMDataValue::from_routing(value.clone()),
+                    }
+                    .into_repr_c()
+                })
+                .collect();
 
-                o_cb(
-                    user_data.0,
-                    FFI_RESULT_OK,
-                    entries_vec.as_safe_ptr(),
-                    entries_vec.len(),
-                );
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                entries_vec.as_safe_ptr(),
+                entries_vec.len(),
+            );
 
-                None
-            })
-            .map_err(Error::from)
+            None
+        })
     })
 }
 

--- a/safe_app/src/ffi/mutable_data/helper.rs
+++ b/safe_app/src/ffi/mutable_data/helper.rs
@@ -7,14 +7,14 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::errors::AppError;
+use crate::ffi::errors::Result;
 use crate::ffi::object_cache::{MDataPermissionsHandle, PubKeyHandle};
 use crate::object_cache::ObjectCache;
 use safe_nd::{MDataPermissionSet, PublicKey};
 use std::collections::BTreeMap;
 
 // Retrieve the sign key corresponding to the handle from the object cache
-pub fn get_user(object_cache: &ObjectCache, handle: PubKeyHandle) -> Result<PublicKey, AppError> {
+pub fn get_user(object_cache: &ObjectCache, handle: PubKeyHandle) -> Result<PublicKey> {
     let user = {
         let sign_key = object_cache.get_pub_sign_key(handle)?;
         *sign_key
@@ -35,7 +35,7 @@ pub fn insert_permissions(
 pub fn get_permissions(
     object_cache: &ObjectCache,
     handle: MDataPermissionsHandle,
-) -> Result<BTreeMap<PublicKey, MDataPermissionSet>, AppError> {
+) -> Result<BTreeMap<PublicKey, MDataPermissionSet>> {
     let output = object_cache.get_mdata_permissions(handle)?.clone();
 
     Ok(output)

--- a/safe_app/src/ffi/mutable_data/metadata.rs
+++ b/safe_app/src/ffi/mutable_data/metadata.rs
@@ -9,7 +9,7 @@
 
 //! FFI routines for handling mutable data metadata.
 
-use crate::AppError;
+use crate::ffi::errors::Result;
 use bincode::serialize;
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
 use safe_core::ffi::ipc::resp::MetadataResponse;
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn mdata_encode_metadata(
         encoded_len: usize,
     ),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let metadata = UserMetadata::clone_from_repr_c(metadata)?;
         let encoded = serialize(&metadata)?;
         o_cb(user_data, FFI_RESULT_OK, encoded.as_ptr(), encoded.len());

--- a/safe_app/src/ffi/mutable_data/mod.rs
+++ b/safe_app/src/ffi/mutable_data/mod.rs
@@ -127,14 +127,13 @@ pub unsafe extern "C" fn mdata_get_version(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, version: u64),
 ) {
-    let f = || {
+    catch_unwind_cb(user_data, o_cb, || {
         let info = NativeMDataInfo::clone_from_repr_c(info)?;
 
         send(app, user_data, o_cb, move |client, _| {
             client.get_mdata_version(*info.address())
         })
-    };
-    catch_unwind_cb(user_data, o_cb, f)
+    });
 }
 
 /// Get size of serialised mutable data.

--- a/safe_app/src/ffi/mutable_data/permissions.rs
+++ b/safe_app/src/ffi/mutable_data/permissions.rs
@@ -10,6 +10,7 @@
 //! FFI for mutable data permissions and permission sets.
 
 use crate::errors::AppError;
+use crate::ffi::errors::Error;
 use crate::ffi::helper::send_sync;
 use crate::ffi::mutable_data::helper;
 use crate::ffi::object_cache::{MDataPermissionsHandle, SignPubKeyHandle, NULL_OBJECT_HANDLE};
@@ -91,30 +92,35 @@ pub unsafe extern "C" fn mdata_permissions_get(
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_, context| {
-            let permissions = try_cb!(
-                context.object_cache().get_mdata_permissions(permissions_h),
-                user_data,
-                o_cb
-            );
-            let user = try_cb!(
-                helper::get_user(context.object_cache(), user_h),
-                user_data,
-                o_cb
-            );
+        (*app)
+            .send(move |_, context| {
+                let permissions = try_cb!(
+                    context
+                        .object_cache()
+                        .get_mdata_permissions(permissions_h)
+                        .map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
+                let user = try_cb!(
+                    helper::get_user(context.object_cache(), user_h).map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
 
-            let permission_set = try_cb!(
-                permissions
-                    .get(&user,)
-                    .ok_or(AppError::InvalidSignPubKeyHandle,),
-                user_data,
-                o_cb
-            );
-            let permission_set = permission_set_into_repr_c(permission_set.clone());
+                let permission_set = try_cb!(
+                    permissions
+                        .get(&user,)
+                        .ok_or_else(|| Error::from(AppError::InvalidSignPubKeyHandle)),
+                    user_data,
+                    o_cb
+                );
+                let permission_set = permission_set_into_repr_c(permission_set.clone());
 
-            o_cb(user_data.0, FFI_RESULT_OK, &permission_set);
-            None
-        })
+                o_cb(user_data.0, FFI_RESULT_OK, &permission_set);
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -134,33 +140,38 @@ pub unsafe extern "C" fn mdata_list_permission_sets(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data, o_cb, || {
-        (*app).send(move |_, context| {
-            let permissions = try_cb!(
-                context.object_cache().get_mdata_permissions(permissions_h),
-                user_data,
-                o_cb
-            );
-            let user_perm_sets: Vec<UserPermissionSet> = permissions
-                .iter()
-                .map(|(user_key, permission_set)| {
-                    let user_h = context.object_cache().insert_pub_sign_key(*user_key);
-                    permissions::UserPermissionSet {
-                        user_h,
-                        perm_set: permission_set.clone(),
-                    }
-                    .into_repr_c()
-                })
-                .collect();
+        (*app)
+            .send(move |_, context| {
+                let permissions = try_cb!(
+                    context
+                        .object_cache()
+                        .get_mdata_permissions(permissions_h)
+                        .map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
+                let user_perm_sets: Vec<UserPermissionSet> = permissions
+                    .iter()
+                    .map(|(user_key, permission_set)| {
+                        let user_h = context.object_cache().insert_pub_sign_key(*user_key);
+                        permissions::UserPermissionSet {
+                            user_h,
+                            perm_set: permission_set.clone(),
+                        }
+                        .into_repr_c()
+                    })
+                    .collect();
 
-            o_cb(
-                user_data.0,
-                FFI_RESULT_OK,
-                user_perm_sets.as_safe_ptr(),
-                user_perm_sets.len(),
-            );
+                o_cb(
+                    user_data.0,
+                    FFI_RESULT_OK,
+                    user_perm_sets.as_safe_ptr(),
+                    user_perm_sets.len(),
+                );
 
-            None
-        })
+                None
+            })
+            .map_err(Error::from)
     })
 }
 

--- a/safe_app/src/ffi/mutable_data/permissions.rs
+++ b/safe_app/src/ffi/mutable_data/permissions.rs
@@ -92,35 +92,33 @@ pub unsafe extern "C" fn mdata_permissions_get(
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
-        (*app)
-            .send(move |_, context| {
-                let permissions = try_cb!(
-                    context
-                        .object_cache()
-                        .get_mdata_permissions(permissions_h)
-                        .map_err(Error::from),
-                    user_data,
-                    o_cb
-                );
-                let user = try_cb!(
-                    helper::get_user(context.object_cache(), user_h).map_err(Error::from),
-                    user_data,
-                    o_cb
-                );
+        (*app).send(move |_, context| {
+            let permissions = try_cb!(
+                context
+                    .object_cache()
+                    .get_mdata_permissions(permissions_h)
+                    .map_err(Error::from),
+                user_data,
+                o_cb
+            );
+            let user = try_cb!(
+                helper::get_user(context.object_cache(), user_h).map_err(Error::from),
+                user_data,
+                o_cb
+            );
 
-                let permission_set = try_cb!(
-                    permissions
-                        .get(&user,)
-                        .ok_or_else(|| Error::from(AppError::InvalidSignPubKeyHandle)),
-                    user_data,
-                    o_cb
-                );
-                let permission_set = permission_set_into_repr_c(permission_set.clone());
+            let permission_set = try_cb!(
+                permissions
+                    .get(&user,)
+                    .ok_or_else(|| Error::from(AppError::InvalidSignPubKeyHandle)),
+                user_data,
+                o_cb
+            );
+            let permission_set = permission_set_into_repr_c(permission_set.clone());
 
-                o_cb(user_data.0, FFI_RESULT_OK, &permission_set);
-                None
-            })
-            .map_err(Error::from)
+            o_cb(user_data.0, FFI_RESULT_OK, &permission_set);
+            None
+        })
     })
 }
 

--- a/safe_app/src/ffi/mutable_data/tests.rs
+++ b/safe_app/src/ffi/mutable_data/tests.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::errors::{ERR_ACCESS_DENIED, ERR_INVALID_SUCCESSOR, ERR_NO_SUCH_ENTRY};
+use crate::ffi::errors::{ERR_ACCESS_DENIED, ERR_INVALID_SUCCESSOR, ERR_NO_SUCH_ENTRY};
 use crate::ffi::mdata_info::*;
 use crate::ffi::mutable_data::entries::*;
 use crate::ffi::mutable_data::entry_actions::*;

--- a/safe_app/src/ffi/nfs.rs
+++ b/safe_app/src/ffi/nfs.rs
@@ -9,6 +9,7 @@
 
 use crate::client::AppClient;
 use crate::errors::AppError;
+use crate::ffi::errors::Error;
 use crate::ffi::helper::send;
 use crate::ffi::object_cache::FileContextHandle;
 use crate::App;
@@ -66,19 +67,21 @@ pub unsafe extern "C" fn dir_fetch_file(
         let file_name = String::clone_from_repr_c(file_name)?;
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |client, _| {
-            file_helper::fetch(client.clone(), parent_info, file_name)
-                .map(move |(version, file)| {
-                    let ffi_file = file.into_repr_c();
-                    o_cb(user_data.0, FFI_RESULT_OK, &ffi_file, version)
-                })
-                .map_err(AppError::from)
-                .map_err(move |err| {
-                    call_result_cb!(Err::<(), _>(err), user_data, o_cb);
-                })
-                .into_box()
-                .into()
-        })
+        (*app)
+            .send(move |client, _| {
+                file_helper::fetch(client.clone(), parent_info, file_name)
+                    .map(move |(version, file)| {
+                        let ffi_file = file.into_repr_c();
+                        o_cb(user_data.0, FFI_RESULT_OK, &ffi_file, version)
+                    })
+                    .map_err(Error::from)
+                    .map_err(move |err| {
+                        call_result_cb!(Err::<(), _>(err), user_data, o_cb);
+                    })
+                    .into_box()
+                    .into()
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -235,16 +238,26 @@ pub unsafe extern "C" fn file_size(
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_client, context| {
-            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+        (*app)
+            .send(move |_client, context| {
+                let file_ctx = try_cb!(
+                    context.object_cache().get_file(file_h).map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
 
-            if let Some(ref reader) = file_ctx.reader {
-                o_cb(user_data.0, FFI_RESULT_OK, reader.size());
-            } else {
-                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
-            }
-            None
-        })
+                if let Some(ref reader) = file_ctx.reader {
+                    o_cb(user_data.0, FFI_RESULT_OK, reader.size());
+                } else {
+                    call_result_cb!(
+                        Err::<(), _>(Error::from(AppError::InvalidFileMode)),
+                        user_data,
+                        o_cb
+                    );
+                }
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -266,32 +279,42 @@ pub unsafe extern "C" fn file_read(
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_client, context| {
-            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+        (*app)
+            .send(move |_client, context| {
+                let file_ctx = try_cb!(
+                    context.object_cache().get_file(file_h).map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
 
-            if let Some(ref reader) = file_ctx.reader {
-                reader
-                    .read(
-                        position,
-                        if len == FILE_READ_TO_END {
-                            reader.size() - position
-                        } else {
-                            len
-                        },
-                    )
-                    .map(move |data| {
-                        o_cb(user_data.0, FFI_RESULT_OK, data.as_safe_ptr(), data.len());
-                    })
-                    .map_err(move |err| {
-                        call_result_cb!(Err::<(), _>(AppError::from(err)), user_data, o_cb);
-                    })
-                    .into_box()
-                    .into()
-            } else {
-                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
-                None
-            }
-        })
+                if let Some(ref reader) = file_ctx.reader {
+                    reader
+                        .read(
+                            position,
+                            if len == FILE_READ_TO_END {
+                                reader.size() - position
+                            } else {
+                                len
+                            },
+                        )
+                        .map(move |data| {
+                            o_cb(user_data.0, FFI_RESULT_OK, data.as_safe_ptr(), data.len());
+                        })
+                        .map_err(move |err| {
+                            call_result_cb!(Err::<(), _>(Error::from(err)), user_data, o_cb);
+                        })
+                        .into_box()
+                        .into()
+                } else {
+                    call_result_cb!(
+                        Err::<(), _>(Error::from(AppError::InvalidFileMode)),
+                        user_data,
+                        o_cb
+                    );
+                    None
+                }
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -309,23 +332,33 @@ pub unsafe extern "C" fn file_write(
         let user_data = OpaqueCtx(user_data);
         let data = vec_clone_from_raw_parts(data, data_len);
 
-        (*app).send(move |_client, context| {
-            let file_ctx = try_cb!(context.object_cache().get_file(file_h), user_data, o_cb);
+        (*app)
+            .send(move |_client, context| {
+                let file_ctx = try_cb!(
+                    context.object_cache().get_file(file_h).map_err(Error::from),
+                    user_data,
+                    o_cb
+                );
 
-            if let Some(ref writer) = file_ctx.writer {
-                writer
-                    .write(&data)
-                    .then(move |res| {
-                        call_result_cb!(res.map_err(AppError::from), user_data, o_cb);
-                        Ok(())
-                    })
-                    .into_box()
-                    .into()
-            } else {
-                call_result_cb!(Err::<(), _>(AppError::InvalidFileMode), user_data, o_cb);
-                None
-            }
-        })
+                if let Some(ref writer) = file_ctx.writer {
+                    writer
+                        .write(&data)
+                        .then(move |res| {
+                            call_result_cb!(res.map_err(Error::from), user_data, o_cb);
+                            Ok(())
+                        })
+                        .into_box()
+                        .into()
+                } else {
+                    call_result_cb!(
+                        Err::<(), _>(Error::from(AppError::InvalidFileMode)),
+                        user_data,
+                        o_cb
+                    );
+                    None
+                }
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -348,29 +381,38 @@ pub unsafe extern "C" fn file_close(
     catch_unwind_cb(user_data, o_cb, || {
         let user_data = OpaqueCtx(user_data);
 
-        (*app).send(move |_client, context| {
-            let file_ctx = try_cb!(context.object_cache().remove_file(file_h), user_data, o_cb);
-
-            if let Some(writer) = file_ctx.writer {
-                writer
-                    .close()
-                    .map(move |file| {
-                        o_cb(user_data.0, FFI_RESULT_OK, &file.into_repr_c());
-                    })
-                    .map_err(move |err| {
-                        call_result_cb!(Err::<(), _>(AppError::from(err)), user_data, o_cb);
-                    })
-                    .into_box()
-                    .into()
-            } else {
-                // The reader will be dropped automatically.
-                o_cb(
-                    user_data.0,
-                    FFI_RESULT_OK,
-                    &file_ctx.original_file.into_repr_c(),
+        (*app)
+            .send(move |_client, context| {
+                let file_ctx = try_cb!(
+                    context
+                        .object_cache()
+                        .remove_file(file_h)
+                        .map_err(Error::from),
+                    user_data,
+                    o_cb
                 );
-                None
-            }
-        })
+
+                if let Some(writer) = file_ctx.writer {
+                    writer
+                        .close()
+                        .map(move |file| {
+                            o_cb(user_data.0, FFI_RESULT_OK, &file.into_repr_c());
+                        })
+                        .map_err(move |err| {
+                            call_result_cb!(Err::<(), _>(Error::from(err)), user_data, o_cb);
+                        })
+                        .into_box()
+                        .into()
+                } else {
+                    // The reader will be dropped automatically.
+                    o_cb(
+                        user_data.0,
+                        FFI_RESULT_OK,
+                        &file_ctx.original_file.into_repr_c(),
+                    );
+                    None
+                }
+            })
+            .map_err(Error::from)
     })
 }

--- a/safe_app/src/ffi/test_utils.rs
+++ b/safe_app/src/ffi/test_utils.rs
@@ -80,10 +80,10 @@ pub unsafe extern "C" fn test_simulate_network_disconnect(
 #[cfg(test)]
 mod tests {
     use super::test_create_app_with_access;
-    use crate::ffi::errors::codes::ERR_NO_SUCH_CONTAINER;
     use crate::App;
     use ffi_utils::test_utils::call_1;
     use safe_authenticator::test_utils::rand_app;
+    use safe_core::ffi::error_codes::ERR_NO_SUCH_CONTAINER;
     use safe_core::ipc::req::AuthReq;
     use safe_core::ipc::Permission;
     use std::collections::HashMap;

--- a/safe_app/src/ffi/test_utils.rs
+++ b/safe_app/src/ffi/test_utils.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::errors::AppError;
+use crate::ffi::errors::{Error, Result};
 use crate::test_utils::{create_app_by_req, create_auth_req};
 use crate::App;
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn test_create_app(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, app: *mut App),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let app_id = String::clone_from_repr_c(app_id)?;
         let auth_req = create_auth_req(Some(app_id), None);
         match create_app_by_req(&auth_req) {
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn test_create_app(
                 o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
             }
             res @ Err(..) => {
-                call_result_cb!(res, user_data, o_cb);
+                call_result_cb!(res.map_err(Error::from), user_data, o_cb);
             }
         }
         Ok(())
@@ -44,14 +44,14 @@ pub unsafe extern "C" fn test_create_app_with_access(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, o_app: *mut App),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let auth_req = NativeAuthReq::clone_from_repr_c(auth_req)?;
         match create_app_by_req(&auth_req) {
             Ok(app) => {
                 o_cb(user_data, FFI_RESULT_OK, Box::into_raw(Box::new(app)));
             }
             res @ Err(..) => {
-                call_result_cb!(res, user_data, o_cb);
+                call_result_cb!(res.map_err(Error::from), user_data, o_cb);
             }
         }
         Ok(())
@@ -80,9 +80,9 @@ pub unsafe extern "C" fn test_simulate_network_disconnect(
 #[cfg(test)]
 mod tests {
     use super::test_create_app_with_access;
-    use crate::{App, AppError};
+    use crate::ffi::errors::codes::ERR_NO_SUCH_CONTAINER;
+    use crate::App;
     use ffi_utils::test_utils::call_1;
-    use ffi_utils::ErrorCode;
     use safe_authenticator::test_utils::rand_app;
     use safe_core::ipc::req::AuthReq;
     use safe_core::ipc::Permission;
@@ -104,7 +104,7 @@ mod tests {
         let result: Result<*mut App, i32> =
             unsafe { call_1(|ud, cb| test_create_app_with_access(&auth_req, ud, cb)) };
         match result {
-            Err(error) if error == AppError::NoSuchContainer("_app".into()).error_code() => (),
+            Err(error) if error == ERR_NO_SUCH_CONTAINER => (),
             x => panic!("Unexpected {:?}", x),
         }
     }

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -8,6 +8,7 @@
 // Software.
 
 use crate::errors::AppError;
+use crate::ffi::errors::Error;
 use crate::ffi::nfs::*;
 use crate::ffi::object_cache::FileContextHandle;
 use crate::test_utils::{create_app_by_req, create_auth_req_with_access};
@@ -69,7 +70,7 @@ fn basics() {
     };
 
     match res {
-        Err(code) if code == AppError::from(NfsError::FileNotFound).error_code() => (),
+        Err(code) if code == Error::from(AppError::from(NfsError::FileNotFound)).error_code() => (),
         Err(x) => panic!("Unexpected: {:?}", x),
         Ok(_) => panic!("Unexpected success"),
     }
@@ -158,7 +159,7 @@ fn open_file() {
 
     let size: Result<u64, i32> = unsafe { call_1(|ud, cb| file_size(&app, write_h, ud, cb)) };
     match size {
-        Err(code) if code == AppError::InvalidFileMode.error_code() => (),
+        Err(code) if code == Error::from(AppError::InvalidFileMode).error_code() => (),
         Err(x) => panic!("Unexpected: {:?}", x),
         Ok(_) => panic!("Unexpected success"),
     }
@@ -989,7 +990,7 @@ fn file_read_chunks() {
         unsafe { call_vec_u8(|ud, cb| file_read(&app, read_h, size, 1, ud, cb)) };
 
     match retrieved_content {
-        Err(code) if code == AppError::from(NfsError::InvalidRange).error_code() => (),
+        Err(code) if code == Error::from(AppError::from(NfsError::InvalidRange)).error_code() => (),
         Err(x) => panic!("Unexpected: {:?}", x),
         Ok(_) => panic!("Unexpected success"),
     }

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -7,17 +7,20 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::ffi::errors::{ERR_INVALID_FILE_MODE, ERR_INVALID_RANGE};
+use crate::ffi::errors::{Error, ERR_INVALID_FILE_MODE, ERR_INVALID_RANGE};
 use crate::ffi::nfs::*;
 use crate::ffi::object_cache::FileContextHandle;
 use crate::test_utils::{create_app_by_req, create_auth_req_with_access};
+use crate::AppError;
 use crate::{run, App};
 use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8};
+use ffi_utils::ErrorCode;
 use futures::Future;
 use safe_core::ffi::nfs::File;
 use safe_core::ffi::MDataInfo;
 use safe_core::ipc::Permission;
 use safe_core::nfs::File as NativeFile;
+use safe_core::nfs::NfsError;
 use safe_core::utils;
 use std;
 use std::collections::HashMap;

--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -7,19 +7,17 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::errors::AppError;
-use crate::ffi::errors::Error;
+use crate::ffi::errors::{ERR_INVALID_FILE_MODE, ERR_INVALID_RANGE};
 use crate::ffi::nfs::*;
 use crate::ffi::object_cache::FileContextHandle;
 use crate::test_utils::{create_app_by_req, create_auth_req_with_access};
 use crate::{run, App};
 use ffi_utils::test_utils::{call_0, call_1, call_2, call_vec_u8};
-use ffi_utils::ErrorCode;
 use futures::Future;
 use safe_core::ffi::nfs::File;
 use safe_core::ffi::MDataInfo;
 use safe_core::ipc::Permission;
-use safe_core::nfs::{File as NativeFile, NfsError};
+use safe_core::nfs::File as NativeFile;
 use safe_core::utils;
 use std;
 use std::collections::HashMap;
@@ -159,7 +157,7 @@ fn open_file() {
 
     let size: Result<u64, i32> = unsafe { call_1(|ud, cb| file_size(&app, write_h, ud, cb)) };
     match size {
-        Err(code) if code == Error::from(AppError::InvalidFileMode).error_code() => (),
+        Err(code) if code == ERR_INVALID_FILE_MODE => (),
         Err(x) => panic!("Unexpected: {:?}", x),
         Ok(_) => panic!("Unexpected success"),
     }
@@ -990,7 +988,7 @@ fn file_read_chunks() {
         unsafe { call_vec_u8(|ud, cb| file_read(&app, read_h, size, 1, ud, cb)) };
 
     match retrieved_content {
-        Err(code) if code == Error::from(AppError::from(NfsError::InvalidRange)).error_code() => (),
+        Err(code) if code == ERR_INVALID_RANGE => (),
         Err(x) => panic!("Unexpected: {:?}", x),
         Ok(_) => panic!("Unexpected success"),
     }

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -56,9 +56,6 @@ pub use safe_nd::PubImmutableData;
 
 // Export FFI interface.
 
-pub mod ffi;
-
-pub use crate::errors::AppError;
 pub use crate::ffi::access_container::*;
 pub use crate::ffi::cipher_opt::*;
 pub use crate::ffi::crypto::*;
@@ -77,20 +74,25 @@ pub use crate::ffi::object_cache::*;
 #[cfg(any(test, feature = "testing"))]
 pub use crate::ffi::test_utils::*;
 pub use crate::ffi::*;
+
+// Export public app objects.
+
+pub use crate::errors::AppError;
 pub use client::AppClient;
 
 pub mod cipher_opt;
-mod client;
-mod errors;
+pub mod ffi;
 pub mod object_cache;
 pub mod permissions;
-
-#[cfg(test)]
-mod tests;
 
 /// Utility functions to test apps functionality.
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
+
+mod client;
+mod errors;
+#[cfg(test)]
+mod tests;
 
 use self::object_cache::ObjectCache;
 use crate::ffi::errors::{Error, Result as FfiResult};

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -395,7 +395,7 @@ where
             .into_box();
         Some(future)
     })?;
-    rx.recv()?.map_err(|e| crate::ffi::errors::Error::from(e))
+    rx.recv()?.map_err(crate::ffi::errors::Error::from)
 }
 
 fn refresh_access_info(context: Rc<Registered>, client: &AppClient) -> Box<AppFuture<()>> {

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -93,6 +93,7 @@ mod tests;
 pub mod test_utils;
 
 use self::object_cache::ObjectCache;
+use crate::ffi::errors::Error;
 use bincode::deserialize;
 use futures::stream::Stream;
 use futures::sync::mpsc as futures_mpsc;
@@ -131,7 +132,7 @@ pub struct App {
 
 impl App {
     /// Send a message to app's event loop.
-    pub fn send<F>(&self, f: F) -> Result<(), AppError>
+    pub fn send<F>(&self, f: F) -> Result<(), Error>
     where
         F: FnOnce(&AppClient, &AppContext) -> Option<Box<dyn Future<Item = (), Error = ()>>>
             + Send
@@ -139,7 +140,7 @@ impl App {
     {
         let msg = CoreMsg::new(f);
         let core_tx = unwrap!(self.core_tx.lock());
-        core_tx.unbounded_send(msg).map_err(AppError::from)
+        core_tx.unbounded_send(msg).map_err(Error::from)
     }
 
     /// Create unregistered app.

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -26,9 +26,11 @@ maidsafe_logo.png",
     unused_qualifications,
     unused_results
 )]
-// Our unsafe FFI functions are missing safety documentation. It is probably not necessary for us to
-// provide this for every single function as that would be repetitive and verbose.
-#![allow(clippy::missing_safety_doc)]
+#![allow(
+    // Our unsafe FFI functions are missing safety documentation. It is probably not necessary for
+    // us to provide this for every single function as that would be repetitive and verbose.
+    clippy::missing_safety_doc,
+)]
 
 #[macro_use]
 extern crate ffi_utils;
@@ -56,9 +58,11 @@ pub use safe_nd::PubImmutableData;
 
 pub mod ffi;
 
+pub use crate::errors::AppError;
 pub use crate::ffi::access_container::*;
 pub use crate::ffi::cipher_opt::*;
 pub use crate::ffi::crypto::*;
+pub use crate::ffi::errors::codes::*;
 pub use crate::ffi::immutable_data::*;
 pub use crate::ffi::ipc::*;
 pub use crate::ffi::logging::*;
@@ -73,6 +77,7 @@ pub use crate::ffi::object_cache::*;
 #[cfg(any(test, feature = "testing"))]
 pub use crate::ffi::test_utils::*;
 pub use crate::ffi::*;
+pub use client::AppClient;
 
 pub mod cipher_opt;
 mod client;
@@ -86,9 +91,6 @@ mod tests;
 /// Utility functions to test apps functionality.
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
-
-pub use self::errors::*;
-pub use client::AppClient;
 
 use self::object_cache::ObjectCache;
 use bincode::deserialize;

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -8,9 +8,9 @@
 
 //! Errors thrown by Authenticator routines.
 
-pub use self::codes::*;
 use bincode::Error as SerialisationError;
-use ffi_utils::{ErrorCode, StringError};
+use ffi_utils::StringError;
+use ffi_utils::StringError;
 use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
@@ -23,89 +23,6 @@ use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::sync::mpsc::RecvError;
-
-#[allow(missing_docs)]
-mod codes {
-    // Core errors
-    pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
-    pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
-    pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
-    pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
-    pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
-    pub const ERR_VERSION_CACHE_MISS: i32 = -6;
-    pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
-    pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
-    pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
-    pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
-    pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
-    pub const ERR_OPERATION_ABORTED: i32 = -12;
-    pub const ERR_SELF_ENCRYPTION: i32 = -13;
-    pub const ERR_REQUEST_TIMEOUT: i32 = -14;
-    pub const ERR_CONFIG_FILE: i32 = -15;
-    pub const ERR_IO: i32 = -16;
-
-    // Data type errors
-    pub const ERR_ACCESS_DENIED: i32 = -100;
-    pub const ERR_NO_SUCH_DATA: i32 = -101;
-    pub const ERR_DATA_EXISTS: i32 = -102;
-    pub const ERR_NO_SUCH_ENTRY: i32 = -103;
-    pub const ERR_TOO_MANY_ENTRIES: i32 = -104;
-    pub const ERR_NO_SUCH_KEY: i32 = -105;
-    pub const ERR_INVALID_OWNERS: i32 = -106;
-    pub const ERR_INVALID_SUCCESSOR: i32 = -107;
-    pub const ERR_INVALID_OPERATION: i32 = -108;
-    pub const ERR_NETWORK_OTHER: i32 = -109;
-    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -110;
-    pub const ERR_DUPLICATE_MSG_ID: i32 = -111;
-    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -112;
-    pub const ERR_KEYS_EXIST: i32 = -113;
-
-    // IPC errors.
-    pub const ERR_AUTH_DENIED: i32 = -200;
-    pub const ERR_CONTAINERS_DENIED: i32 = -201;
-    pub const ERR_INVALID_MSG: i32 = -202;
-    pub const ERR_ALREADY_AUTHORISED: i32 = -203;
-    pub const ERR_UNKNOWN_APP: i32 = -204;
-    pub const ERR_STRING_ERROR: i32 = -205;
-    pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
-    pub const ERR_INVALID_OWNER: i32 = -207;
-    pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
-
-    // NFS errors.
-    pub const ERR_FILE_EXISTS: i32 = -300;
-    pub const ERR_FILE_NOT_FOUND: i32 = -301;
-    pub const ERR_INVALID_RANGE: i32 = -302;
-
-    // Authenticator errors.
-    pub const ERR_IO_ERROR: i32 = -1013;
-    pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
-    pub const ERR_NO_SUCH_CONTAINER: i32 = -1015;
-    pub const ERR_PENDING_REVOCATION: i32 = -1016;
-    pub const ERR_UNEXPECTED: i32 = -2000;
-
-    // Identity & permission errors.
-    pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
-    pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
-    pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
-    pub const ERR_INVALID_SIGNATURE: i32 = -3004;
-
-    // Coin errors.
-    pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
-    pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
-    pub const ERR_FAILED_TO_PARSE: i32 = -4002;
-    pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
-    pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
-    pub const ERR_BALANCE_EXISTS: i32 = -4005;
-    pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
-
-    // Login packet errors.
-    pub const ERR_EXCEEDED_SIZE: i32 = -5001;
-    pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
-    pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
-
-    // Quic P2P errors.
-    pub const ERR_QUIC_P2P: i32 = -6000;
-}
 
 /// Authenticator errors.
 #[allow(clippy::large_enum_variant)]
@@ -254,100 +171,5 @@ impl From<FromUtf8Error> for AuthError {
 impl From<StringError> for AuthError {
     fn from(_err: StringError) -> Self {
         Self::EncodeDecodeError
-    }
-}
-
-impl ErrorCode for AuthError {
-    fn error_code(&self) -> i32 {
-        match *self {
-            Self::CoreError(ref err) => core_error_code(err),
-            Self::SndError(ref err) => safe_nd_error_core(err),
-            Self::IpcError(ref err) => match *err {
-                IpcError::AuthDenied => ERR_AUTH_DENIED,
-                IpcError::ContainersDenied => ERR_CONTAINERS_DENIED,
-                IpcError::InvalidMsg => ERR_INVALID_MSG,
-                IpcError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
-                IpcError::AlreadyAuthorised => ERR_ALREADY_AUTHORISED,
-                IpcError::UnknownApp => ERR_UNKNOWN_APP,
-                IpcError::Unexpected(_) => ERR_UNEXPECTED,
-                IpcError::StringError(_) => ERR_STRING_ERROR,
-                IpcError::ShareMDataDenied => ERR_SHARE_MDATA_DENIED,
-                IpcError::InvalidOwner(..) => ERR_INVALID_OWNER,
-                IpcError::IncompatibleMockStatus => ERR_INCOMPATIBLE_MOCK_STATUS,
-            },
-            Self::NfsError(ref err) => match *err {
-                NfsError::CoreError(ref err) => core_error_code(err),
-                NfsError::FileExists => ERR_FILE_EXISTS,
-                NfsError::FileNotFound => ERR_FILE_NOT_FOUND,
-                NfsError::InvalidRange => ERR_INVALID_RANGE,
-                NfsError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
-                NfsError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
-                NfsError::Unexpected(_) => ERR_UNEXPECTED,
-            },
-            Self::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
-            Self::IoError(_) => ERR_IO_ERROR,
-
-            Self::AccountContainersCreation(_) => ERR_ACCOUNT_CONTAINERS_CREATION,
-            Self::NoSuchContainer(_) => ERR_NO_SUCH_CONTAINER,
-            Self::PendingRevocation => ERR_PENDING_REVOCATION,
-            Self::Unexpected(_) => ERR_UNEXPECTED,
-        }
-    }
-}
-
-fn safe_nd_error_core(err: &SndError) -> i32 {
-    match *err {
-        SndError::AccessDenied => ERR_ACCESS_DENIED,
-        SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
-        SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,
-        SndError::NoSuchData => ERR_NO_SUCH_DATA,
-        SndError::DataExists => ERR_DATA_EXISTS,
-        SndError::NoSuchEntry => ERR_NO_SUCH_ENTRY,
-        SndError::TooManyEntries => ERR_TOO_MANY_ENTRIES,
-        SndError::InvalidEntryActions(_) => ERR_INVALID_ENTRY_ACTIONS,
-        SndError::NoSuchKey => ERR_NO_SUCH_KEY,
-        SndError::KeysExist(_) => ERR_KEYS_EXIST,
-        SndError::DuplicateEntryKeys => ERR_DUPLICATE_ENTRY_KEYS,
-        SndError::DuplicateMessageId => ERR_DUPLICATE_MSG_ID,
-        SndError::InvalidOwners => ERR_INVALID_OWNERS,
-        SndError::InvalidSuccessor(_) => ERR_INVALID_SUCCESSOR,
-        SndError::InvalidOperation => ERR_INVALID_OPERATION,
-        SndError::NetworkOther(_) => ERR_NETWORK_OTHER,
-        SndError::InvalidOwnersSuccessor(_) => ERR_INVALID_OWNERS_SUCCESSOR,
-        SndError::InvalidPermissionsSuccessor(_) => ERR_INVALID_PERMISSIONS_SUCCESSOR,
-        SndError::SigningKeyTypeMismatch => ERR_SIGN_KEYTYPE_MISMATCH,
-        SndError::InvalidSignature => ERR_INVALID_SIGNATURE,
-        SndError::LossOfPrecision => ERR_LOSS_OF_PRECISION,
-        SndError::ExcessiveValue => ERR_EXCESSIVE_VALUE,
-        SndError::NoSuchBalance => ERR_NO_SUCH_BALANCE,
-        SndError::BalanceExists => ERR_BALANCE_EXISTS,
-        SndError::FailedToParse(_) => ERR_FAILED_TO_PARSE,
-        SndError::TransactionIdExists => ERR_TRANSACTION_ID_EXISTS,
-        SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
-        SndError::ExceededSize => ERR_EXCEEDED_SIZE,
-    }
-}
-
-fn core_error_code(err: &CoreError) -> i32 {
-    match *err {
-        CoreError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
-        CoreError::AsymmetricDecipherFailure => ERR_ASYMMETRIC_DECIPHER_FAILURE,
-        CoreError::SymmetricDecipherFailure => ERR_SYMMETRIC_DECIPHER_FAILURE,
-        CoreError::ReceivedUnexpectedData => ERR_RECEIVED_UNEXPECTED_DATA,
-        CoreError::ReceivedUnexpectedEvent => ERR_RECEIVED_UNEXPECTED_EVENT,
-        CoreError::VersionCacheMiss => ERR_VERSION_CACHE_MISS,
-        CoreError::RootDirectoryExists => ERR_ROOT_DIRECTORY_EXISTS,
-        CoreError::RandomDataGenerationFailure => ERR_RANDOM_DATA_GENERATION_FAILURE,
-        CoreError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
-        CoreError::DataError(ref err) => safe_nd_error_core(err),
-        CoreError::QuicP2p(ref _error) => ERR_QUIC_P2P, // FIXME: use proper error codes
-        CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
-        CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
-        CoreError::OperationAborted => ERR_OPERATION_ABORTED,
-        CoreError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
-        CoreError::RequestTimeout => ERR_REQUEST_TIMEOUT,
-        CoreError::ConfigError(_) => ERR_CONFIG_FILE,
-        CoreError::IoError(_) => ERR_IO,
-        CoreError::Unexpected(_) => ERR_UNEXPECTED,
     }
 }

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -10,7 +10,6 @@
 
 use bincode::Error as SerialisationError;
 use ffi_utils::StringError;
-use ffi_utils::StringError;
 use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -60,17 +60,15 @@ pub unsafe extern "C" fn auth_rm_revoked_app(
     catch_unwind_cb(user_data.0, o_cb, || -> Result<_> {
         let app_id = String::clone_from_repr_c(app_id)?;
 
-        (*auth)
-            .send(move |client| {
-                remove_revoked_app(client, app_id)
-                    .then(move |res| {
-                        call_result_cb!(res.map_err(Error::from), user_data, o_cb);
-                        Ok(())
-                    })
-                    .into_box()
-                    .into()
-            })
-            .map_err(Error::from)
+        (*auth).send(move |client| {
+            remove_revoked_app(client, app_id)
+                .then(move |res| {
+                    call_result_cb!(res.map_err(Error::from), user_data, o_cb);
+                    Ok(())
+                })
+                .into_box()
+                .into()
+        })
     });
 }
 

--- a/safe_authenticator/src/ffi/apps.rs
+++ b/safe_authenticator/src/ffi/apps.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn auth_revoked_apps(
     ),
 ) {
     let user_data = OpaqueCtx(user_data);
-    let f = || -> Result<_> {
+    catch_unwind_cb(user_data.0, o_cb, || -> Result<_> {
         (*auth).send(move |client| {
             list_revoked(client)
                 .and_then(move |apps| {
@@ -110,8 +110,7 @@ pub unsafe extern "C" fn auth_revoked_apps(
         })?;
 
         Ok(())
-    };
-    catch_unwind_cb(user_data.0, o_cb, f)
+    });
 }
 
 /// Get a list of apps registered in authenticator.

--- a/safe_authenticator/src/ffi/errors.rs
+++ b/safe_authenticator/src/ffi/errors.rs
@@ -1,0 +1,263 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+pub use crate::ffi::errors::codes::*;
+pub use safe_core::ffi::error_codes::*;
+
+use crate::errors::AuthError;
+use config_file_handler::Error as ConfigFileHandlerError;
+use ffi_utils::{ErrorCode, StringError};
+use futures::sync::mpsc::SendError;
+use maidsafe_utilities::serialisation::SerialisationError;
+use safe_core::ipc::IpcError;
+use safe_core::nfs::NfsError;
+use safe_core::CoreError;
+use safe_nd::Error as SndError;
+use std::ffi::NulError;
+use std::fmt::{self, Display, Formatter};
+use std::io::Error as IoError;
+use std::str::Utf8Error;
+use std::string::FromUtf8Error;
+use std::sync::mpsc::RecvError;
+
+#[allow(missing_docs)]
+pub mod codes {
+    // Data type errors
+    pub const ERR_NO_SUCH_DATA: i32 = -101;
+    pub const ERR_DATA_EXISTS: i32 = -102;
+    pub const ERR_NO_SUCH_ENTRY: i32 = -103;
+    pub const ERR_TOO_MANY_ENTRIES: i32 = -104;
+    pub const ERR_NO_SUCH_KEY: i32 = -105;
+    pub const ERR_INVALID_OWNERS: i32 = -106;
+    pub const ERR_INVALID_SUCCESSOR: i32 = -107;
+    pub const ERR_INVALID_OPERATION: i32 = -108;
+    pub const ERR_NETWORK_OTHER: i32 = -109;
+    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -110;
+    pub const ERR_DUPLICATE_MSG_ID: i32 = -111;
+    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -112;
+    pub const ERR_KEYS_EXIST: i32 = -113;
+
+    // Authenticator errors.
+    pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
+    pub const ERR_NO_SUCH_CONTAINER: i32 = -1015;
+    pub const ERR_PENDING_REVOCATION: i32 = -1016;
+}
+
+/// FFI Result type
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// FFI Error type
+#[derive(Debug)]
+pub struct Error(AuthError);
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Into<IpcError> for Error {
+    fn into(self) -> IpcError {
+        match self.0 {
+            AuthError::Unexpected(desc) => IpcError::Unexpected(desc),
+            AuthError::IpcError(err) => err,
+            err => IpcError::Unexpected(format!("{:?}", err)),
+        }
+    }
+}
+
+impl From<AuthError> for Error {
+    fn from(error: AuthError) -> Self {
+        Self(error)
+    }
+}
+
+impl From<StringError> for Error {
+    fn from(_err: StringError) -> Self {
+        Self(AuthError::EncodeDecodeError)
+    }
+}
+
+impl<'a> From<&'a str> for Error {
+    fn from(s: &'a str) -> Self {
+        Self(AuthError::Unexpected(s.to_string()))
+    }
+}
+
+impl From<CoreError> for Error {
+    fn from(error: CoreError) -> Self {
+        Self(AuthError::CoreError(error))
+    }
+}
+
+impl<T: 'static> From<SendError<T>> for Error {
+    fn from(error: SendError<T>) -> Self {
+        Self(AuthError::from(error))
+    }
+}
+
+impl From<ConfigFileHandlerError> for Error {
+    fn from(error: ConfigFileHandlerError) -> Self {
+        Self(AuthError::from(error.to_string()))
+    }
+}
+
+impl From<IpcError> for Error {
+    fn from(error: IpcError) -> Self {
+        Self(AuthError::IpcError(error))
+    }
+}
+
+impl From<RecvError> for Error {
+    fn from(error: RecvError) -> Self {
+        Self(AuthError::from(error))
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(error: NulError) -> Self {
+        Self(AuthError::from(error))
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(error: IoError) -> Self {
+        Self(AuthError::IoError(error))
+    }
+}
+
+impl From<SndError> for Error {
+    fn from(error: SndError) -> Self {
+        Self(AuthError::SndError(error))
+    }
+}
+
+impl From<String> for Error {
+    fn from(error: String) -> Self {
+        Self(AuthError::Unexpected(error))
+    }
+}
+
+impl From<NfsError> for Error {
+    fn from(error: NfsError) -> Self {
+        Self(AuthError::NfsError(error))
+    }
+}
+
+impl From<SerialisationError> for Error {
+    fn from(_err: SerialisationError) -> Self {
+        Self(AuthError::EncodeDecodeError)
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_err: Utf8Error) -> Self {
+        Self(AuthError::EncodeDecodeError)
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(_err: FromUtf8Error) -> Self {
+        Self(AuthError::EncodeDecodeError)
+    }
+}
+
+impl ErrorCode for Error {
+    fn error_code(&self) -> i32 {
+        match (*self).0 {
+            AuthError::CoreError(ref err) => core_error_code(err),
+            AuthError::SndError(ref err) => safe_nd_error_core(err),
+            AuthError::IpcError(ref err) => match *err {
+                IpcError::AuthDenied => ERR_AUTH_DENIED,
+                IpcError::ContainersDenied => ERR_CONTAINERS_DENIED,
+                IpcError::InvalidMsg => ERR_INVALID_MSG,
+                IpcError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
+                IpcError::AlreadyAuthorised => ERR_ALREADY_AUTHORISED,
+                IpcError::UnknownApp => ERR_UNKNOWN_APP,
+                IpcError::Unexpected(_) => ERR_UNEXPECTED,
+                IpcError::StringError(_) => ERR_STRING_ERROR,
+                IpcError::ShareMDataDenied => ERR_SHARE_MDATA_DENIED,
+                IpcError::InvalidOwner(..) => ERR_INVALID_OWNER,
+                IpcError::IncompatibleMockStatus => ERR_INCOMPATIBLE_MOCK_STATUS,
+            },
+            AuthError::NfsError(ref err) => match *err {
+                NfsError::CoreError(ref err) => core_error_code(err),
+                NfsError::FileExists => ERR_FILE_EXISTS,
+                NfsError::FileNotFound => ERR_FILE_NOT_FOUND,
+                NfsError::InvalidRange => ERR_INVALID_RANGE,
+                NfsError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
+                NfsError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
+                NfsError::Unexpected(_) => ERR_UNEXPECTED,
+            },
+            AuthError::EncodeDecodeError => ERR_ENCODE_DECODE_ERROR,
+            AuthError::IoError(_) => ERR_IO_ERROR,
+
+            AuthError::AccountContainersCreation(_) => ERR_ACCOUNT_CONTAINERS_CREATION,
+            AuthError::NoSuchContainer(_) => ERR_NO_SUCH_CONTAINER,
+            AuthError::PendingRevocation => ERR_PENDING_REVOCATION,
+            AuthError::Unexpected(_) => ERR_UNEXPECTED,
+        }
+    }
+}
+
+fn safe_nd_error_core(err: &SndError) -> i32 {
+    match *err {
+        SndError::AccessDenied => ERR_ACCESS_DENIED,
+        SndError::NoSuchLoginPacket => ERR_NO_SUCH_LOGIN_PACKET,
+        SndError::LoginPacketExists => ERR_LOGIN_PACKET_EXISTS,
+        SndError::NoSuchData => ERR_NO_SUCH_DATA,
+        SndError::DataExists => ERR_DATA_EXISTS,
+        SndError::NoSuchEntry => ERR_NO_SUCH_ENTRY,
+        SndError::TooManyEntries => ERR_TOO_MANY_ENTRIES,
+        SndError::InvalidEntryActions(_) => ERR_INVALID_ENTRY_ACTIONS,
+        SndError::NoSuchKey => ERR_NO_SUCH_KEY,
+        SndError::KeysExist(_) => ERR_KEYS_EXIST,
+        SndError::DuplicateEntryKeys => ERR_DUPLICATE_ENTRY_KEYS,
+        SndError::DuplicateMessageId => ERR_DUPLICATE_MSG_ID,
+        SndError::InvalidOwners => ERR_INVALID_OWNERS,
+        SndError::InvalidSuccessor(_) => ERR_INVALID_SUCCESSOR,
+        SndError::InvalidOperation => ERR_INVALID_OPERATION,
+        SndError::NetworkOther(_) => ERR_NETWORK_OTHER,
+        SndError::InvalidOwnersSuccessor(_) => ERR_INVALID_OWNERS_SUCCESSOR,
+        SndError::InvalidPermissionsSuccessor(_) => ERR_INVALID_PERMISSIONS_SUCCESSOR,
+        SndError::SigningKeyTypeMismatch => ERR_SIGN_KEYTYPE_MISMATCH,
+        SndError::InvalidSignature => ERR_INVALID_SIGNATURE,
+        SndError::LossOfPrecision => ERR_LOSS_OF_PRECISION,
+        SndError::ExcessiveValue => ERR_EXCESSIVE_VALUE,
+        SndError::NoSuchBalance => ERR_NO_SUCH_BALANCE,
+        SndError::BalanceExists => ERR_BALANCE_EXISTS,
+        SndError::FailedToParse(_) => ERR_FAILED_TO_PARSE,
+        SndError::TransactionIdExists => ERR_TRANSACTION_ID_EXISTS,
+        SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
+        SndError::ExceededSize => ERR_EXCEEDED_SIZE,
+    }
+}
+
+fn core_error_code(err: &CoreError) -> i32 {
+    match *err {
+        CoreError::EncodeDecodeError(_) => ERR_ENCODE_DECODE_ERROR,
+        CoreError::AsymmetricDecipherFailure => ERR_ASYMMETRIC_DECIPHER_FAILURE,
+        CoreError::SymmetricDecipherFailure => ERR_SYMMETRIC_DECIPHER_FAILURE,
+        CoreError::ReceivedUnexpectedData => ERR_RECEIVED_UNEXPECTED_DATA,
+        CoreError::ReceivedUnexpectedEvent => ERR_RECEIVED_UNEXPECTED_EVENT,
+        CoreError::VersionCacheMiss => ERR_VERSION_CACHE_MISS,
+        CoreError::RootDirectoryExists => ERR_ROOT_DIRECTORY_EXISTS,
+        CoreError::RandomDataGenerationFailure => ERR_RANDOM_DATA_GENERATION_FAILURE,
+        CoreError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
+        CoreError::DataError(ref err) => safe_nd_error_core(err),
+        CoreError::QuicP2p(ref _err) => ERR_QUIC_P2P, // FIXME: use proper error codes
+        CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
+        CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
+        CoreError::OperationAborted => ERR_OPERATION_ABORTED,
+        CoreError::SelfEncryption(_) => ERR_SELF_ENCRYPTION,
+        CoreError::RequestTimeout => ERR_REQUEST_TIMEOUT,
+        CoreError::ConfigError(_) => ERR_CONFIG_FILE,
+        CoreError::IoError(_) => ERR_IO,
+        CoreError::Unexpected(_) => ERR_UNEXPECTED,
+    }
+}

--- a/safe_authenticator/src/ffi/errors.rs
+++ b/safe_authenticator/src/ffi/errors.rs
@@ -10,10 +10,8 @@ pub use crate::ffi::errors::codes::*;
 pub use safe_core::ffi::error_codes::*;
 
 use crate::errors::AuthError;
-use config_file_handler::Error as ConfigFileHandlerError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
-use maidsafe_utilities::serialisation::SerialisationError;
 use safe_core::ipc::IpcError;
 use safe_core::nfs::NfsError;
 use safe_core::CoreError;
@@ -101,12 +99,6 @@ impl<T: 'static> From<SendError<T>> for Error {
     }
 }
 
-impl From<ConfigFileHandlerError> for Error {
-    fn from(error: ConfigFileHandlerError) -> Self {
-        Self(AuthError::from(error.to_string()))
-    }
-}
-
 impl From<IpcError> for Error {
     fn from(error: IpcError) -> Self {
         Self(AuthError::IpcError(error))
@@ -146,12 +138,6 @@ impl From<String> for Error {
 impl From<NfsError> for Error {
     fn from(error: NfsError) -> Self {
         Self(AuthError::NfsError(error))
-    }
-}
-
-impl From<SerialisationError> for Error {
-    fn from(_err: SerialisationError) -> Self {
-        Self(AuthError::EncodeDecodeError)
     }
 }
 

--- a/safe_authenticator/src/ffi/errors/codes.rs
+++ b/safe_authenticator/src/ffi/errors/codes.rs
@@ -1,0 +1,12 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+#![allow(missing_docs)]
+
+pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
+pub const ERR_PENDING_REVOCATION: i32 = -1016;

--- a/safe_authenticator/src/ffi/errors/codes.rs
+++ b/safe_authenticator/src/ffi/errors/codes.rs
@@ -8,5 +8,6 @@
 
 #![allow(missing_docs)]
 
-pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
-pub const ERR_PENDING_REVOCATION: i32 = -1016;
+// These error codes are positive so as not to conflict with the shared error codes, which are negative
+pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = 1;
+pub const ERR_PENDING_REVOCATION: i32 = 2;

--- a/safe_authenticator/src/ffi/errors/mod.rs
+++ b/safe_authenticator/src/ffi/errors/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2019 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed

--- a/safe_authenticator/src/ffi/errors/mod.rs
+++ b/safe_authenticator/src/ffi/errors/mod.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+pub mod codes;
+
 pub use crate::ffi::errors::codes::*;
 pub use safe_core::ffi::error_codes::*;
 
@@ -22,29 +24,6 @@ use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::sync::mpsc::RecvError;
-
-#[allow(missing_docs)]
-pub mod codes {
-    // Data type errors
-    pub const ERR_NO_SUCH_DATA: i32 = -101;
-    pub const ERR_DATA_EXISTS: i32 = -102;
-    pub const ERR_NO_SUCH_ENTRY: i32 = -103;
-    pub const ERR_TOO_MANY_ENTRIES: i32 = -104;
-    pub const ERR_NO_SUCH_KEY: i32 = -105;
-    pub const ERR_INVALID_OWNERS: i32 = -106;
-    pub const ERR_INVALID_SUCCESSOR: i32 = -107;
-    pub const ERR_INVALID_OPERATION: i32 = -108;
-    pub const ERR_NETWORK_OTHER: i32 = -109;
-    pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -110;
-    pub const ERR_DUPLICATE_MSG_ID: i32 = -111;
-    pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -112;
-    pub const ERR_KEYS_EXIST: i32 = -113;
-
-    // Authenticator errors.
-    pub const ERR_ACCOUNT_CONTAINERS_CREATION: i32 = -1014;
-    pub const ERR_NO_SUCH_CONTAINER: i32 = -1015;
-    pub const ERR_PENDING_REVOCATION: i32 = -1016;
-}
 
 /// FFI Result type
 pub type Result<T> = std::result::Result<T, Error>;

--- a/safe_authenticator/src/ffi/ipc.rs
+++ b/safe_authenticator/src/ffi/ipc.rs
@@ -230,17 +230,15 @@ pub unsafe extern "C" fn auth_flush_app_revocation_queue(
     let user_data = OpaqueCtx(user_data);
 
     catch_unwind_cb(user_data.0, o_cb, || -> Result<_> {
-        (*auth)
-            .send(move |client| {
-                flush_app_revocation_queue(client)
-                    .then(move |res| {
-                        call_result_cb!(res.map_err(Error::from), user_data, o_cb);
-                        Ok(())
-                    })
-                    .into_box()
-                    .into()
-            })
-            .map_err(Error::from)
+        (*auth).send(move |client| {
+            flush_app_revocation_queue(client)
+                .then(move |res| {
+                    call_result_cb!(res.map_err(Error::from), user_data, o_cb);
+                    Ok(())
+                })
+                .into_box()
+                .into()
+        })
     })
 }
 

--- a/safe_authenticator/src/ffi/logging.rs
+++ b/safe_authenticator/src/ffi/logging.rs
@@ -10,7 +10,8 @@
 //! This module is exactly the same as `safe_app::ffi::logging`, therefore changes to either one of
 //! them should also be reflected to the other to stay in sync.
 
-use super::AuthError;
+use crate::errors::AuthError;
+use crate::ffi::errors::Result;
 use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
 use safe_core::utils::logging;
 use std::ffi::CString;
@@ -25,7 +26,7 @@ pub unsafe extern "C" fn auth_init_logging(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         if output_file_name_override.is_null() {
             logging::init(false)?;
         } else {
@@ -43,7 +44,7 @@ pub unsafe extern "C" fn auth_config_dir_path(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<(), AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let config_dir = safe_core::config_dir()?;
         let config_dir_path = CString::new(
             config_dir

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -12,12 +12,14 @@
 
 /// Apps management
 pub mod apps;
+/// Errors
+pub mod errors;
 /// Authenticator communication with apps
 pub mod ipc;
 /// Logging utilities
 pub mod logging;
 
-use crate::errors::AuthError;
+use crate::ffi::errors::{Error, Result};
 use crate::Authenticator;
 use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, ReprC, FFI_RESULT_OK};
 use rand::thread_rng;
@@ -45,7 +47,7 @@ pub unsafe extern "C" fn create_acc(
 ) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         trace!("Authenticator - create a client account.");
 
         let acc_locator = String::clone_from_repr_c(account_locator)?;
@@ -90,7 +92,7 @@ pub unsafe extern "C" fn login(
 ) {
     let user_data = OpaqueCtx(user_data);
 
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         trace!("Authenticator - log in a registered client.");
 
         let acc_locator = String::clone_from_repr_c(account_locator)?;
@@ -117,17 +119,19 @@ pub unsafe extern "C" fn auth_reconnect(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let user_data = OpaqueCtx(user_data);
-        (*auth).send(move |client| {
-            try_cb!(
-                client.restart_network().map_err(AuthError::from),
-                user_data.0,
-                o_cb
-            );
-            o_cb(user_data.0, FFI_RESULT_OK);
-            None
-        })
+        (*auth)
+            .send(move |client| {
+                try_cb!(
+                    client.restart_network().map_err(Error::from),
+                    user_data.0,
+                    o_cb
+                );
+                o_cb(user_data.0, FFI_RESULT_OK);
+                None
+            })
+            .map_err(Error::from)
     })
 }
 
@@ -138,7 +142,7 @@ pub unsafe extern "C" fn auth_set_config_dir_path(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AuthError> {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let new_path = CStr::from_ptr(new_path).to_str()?;
         config_handler::set_config_dir_path(OsStr::new(new_path));
         o_cb(user_data, FFI_RESULT_OK);
@@ -166,6 +170,7 @@ mod tests {
     use super::*;
     use crate::ffi::auth_is_mock;
     use crate::run;
+    use crate::AuthError;
     use ffi_utils::test_utils::call_1;
     use futures::Future;
     use safe_core::{utils, FutureExt};

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -121,17 +121,15 @@ pub unsafe extern "C" fn auth_reconnect(
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<_> {
         let user_data = OpaqueCtx(user_data);
-        (*auth)
-            .send(move |client| {
-                try_cb!(
-                    client.restart_network().map_err(Error::from),
-                    user_data.0,
-                    o_cb
-                );
-                o_cb(user_data.0, FFI_RESULT_OK);
-                None
-            })
-            .map_err(Error::from)
+        (*auth).send(move |client| {
+            try_cb!(
+                client.restart_network().map_err(Error::from),
+                user_data.0,
+                o_cb
+            );
+            o_cb(user_data.0, FFI_RESULT_OK);
+            None
+        })
     })
 }
 

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -13,6 +13,7 @@ use crate::access_container;
 use crate::app_auth::{app_state, AppState};
 use crate::client::AuthClient;
 use crate::config;
+use crate::ffi::errors::Error as FFIError;
 use bincode::deserialize;
 use ffi_utils::StringError;
 use futures::future::{self, Either};
@@ -81,7 +82,7 @@ pub fn decode_ipc_msg(
                         AppState::Revoked | AppState::NotAuthenticated => {
                             // App is not authenticated
                             let (error_code, description) =
-                                ffi_error!(AuthError::from(IpcError::UnknownApp));
+                                ffi_error!(FFIError::from(IpcError::UnknownApp));
 
                             let response = IpcMsg::Resp {
                                 response: IpcResp::Auth(Err(IpcError::UnknownApp)),

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -66,6 +66,7 @@ pub use self::errors::AuthError;
 pub use crate::ffi::errors::codes::*;
 pub use client::AuthClient;
 
+use crate::ffi::errors::Error;
 use futures::stream::Stream;
 use futures::sync::mpsc;
 use futures::{Future, IntoFuture};
@@ -106,13 +107,13 @@ pub struct Authenticator {
 
 impl Authenticator {
     /// Send a message to the authenticator event loop.
-    pub fn send<F>(&self, f: F) -> Result<(), AuthError>
+    pub fn send<F>(&self, f: F) -> crate::ffi::errors::Result<()>
     where
         F: FnOnce(&AuthClient) -> Option<Box<dyn Future<Item = (), Error = ()>>> + Send + 'static,
     {
         let msg = CoreMsg::new(|client, _| f(client));
         let core_tx = unwrap!(self.core_tx.lock());
-        core_tx.unbounded_send(msg).map_err(AuthError::from)
+        core_tx.unbounded_send(msg).map_err(Error::from)
     }
 
     /// Create a new account.

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -24,9 +24,11 @@
     unused_qualifications,
     unused_results
 )]
-// Our unsafe FFI functions are missing safety documentation. It is probably not necessary for us to
-// provide this for every single function as that would be repetitive and verbose.
-#![allow(clippy::missing_safety_doc)]
+#![allow(
+    // Our unsafe FFI functions are missing safety documentation. It is probably not necessary for
+    // us to provide this for every single function as that would be repetitive and verbose.
+    clippy::missing_safety_doc,
+)]
 
 #[macro_use]
 extern crate ffi_utils;
@@ -61,6 +63,7 @@ mod std_dirs;
 mod tests;
 
 pub use self::errors::AuthError;
+pub use crate::ffi::errors::codes::*;
 pub use client::AuthClient;
 
 use futures::stream::Stream;

--- a/safe_authenticator/src/lib.rs
+++ b/safe_authenticator/src/lib.rs
@@ -39,6 +39,19 @@ extern crate safe_core;
 #[macro_use]
 extern crate unwrap;
 
+// Export FFI interface
+
+pub use crate::ffi::apps::*;
+pub use crate::ffi::errors::codes::*;
+pub use crate::ffi::ipc::*;
+pub use crate::ffi::logging::*;
+pub use crate::ffi::*;
+
+// Export public auth objects.
+
+pub use self::errors::AuthError;
+pub use client::AuthClient;
+
 pub mod access_container;
 pub mod app_auth;
 pub mod app_container;
@@ -52,19 +65,10 @@ pub mod revocation;
 #[macro_use]
 pub mod test_utils;
 
-pub use ffi::apps::*;
-pub use ffi::ipc::*;
-pub use ffi::logging::*;
-pub use ffi::*;
-
 mod client;
 mod std_dirs;
 #[cfg(test)]
 mod tests;
-
-pub use self::errors::AuthError;
-pub use crate::ffi::errors::codes::*;
-pub use client::AuthClient;
 
 use crate::ffi::errors::Error;
 use futures::stream::Stream;

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -15,8 +15,10 @@ mod utils;
 
 use crate::access_container as access_container_tools;
 use crate::config::{self, KEY_APPS};
-use crate::errors::{AuthError, ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
+use crate::errors::AuthError;
 use crate::ffi::apps::*;
+use crate::ffi::errors::codes::ERR_NO_SUCH_CONTAINER;
+use crate::ffi::errors::{ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
 use crate::ffi::ipc::{
     auth_revoke_app, encode_auth_resp, encode_containers_resp, encode_unregistered_resp,
 };
@@ -28,7 +30,7 @@ use crate::std_dirs::{DEFAULT_PRIVATE_DIRS, DEFAULT_PUBLIC_DIRS};
 use crate::test_utils::{self, ChannelType};
 use crate::{app_container, run};
 use ffi_utils::test_utils::{call_1, call_vec, sender_as_user_data};
-use ffi_utils::{ErrorCode, ReprC, StringError};
+use ffi_utils::{ReprC, StringError};
 use futures::{future, Future};
 use safe_core::config_handler::Config;
 use safe_core::{app_container_name, mdata_info, AuthActions, Client};
@@ -614,7 +616,7 @@ fn invalid_container_authentication() {
         })
     };
     match result {
-        Err(error) if error == AuthError::NoSuchContainer("_app".into()).error_code() => (),
+        Err(error) if error == ERR_NO_SUCH_CONTAINER => (),
         x => panic!("Unexpected {:?}", x),
     };
 }

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -17,7 +17,6 @@ use crate::access_container as access_container_tools;
 use crate::config::{self, KEY_APPS};
 use crate::errors::AuthError;
 use crate::ffi::apps::*;
-use crate::ffi::errors::codes::ERR_NO_SUCH_CONTAINER;
 use crate::ffi::errors::{ERR_INVALID_MSG, ERR_OPERATION_FORBIDDEN, ERR_UNKNOWN_APP};
 use crate::ffi::ipc::{
     auth_revoke_app, encode_auth_resp, encode_containers_resp, encode_unregistered_resp,
@@ -33,6 +32,7 @@ use ffi_utils::test_utils::{call_1, call_vec, sender_as_user_data};
 use ffi_utils::{ReprC, StringError};
 use futures::{future, Future};
 use safe_core::config_handler::Config;
+use safe_core::ffi::error_codes::ERR_NO_SUCH_CONTAINER;
 use safe_core::{app_container_name, mdata_info, AuthActions, Client};
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -6,8 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::errors::{AuthError, ERR_INVALID_OWNER, ERR_NO_SUCH_DATA};
+use crate::errors::AuthError;
 use crate::ffi::apps::*;
+use crate::ffi::errors::{ERR_INVALID_OWNER, ERR_NO_SUCH_DATA};
 use crate::ffi::ipc::encode_share_mdata_resp;
 use crate::run;
 use crate::test_utils::{self, Payload};

--- a/safe_core/src/ffi/error_codes.rs
+++ b/safe_core/src/ffi/error_codes.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 MaidSafe.net limited.
+// Copyright 2019 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
 // https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD

--- a/safe_core/src/ffi/error_codes.rs
+++ b/safe_core/src/ffi/error_codes.rs
@@ -1,0 +1,77 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+
+#![allow(missing_docs)]
+
+// Core errors
+pub const ERR_ENCODE_DECODE_ERROR: i32 = -1;
+pub const ERR_ASYMMETRIC_DECIPHER_FAILURE: i32 = -2;
+pub const ERR_SYMMETRIC_DECIPHER_FAILURE: i32 = -3;
+pub const ERR_RECEIVED_UNEXPECTED_DATA: i32 = -4;
+pub const ERR_RECEIVED_UNEXPECTED_EVENT: i32 = -5;
+pub const ERR_VERSION_CACHE_MISS: i32 = -6;
+pub const ERR_ROOT_DIRECTORY_EXISTS: i32 = -7;
+pub const ERR_RANDOM_DATA_GENERATION_FAILURE: i32 = -8;
+pub const ERR_OPERATION_FORBIDDEN: i32 = -9;
+pub const ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH: i32 = -10;
+pub const ERR_UNSUCCESSFUL_PW_HASH: i32 = -11;
+pub const ERR_OPERATION_ABORTED: i32 = -12;
+pub const ERR_SELF_ENCRYPTION: i32 = -13;
+pub const ERR_REQUEST_TIMEOUT: i32 = -14;
+pub const ERR_CONFIG_FILE: i32 = -15;
+pub const ERR_IO: i32 = -16;
+
+// Data type errors
+pub const ERR_ACCESS_DENIED: i32 = -100;
+
+// IPC errors.
+pub const ERR_AUTH_DENIED: i32 = -200;
+pub const ERR_CONTAINERS_DENIED: i32 = -201;
+pub const ERR_INVALID_MSG: i32 = -202;
+pub const ERR_ALREADY_AUTHORISED: i32 = -203;
+pub const ERR_UNKNOWN_APP: i32 = -204;
+pub const ERR_STRING_ERROR: i32 = -205;
+pub const ERR_SHARE_MDATA_DENIED: i32 = -206;
+pub const ERR_INVALID_OWNER: i32 = -207;
+pub const ERR_INCOMPATIBLE_MOCK_STATUS: i32 = -208;
+
+// NFS errors.
+pub const ERR_FILE_EXISTS: i32 = -300;
+pub const ERR_FILE_NOT_FOUND: i32 = -301;
+pub const ERR_INVALID_RANGE: i32 = -302;
+
+// IO error.
+pub const ERR_IO_ERROR: i32 = -1013;
+
+// Unexpected error.
+pub const ERR_UNEXPECTED: i32 = -2000;
+
+// Identity & permission errors.
+pub const ERR_INVALID_OWNERS_SUCCESSOR: i32 = -3001;
+pub const ERR_INVALID_PERMISSIONS_SUCCESSOR: i32 = -3002;
+pub const ERR_SIGN_KEYTYPE_MISMATCH: i32 = -3003;
+pub const ERR_INVALID_SIGNATURE: i32 = -3004;
+
+// Coin errors.
+pub const ERR_LOSS_OF_PRECISION: i32 = -4000;
+pub const ERR_EXCESSIVE_VALUE: i32 = -4001;
+pub const ERR_FAILED_TO_PARSE: i32 = -4002;
+pub const ERR_TRANSACTION_ID_EXISTS: i32 = -4003;
+pub const ERR_INSUFFICIENT_BALANCE: i32 = -4004;
+pub const ERR_BALANCE_EXISTS: i32 = -4005;
+pub const ERR_NO_SUCH_BALANCE: i32 = -4006;
+
+// Login packet errors.
+pub const ERR_EXCEEDED_SIZE: i32 = -5001;
+pub const ERR_NO_SUCH_LOGIN_PACKET: i32 = -5002;
+pub const ERR_LOGIN_PACKET_EXISTS: i32 = -5003;
+
+// QuicP2P errors.
+pub const ERR_QUIC_P2P: i32 = -6000;

--- a/safe_core/src/ffi/error_codes.rs
+++ b/safe_core/src/ffi/error_codes.rs
@@ -7,7 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-
 #![allow(missing_docs)]
 
 // Core errors

--- a/safe_core/src/ffi/error_codes.rs
+++ b/safe_core/src/ffi/error_codes.rs
@@ -30,6 +30,19 @@ pub const ERR_IO: i32 = -16;
 
 // Data type errors
 pub const ERR_ACCESS_DENIED: i32 = -100;
+pub const ERR_NO_SUCH_DATA: i32 = -101;
+pub const ERR_DATA_EXISTS: i32 = -102;
+pub const ERR_NO_SUCH_ENTRY: i32 = -103;
+pub const ERR_TOO_MANY_ENTRIES: i32 = -104;
+pub const ERR_NO_SUCH_KEY: i32 = -105;
+pub const ERR_INVALID_OWNERS: i32 = -106;
+pub const ERR_INVALID_SUCCESSOR: i32 = -107;
+pub const ERR_INVALID_OPERATION: i32 = -108;
+pub const ERR_NETWORK_OTHER: i32 = -109;
+pub const ERR_INVALID_ENTRY_ACTIONS: i32 = -110;
+pub const ERR_DUPLICATE_MSG_ID: i32 = -111;
+pub const ERR_DUPLICATE_ENTRY_KEYS: i32 = -112;
+pub const ERR_KEYS_EXIST: i32 = -113;
 
 // IPC errors.
 pub const ERR_AUTH_DENIED: i32 = -200;
@@ -49,6 +62,9 @@ pub const ERR_INVALID_RANGE: i32 = -302;
 
 // IO error.
 pub const ERR_IO_ERROR: i32 = -1013;
+
+// Authenticator errors.
+pub const ERR_NO_SUCH_CONTAINER: i32 = -1014;
 
 // Unexpected error.
 pub const ERR_UNEXPECTED: i32 = -2000;

--- a/safe_core/src/ffi/mod.rs
+++ b/safe_core/src/ffi/mod.rs
@@ -12,6 +12,8 @@
 
 /// Type definitions for arrays that are FFI input params.
 pub mod arrays;
+/// FFI Error Codes
+pub mod error_codes;
 /// IPC utilities.
 pub mod ipc;
 /// NFS API.


### PR DESCRIPTION
This PR creates FFI-specific Result types for better separation.

Common FFI error codes have been moved to safe_core.

Resolves https://github.com/maidsafe/safe_client_libs/issues/1055

