### PR TITLE
Fix non-mock tests and inconsistency with real vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,19 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config_file_handler"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,11 +884,6 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -1814,7 +1796,6 @@ version = "0.10.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1855,7 +1836,6 @@ name = "safe_authenticator"
 version = "0.10.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2839,7 +2819,6 @@ dependencies = [
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-"checksum config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0103336b0f2ddd541c0c81a60fc3be2e6e1d4f5b3dd8d89d2b2869d79d04efc4"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
@@ -2904,7 +2883,6 @@ dependencies = [
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)" = "c665266eb592905e8503ba3403020f4b8794d26263f412ca33171600eca9a6fa"

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.10.0"
 
 [dependencies]
 bincode = "~1.1.4"
-config_file_handler = "~0.11.0"
 env_logger = { version = "~0.6.2", optional = true }
 ffi_utils = "~0.12.0"
 futures = "~0.1.17"

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -9,7 +9,6 @@
 
 pub use self::codes::*;
 use bincode::Error as SerialisationError;
-use config_file_handler::Error as ConfigFileHandlerError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
@@ -256,12 +255,6 @@ impl From<IpcError> for AppError {
             IpcError::Unexpected(reason) => Self::Unexpected(reason),
             _ => Self::IpcError(err),
         }
-    }
-}
-
-impl From<ConfigFileHandlerError> for AppError {
-    fn from(err: ConfigFileHandlerError) -> Self {
-        Self::Unexpected(err.to_string())
     }
 }
 

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -12,7 +12,6 @@
 //! either one of them should also be reflected to the other to stay in sync.
 
 use super::AppError;
-use config_file_handler::FileHandler;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, FFI_RESULT_OK};
 use safe_core::utils::logging;
 use std::ffi::CString;
@@ -39,28 +38,22 @@ pub unsafe extern "C" fn app_init_logging(
     });
 }
 
-/// This function should be called to find where log file will be created. It
-/// will additionally create an empty log file in the path in the deduced
-/// location and will return the file name along with complete path to it.
+/// Returns the path at which the the configuration files are expected.
 #[no_mangle]
-pub unsafe extern "C" fn app_output_log_path(
-    output_file_name: *const c_char,
+pub unsafe extern "C" fn app_config_dir_path(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<(), AppError> {
-        let op_file = from_c_str(output_file_name)?;
-        let fh = FileHandler::<()>::new(&op_file, true)
-            .map_err(|e| AppError::Unexpected(format!("{}", e)))?;
-        let op_file_path = CString::new(
-            fh.path()
-                .to_path_buf()
+        let config_dir = safe_core::config_dir()?;
+        let config_dir_path = CString::new(
+            config_dir
                 .into_os_string()
                 .into_string()
                 .map_err(|_| AppError::Unexpected("Couldn't convert OsString".to_string()))?
                 .into_bytes(),
         )?;
-        o_cb(user_data, FFI_RESULT_OK, op_file_path.as_ptr());
+        o_cb(user_data, FFI_RESULT_OK, config_dir_path.as_ptr());
         Ok(())
     })
 }
@@ -80,19 +73,11 @@ mod tests {
 
     // Test path where log file is created.
     #[test]
-    fn output_log_path() {
-        let name = "_test path";
-        let path_str = unwrap!(CString::new(name));
+    fn config_dir_path() {
+        let path: String = unsafe { unwrap!(call_1(|ud, cb| app_config_dir_path(ud, cb),)) };
+        let expected_path = unwrap!(unwrap!(config_dir()).into_os_string().into_string());
 
-        let path: String = unsafe {
-            unwrap!(call_1(|ud, cb| app_output_log_path(
-                path_str.as_ptr(),
-                ud,
-                cb
-            ),))
-        };
-
-        assert!(path.contains(name));
+        assert_eq!(path, expected_path);
     }
 
     // Test logging errors to file.

--- a/safe_app/src/ffi/mod.rs
+++ b/safe_app/src/ffi/mod.rs
@@ -42,7 +42,6 @@ mod tests;
 use super::errors::AppError;
 use super::App;
 use bincode::deserialize;
-use config_file_handler;
 use ffi_utils::{catch_unwind_cb, from_c_str, FfiResult, OpaqueCtx, ReprC, FFI_RESULT_OK};
 use safe_core::ffi::ipc::resp::AuthGranted;
 use safe_core::ipc::{AuthGranted as NativeAuthGranted, BootstrapConfig};
@@ -127,29 +126,6 @@ pub unsafe extern "C" fn app_reconnect(
     })
 }
 
-/// Returns the expected name for the application executable without an extension
-#[no_mangle]
-pub unsafe extern "C" fn app_exe_file_stem(
-    user_data: *mut c_void,
-    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, filename: *const c_char),
-) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
-        if let Ok(path) = config_file_handler::exe_file_stem()?.into_string() {
-            let path_c_str = CString::new(path)?;
-            o_cb(user_data, FFI_RESULT_OK, path_c_str.as_ptr());
-        } else {
-            call_result_cb!(
-                Err::<(), _>(AppError::from(
-                    "config_file_handler returned invalid string",
-                )),
-                user_data,
-                o_cb
-            );
-        }
-        Ok(())
-    });
-}
-
 /// Sets the path from which the `safe_core.config` file will be read.
 #[no_mangle]
 pub unsafe extern "C" fn app_set_config_dir_path(
@@ -160,21 +136,6 @@ pub unsafe extern "C" fn app_set_config_dir_path(
     catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
         let new_path = CStr::from_ptr(new_path).to_str()?;
         config_handler::set_config_dir_path(OsStr::new(new_path));
-        o_cb(user_data, FFI_RESULT_OK);
-        Ok(())
-    });
-}
-
-/// Sets the additional path in `config_file_handler` to search for files
-#[no_mangle]
-pub unsafe extern "C" fn app_set_additional_search_path(
-    new_path: *const c_char,
-    user_data: *mut c_void,
-    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
-) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<_, AppError> {
-        let new_path = CStr::from_ptr(new_path).to_str()?;
-        config_file_handler::set_additional_search_path(OsStr::new(new_path));
         o_cb(user_data, FFI_RESULT_OK);
         Ok(())
     });

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.10.0"
 
 [dependencies]
 bincode = "~1.1.4"
-config_file_handler = "~0.11.0"
 ffi_utils = "~0.12.0"
 futures = "~0.1.17"
 jni = { version = "~0.12.0", optional = true }

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -904,7 +904,10 @@ mod tests {
         let sig = client_full_id.sign(&acc_ciphertext);
         let client_pk = *client_full_id.public_id().public_key();
         let new_login_packet = unwrap!(LoginPacket::new(acc_loc, client_pk, acc_ciphertext, sig));
+        let new_login_packet2 = new_login_packet.clone();
         let five_coins = unwrap!(Coins::from_str("5"));
+        let random_key = BlsSecretKey::random();
+        let random_pk = random_key.public_key();
 
         // The `random_client()` initializes the client with 10 coins.
         let start_bal = unwrap!(Coins::from_str("10"));
@@ -913,6 +916,8 @@ mod tests {
         random_client(move |client| {
             let c1 = client.clone();
             let c2 = client.clone();
+            let c3 = client.clone();
+            let c4 = client.clone();
             client
                 .insert_login_packet_for(
                     None,
@@ -922,7 +927,7 @@ mod tests {
                     new_login_packet.clone(),
                 )
                 // Make sure no error occurred.
-                .then(|result| match result {
+                .then(move |result| match result {
                     Ok(_transaction) => Ok::<_, CoreError>(()),
                     res => panic!("Unexpected {:?}", res),
                 })
@@ -936,16 +941,39 @@ mod tests {
                     )
                 })
                 // Re-insert to check for refunds for a failed insert_login_packet_for operation
-                .then(|result| match result {
+                // The balance is created first, so `BalanceExists` is returned.
+                .then(move |result| match result {
+                    Err(CoreError::DataError(SndError::BalanceExists)) => Ok::<_, CoreError>(()),
+                    res => panic!("Unexpected {:?}", res),
+                })
+                // For a different balance and an existing login packet
+                // `LoginPacketExists` should be returned.
+                .and_then(move |_| {
+                    c3.insert_login_packet_for(
+                        None,
+                        random_pk.into(),
+                        unwrap!(Coins::from_str("3")),
+                        None,
+                        new_login_packet2,
+                    )
+                })
+                .then(move |result| match result {
                     Err(CoreError::DataError(SndError::LoginPacketExists)) => {
-                        Ok::<_, CoreError>(())
+                        c4.get_balance(Some(&random_key))
                     }
                     res => panic!("Unexpected {:?}", res),
                 })
-                // Check if coins are refunded
-                .and_then(move |_| c2.get_balance(None))
+                // The new balance should exist
                 .and_then(move |balance| {
-                    let expected = calculate_new_balance(start_bal, Some(2), Some(five_coins));
+                    assert_eq!(balance, unwrap!(Coins::from_str("3")));
+                    c2.get_balance(None)
+                })
+                .and_then(move |balance| {
+                    let expected = calculate_new_balance(
+                        start_bal,
+                        Some(3),
+                        Some(unwrap!(Coins::from_str("8"))),
+                    );
                     assert_eq!(balance, expected);
                     Ok(())
                 })

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -10,7 +10,6 @@
 
 pub use self::codes::*;
 use bincode::Error as SerialisationError;
-use config_file_handler::Error as ConfigFileHandlerError;
 use ffi_utils::{ErrorCode, StringError};
 use futures::sync::mpsc::SendError;
 use safe_core::ipc::IpcError;
@@ -177,12 +176,6 @@ impl Into<IpcError> for AuthError {
 impl<T: 'static> From<SendError<T>> for AuthError {
     fn from(error: SendError<T>) -> Self {
         Self::Unexpected(error.description().to_owned())
-    }
-}
-
-impl From<ConfigFileHandlerError> for AuthError {
-    fn from(error: ConfigFileHandlerError) -> Self {
-        Self::from(error.to_string())
     }
 }
 

--- a/safe_core/src/config_handler.rs
+++ b/safe_core/src/config_handler.rs
@@ -198,7 +198,7 @@ pub fn write_config_file(config: &Config) -> Result<PathBuf, CoreError> {
     Ok(path)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mock-network"))]
 mod test {
     use super::*;
     use std::env::temp_dir;

--- a/tests/src/real_network.rs
+++ b/tests/src/real_network.rs
@@ -97,10 +97,6 @@ fn setup_test() -> *mut Authenticator {
         let exe_path = unwrap!(env::current_exe());
         let exe_path = exe_path.as_path();
 
-        // Test `auth_exe_file_stem`
-        let auth_exe: String = unsafe { unwrap!(call_1(|ud, cb| auth_exe_file_stem(ud, cb))) };
-        assert_eq!(auth_exe, unwrap!(unwrap!(exe_path.file_name()).to_str()));
-
         let crust_config_file = format!("{}.crust.config", unwrap!(exe_path.to_str()));
         println!("Copying crust.config to \"{}\"", crust_config_file);
 


### PR DESCRIPTION
- When running the custom_config_dir the non-mock tests break since the
config file is read from the wrong location. Feature-gate that test
behind mock-network
- In the real vault, for `CreateLoginPacketFor` a balance is first
created and then the login packet is inserted at the specified location.
Make the mock vault consistent with this.
