### PR TITLE
chore/ci: re-enable description for release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -232,8 +232,10 @@ jobs:
       - shell: bash
         id: release_description
         run: |
-          #description=$(./scripts/get-release-description ${{ steps.versioning.outputs.app_version }})
-          description="replace when set-output problem has been fixed"
+          description=$(./scripts/get-release-description ${{ steps.versioning.outputs.cli_version }})
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}"
           echo "::set-output name=description::$description"
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 


### PR DESCRIPTION
The description string is a small yaml document with multiple lines, but set-output truncates anything after the first line. The Actions developers advised fixing it the way it's been done here. I tested this
on safe-api and it works.

Here is the support issue thread:
https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
