### PR TITLE
chore/ci: use actions for build and release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,348 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-gnu
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --manifest-path=safe_authenticator/Cargo.toml
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --manifest-path=safe_app/Cargo.toml
+      - shell: bash
+        run: |
+          [[ -d "artifacts" ]] && rm -rf artifacts
+          mkdir artifacts
+          find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe_client_libs-${{ matrix.target }}-prod
+          path: artifacts
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: >
+            --release --manifest-path=safe_authenticator/Cargo.toml
+            --features=mock-network
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: >
+            --release --manifest-path=safe_app/Cargo.toml
+            --features=mock-network
+      - shell: bash
+        run: |
+          [[ -d "artifacts" ]] && rm -rf artifacts
+          mkdir artifacts
+          find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe_client_libs-${{ matrix.target }}-dev
+          path: artifacts
+
+  #build-ios:
+    #runs-on: macOS-latest
+    #strategy:
+      #matrix:
+        #target: [aarch64-apple-ios, x86_64-apple-ios]
+    #steps:
+      #- uses: actions/checkout@v1
+      #- uses: actions-rs/toolchain@v1
+        #with:
+          #toolchain: stable
+          #override: true
+          #target: ${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_authenticator/Cargo.toml
+            #--target=${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_app/Cargo.toml
+            #--target=${{ matrix.target }}
+      #- shell: bash
+        #run: |
+          #[[ -d "artifacts" ]] && rm -rf artifacts
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f
+            #-exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe_client_libs-${{ matrix.target }}-prod
+          #path: artifacts
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_authenticator/Cargo.toml
+            #--features=mock-network --target=${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_app/Cargo.toml
+            #--features=mock-network --target=${{ matrix.target }}
+      #- shell: bash
+        #run: |
+          #[[ -d "artifacts" ]] && rm -rf artifacts
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f
+            #-exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe_client_libs-${{ matrix.target }}-dev
+          #path: artifacts
+
+  # Put the universal iOS build here when macOS is ready.
+  # It will need to depend on the build-ios job.
+  
+  build-android:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [armv7-linux-androideabi, x86_64-linux-android]
+        type: [prod, dev]
+    env:
+      SAFE_CLIENT_LIBS_CONTAINER_TARGET: ${{ matrix.target }}
+      SAFE_CLIENT_LIBS_CONTAINER_TYPE: ${{ matrix.type }}
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        run: make build-android
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe_client_libs-${{ matrix.target }}-${{ matrix.type }}
+          path: artifacts
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build, build-android]
+    env:
+      AWS_ACCESS_KEY_ID: AKIAVVODCRMSDTFZ72NK
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # Checkout and get all the artifacts built in the previous jobs.
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-script
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-pc-windows-gnu-prod
+          path: artifacts/prod/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-pc-windows-gnu-dev
+          path: artifacts/dev/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-unknown-linux-gnu-prod
+          path: artifacts/prod/x86_64-unknown-linux-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-unknown-linux-gnu-dev
+          path: artifacts/dev/x86_64-unknown-linux-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-armv7-linux-androideabi-prod
+          path: artifacts/prod/armv7-linux-androideabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-armv7-linux-androideabi-dev
+          path: artifacts/dev/armv7-linux-androideabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-linux-android-prod
+          path: artifacts/prod/x86_64-linux-android/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-linux-android-dev
+          path: artifacts/dev/x86_64-linux-android/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe_client_libs-x86_64-apple-darwin-prod
+          #path: artifacts/prod/x86_64-apple-darwin/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe_client_libs-x86_64-apple-darwin-dev
+          #path: artifacts/dev/x86_64-apple-darwin/release
+
+      # Get information for the release.
+      - shell: bash
+        id: commit_message
+        run: |
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=commit_message::$commit_message"
+      - shell: bash
+        id: versioning
+        run: |
+          core_version=$(grep "^version" < safe_core/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          auth_version=$(grep "^version" < safe_authenticator/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          app_version=$(grep "^version" < safe_app/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=core_version::$core_version"
+          echo "::set-output name=auth_version::$auth_version"
+          echo "::set-output name=app_version::$app_version"
+
+      # Put the artifacts into tar/zip archives for deployment with the release.
+      - shell: bash
+        run: make package-commit_hash-deploy-artifacts
+        if: "!startsWith(steps.commit_message.outputs.commit_message, 'Version change')"
+      - shell: bash
+        run: make package-versioned-deploy-artifacts
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - shell: bash
+        id: release_description
+        run: |
+          #description=$(./scripts/get-release-description ${{ steps.versioning.outputs.app_version }})
+          description="replace when set-output problem has been fixed"
+          echo "::set-output name=description::$description"
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
+      # Create the release and attach safe_client_libs archives as assets.
+      - uses: csexton/create-release@add-body
+        id: create_release
+        with:
+          tag_name: ${{ steps.versioning.outputs.app_version }}
+          release_name: safe_client_libs
+          draft: false
+          prerelease: false
+          body: ${{ steps.release_description.outputs.description }}
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      #- uses: actions/upload-release-asset@v1.0.1
+        #with:
+          #upload_url: ${{ steps.create_release.outputs.upload_url }}
+          #asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
+          #asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
+          #asset_content_type: application/zip
+        #if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
+          asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
+          asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_content_type: application/zip
+      #- uses: actions/upload-release-asset@v1.0.1
+        #with:
+          #upload_url: ${{ steps.create_release.outputs.upload_url }}
+          #asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
+          #asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
+          #asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
+          asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
+          asset_content_type: application/zip
+
+      # Upload all the release archives to S3.
+      - uses: actions/aws/cli@master
+        with:
+          args: s3 sync deploy/dev s3://safe-client-libs
+      - uses: actions/aws/cli@master
+        with:
+          args: s3 sync deploy/prod s3://safe-client-libs
+
+  publish:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        id: commit_message
+        run: |
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=commit_message::$commit_message"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --manifest-path=safe_core/Cargo.toml --dry-run
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --manifest-path=safe_authenticator/Cargo.toml --dry-run
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --manifest-path=safe_app/Cargo.toml --dry-run
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,117 @@
+on: [pull_request]
+
+jobs:
+  #build-ios:
+    #runs-on: macOS-latest
+    #strategy:
+      #matrix:
+        #target: [aarch64-apple-ios, x86_64-apple-ios]
+    #steps:
+      #- uses: actions/checkout@v1
+      #- uses: actions-rs/toolchain@v1
+        #with:
+          #toolchain: stable
+          #override: true
+          #target: ${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_authenticator/Cargo.toml
+            #--target=${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_app/Cargo.toml
+            #--target=${{ matrix.target }}
+      #- shell: bash
+        #run: |
+          #[[ -d "artifacts" ]] && rm -rf artifacts
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f
+            #-exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe_client_libs-${{ matrix.target }}-prod
+          #path: artifacts
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_authenticator/Cargo.toml
+            #--features=mock-network --target=${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: >
+            #--release --manifest-path=safe_app/Cargo.toml
+            #--features=mock-network --target=${{ matrix.target }}
+      #- shell: bash
+        #run: |
+          #[[ -d "artifacts" ]] && rm -rf artifacts
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f
+            #-exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe_client_libs-${{ matrix.target }}-dev
+          #path: artifacts
+          
+  # Put the universal iOS build here when macOS is ready.
+  # It will need to depend on the build-ios job.
+
+  build-android:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [armv7-linux-androideabi, x86_64-linux-android]
+        type: [prod, dev]
+    env:
+      SAFE_CLIENT_LIBS_CONTAINER_TARGET: ${{ matrix.target }}
+      SAFE_CLIENT_LIBS_CONTAINER_TYPE: ${{ matrix.type }}
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        run: make build-android
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe_client_libs-${{ matrix.target }}-${{ matrix.type }}
+          path: artifacts
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    env:
+      SAFE_MOCK_IN_MEMORY_STORAGE: 1
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            config_mock_vault_path
+            --manifest-path=safe_core/Cargo.toml --features=mock-network
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --manifest-path=safe_core/Cargo.toml --features=mock-network
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --manifest-path=safe_authenticator/Cargo.toml --features=mock-network
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --release --manifest-path=safe_app/Cargo.toml
+            --features=mock-network
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --release --manifest-path=tests/Cargo.toml --features=mock-network

--- a/scripts/Dockerfile.android.armv7.build
+++ b/scripts/Dockerfile.android.armv7.build
@@ -1,10 +1,11 @@
 FROM rust:latest
 
-# These is only referenced in the build-android-cache script.
+# These are only referenced in the build-android-cache script.
 ARG build_type
-ARG target
+ARG build_target
 
-RUN addgroup --gid 1001 maidsafe && \
+# 115 is the ID of the group on the Actions slave.
+RUN addgroup --gid 115 maidsafe && \
     adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
     # The parent container sets this to the 'staff' group, which causes problems
     # with reading code stored in Cargo's registry.

--- a/scripts/Dockerfile.android.x86_64.build
+++ b/scripts/Dockerfile.android.x86_64.build
@@ -2,9 +2,10 @@ FROM rust:latest
 
 # These is only referenced in the build-android-cache script.
 ARG build_type
-ARG target
+ARG build_target
 
-RUN addgroup --gid 1001 maidsafe && \
+# 115 is the ID of the group on the Actions slave.
+RUN addgroup --gid 115 maidsafe && \
     adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
     # The parent container sets this to the 'staff' group, which causes problems
     # with reading code stored in Cargo's registry.

--- a/scripts/build-android-cache
+++ b/scripts/build-android-cache
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 
 if [[ -z "$build_type" ]]; then
-    echo "build_type must be set to dev or non-dev"
+    echo "build_type must be set to prod or dev"
     exit 1
 fi
 
-if [[ -z "$target" ]]; then
+if [[ -z "$build_target" ]]; then
     echo "target must be set to x86_64-linux-android or armv7-linux-androideabi"
     exit 1
 fi
 
-if [[ "$build_type" == "mock" ]]; then
+if [[ "$build_type" == "dev" ]]; then
     cargo build --features=mock-network \
-        --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$target"
+        --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$build_target"
     cargo build --features=mock-network \
-        --release --lib --manifest-path=safe_app/Cargo.toml --target="$target"
+        --release --lib --manifest-path=safe_app/Cargo.toml --target="$build_target"
 else
-    cargo build --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$target"
-    cargo build --release --lib --manifest-path=safe_app/Cargo.toml --target="$target"
+    cargo build --release --lib --manifest-path=safe_authenticator/Cargo.toml --target="$build_target"
+    cargo build --release --lib --manifest-path=safe_app/Cargo.toml --target="$build_target"
 fi

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+target=$1
+if [[ -z "$target" ]]; then
+    echo "You must supply the target for the build."
+    echo "Valid values are rust target triples, e.g. 'x86_64-unknown-linux-gnu', 'safe-api' or 'safe-ffi'."
+    exit 1
+fi
+
+build_type=$2
+if [[ -z "$build_type" ]]; then
+    echo "You must supply the type for the build."
+    echo "Valid values are 'dev' or 'prod'."
+    exit 1
+fi
+
+function get_dockerfile_name() {
+    case $target in
+        x86_64-unknown-linux-gnu)
+            echo "scripts/Dockerfile.build"
+            ;;
+        x86_64-linux-android)
+            echo "scripts/Dockerfile.android.x86_64.build"
+            ;;
+        armv7-linux-androideabi)
+            echo "scripts/Dockerfile.android.armv7.build"
+            ;;
+        *)
+            echo "$target is not supported. Please extend to support this target."
+            exit 1
+            ;;
+    esac
+}
+
+tag="$target-$build_type"
+rm -rf target/
+docker rmi -f maidsafe/safe-client-libs-build:"$tag" || true
+docker build -f $(get_dockerfile_name) -t maidsafe/safe-client-libs-build:"$tag" \
+    --build-arg build_target="$target" \
+    --build-arg build_type="$build_type" .

--- a/scripts/get-release-description
+++ b/scripts/get-release-description
@@ -71,41 +71,41 @@ s3_safe_auth_android_armv7_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.c
 s3_safe_auth_android_x86_64_deploy_url="https:\/\/safe-client-libs.s3.amazonaws.com\/safe_authenticator-mock-$version-x86_64-linux-android.tar.gz"
 
 tar_safe_app_linux_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    "./deploy/prod/safe_app-$version-x86_64-unknown-linux-gnu.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_app_macos_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/safe_app-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_app_win_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/prod/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_app_ios_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-apple-ios.tar.gz" | \
+    "./deploy/prod/safe_app-$version-apple-ios.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_app_android_armv7_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-armv7-linux-androideabi.tar.gz" | \
+    "./deploy/prod/safe_app-$version-armv7-linux-androideabi.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_app_android_x86_64_checksum=$(sha256sum \
-    "./deploy/real/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/prod/safe_app-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 
 tar_safe_auth_linux_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-x86_64-unknown-linux-gnu.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_auth_macos_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_auth_win_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_auth_ios_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-apple-ios.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-apple-ios.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_auth_android_armv7_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-armv7-linux-androideabi.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-armv7-linux-androideabi.tar.gz" | \
     awk '{ print $1 }')
 tar_safe_auth_android_x86_64_checksum=$(sha256sum \
-    "./deploy/real/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/prod/safe_authenticator-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/S3_SAFE_APP_LINUX_DEPLOY_URL/$s3_safe_app_linux_deploy_url/g" <<< "$release_description")

--- a/scripts/package-runner
+++ b/scripts/package-runner
@@ -44,7 +44,7 @@ function run_packaging() {
     package_args="$package_args --target $target --artifacts artifacts/$build_type"
     [[ "$deployment_type" == "nightly" ]] && package_args="$package_args --nightly"
     [[ "$deployment_type" == "commit_hash" ]] && package_args="$package_args --commit"
-    [[ "$build_type" == "dev" ]] && package_args="$package_args --mock"
+    [[ "$build_type" == "dev" ]] && package_args="$package_args --dev"
 
     package_command=(./scripts/package.rs $package_args)
     "${package_command[@]}"


### PR DESCRIPTION
Uses GitHub Actions for the build and release process, though at this point, it doesn't contain any builds for macOS, due to an issue with rust_sodium building on Catalina. The iOS stuff is in here, but it's currently commented out. When the rust_sodium problem is resolved, macOS-latest can be added the the appropriate strategy matrix and the job for building on iOS can be uncommented. After that you'll need to add a job for building the universal iOS library, but you can copy the `safe-api` Actions implementation for that.

The strategy matrix is utilised to reduce as much duplication as possible.

There is a full example build [here](https://github.com/jacderida/safe_client_libs/commit/44c4790158389f8e1b1e5f964332f6f5bbc02b98/checks?check_suite_id=316492320). There is a problem here with the `--dry-run` publish, but that's not a problem with the build process, it's something that needs to be resolved. You'll need to remove that `--dry-run` flag when you're satisfied things are ready.

For building on Android, the Makefile is used to help reduce duplication in the job definitions. Parameters can be passed for the target and the type of the build.

This also refactors some things around the containers being used:

* All the different targets for building and pushing the container were
replaced with 2 generic targets.
* To make them more easy and generic to use with Actions, the container
tags have been changed to container the build target and type (dev or
prod)

All references to "mock" and "real" in the release process should now be replaced with `dev` and `prod`, though they are probably still present in other things for legacy reasons.
