### PR TITLE
Replace rust-sodium functions for symmetric encryption and key generation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -242,10 +242,10 @@ jobs:
       # Upload all the release archives to S3.
       - uses: actions/aws/cli@master
         with:
-          args: s3 sync deploy/dev s3://safe-client-libs
+          args: s3 sync deploy/dev s3://safe-client-libs --acl public-read
       - uses: actions/aws/cli@master
         with:
-          args: s3 sync deploy/prod s3://safe-client-libs
+          args: s3 sync deploy/prod s3://safe-client-libs --acl public-read
 
       # Create the release and attach safe_client_libs archives as assets.
       - uses: csexton/create-release@add-body

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
+name = "aes"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "block-cipher-trait",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+dependencies = [
+ "block-cipher-trait",
+ "byteorder",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+dependencies = [
+ "block-cipher-trait",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-cipher-trait"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmac"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4a435124bcc292eba031f1f725d7abacdaf13cbf9f935450e8c45aa9e96cad"
+dependencies = [
+ "block-cipher-trait",
+ "crypto-mac",
+ "dbl",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,12 +548,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array 0.12.3",
+ "subtle 1.0.0",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
 dependencies = [
  "sct",
+]
+
+[[package]]
+name = "ctr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
+dependencies = [
+ "block-cipher-trait",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -514,7 +586,7 @@ dependencies = [
  "clear_on_drop",
  "digest 0.8.1",
  "rand_core 0.3.1",
- "subtle",
+ "subtle 2.2.1",
 ]
 
 [[package]]
@@ -522,6 +594,15 @@ name = "data-encoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
+
+[[package]]
+name = "dbl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
+dependencies = [
+ "generic-array 0.12.3",
+]
 
 [[package]]
 name = "diff"
@@ -1183,6 +1264,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "miscreant"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e37d77fff73f19e198036d3ca2bdbf8d4bca650daeda979bae0fdd31fce11d9"
+dependencies = [
+ "aes",
+ "aesni",
+ "byteorder",
+ "cmac",
+ "crypto-mac",
+ "ctr",
+ "dbl",
+ "generic-array 0.12.3",
+ "pmac",
+ "stream-cipher",
+ "subtle 2.2.1",
+ "zeroize",
+]
+
+[[package]]
 name = "msdos_time"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1483,17 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+
+[[package]]
+name = "pmac"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd76d63e86aa67a4bd063079f0d93bb8730b036eea5697345f651e6874ea61e5"
+dependencies = [
+ "block-cipher-trait",
+ "crypto-mac",
+ "dbl",
+]
 
 [[package]]
 name = "podio"
@@ -1932,6 +2044,7 @@ dependencies = [
  "jni",
  "log 0.4.8",
  "lru-cache",
+ "miscreant",
  "rand 0.6.5",
  "rust_sodium",
  "safe-nd",
@@ -2033,6 +2146,7 @@ dependencies = [
  "log 0.4.8",
  "log4rs",
  "lru-cache",
+ "miscreant",
  "quic-p2p",
  "rand 0.6.5",
  "regex 1.3.1",
@@ -2264,6 +2378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "stream-cipher"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
 name = "strings"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2422,12 @@ dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
 ]
+
+[[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -2994,6 +3123,12 @@ dependencies = [
  "bit-vec",
  "chrono",
 ]
+
+[[package]]
+name = "zeroize"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+dependencies = [
+ "crypto-mac",
+ "digest 0.8.1",
+]
+
+[[package]]
 name = "http_req"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1458,16 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+dependencies = [
+ "byteorder",
+ "crypto-mac",
 ]
 
 [[package]]
@@ -2142,11 +2162,13 @@ dependencies = [
  "ffi_utils",
  "fs2",
  "futures",
+ "hmac",
  "lazy_static",
  "log 0.4.8",
  "log4rs",
  "lru-cache",
  "miscreant",
+ "pbkdf2",
  "quic-p2p",
  "rand 0.6.5",
  "regex 1.3.1",
@@ -2156,6 +2178,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
+ "sha3",
  "tempfile",
  "threshold_crypto",
  "tiny-keccak",

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -19,6 +19,7 @@ futures = "~0.1.17"
 jni = { version = "~0.12.0", optional = true }
 log = "~0.4.1"
 lru-cache = "~0.1.1"
+miscreant = { version = "0.4.2", features = ["soft-aes"] }
 rand = "0.6"
 rust_sodium = "~0.10.2"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", optional = true }

--- a/safe_app/build.rs
+++ b/safe_app/build.rs
@@ -17,7 +17,7 @@ fn main() {
 #[cfg(feature = "bindings")]
 mod bindings {
     use jni::signature::{JavaType, Primitive};
-    use rust_sodium::crypto::{box_, secretbox, sign};
+    use rust_sodium::crypto::{box_, sign};
     use safe_bindgen::{Bindgen, FilterMode, LangC, LangCSharp, LangJava};
     use safe_nd::XOR_NAME_LEN;
     use std::collections::HashMap;
@@ -197,8 +197,6 @@ mod bindings {
         lang.add_const("ulong", "ASYM_PUBLIC_KEY_LEN", box_::PUBLICKEYBYTES);
         lang.add_const("ulong", "ASYM_SECRET_KEY_LEN", box_::SECRETKEYBYTES);
         lang.add_const("ulong", "ASYM_NONCE_LEN", box_::NONCEBYTES);
-        lang.add_const("ulong", "SYM_KEY_LEN", secretbox::KEYBYTES);
-        lang.add_const("ulong", "SYM_NONCE_LEN", secretbox::NONCEBYTES);
         lang.add_const("ulong", "SIGN_PUBLIC_KEY_LEN", sign::PUBLICKEYBYTES);
         lang.add_const("ulong", "SIGN_SECRET_KEY_LEN", sign::SECRETKEYBYTES);
         lang.add_const("ulong", "XOR_NAME_LEN", XOR_NAME_LEN);

--- a/safe_app/src/ffi/ipc.rs
+++ b/safe_app/src/ffi/ipc.rs
@@ -337,7 +337,6 @@ mod tests {
     use crate::test_utils;
     use ffi_utils::test_utils::{call_1, call_2};
     use ffi_utils::ReprC;
-    use rust_sodium::crypto::secretbox;
     use safe_authenticator::ffi::ipc::encode_auth_resp;
     use safe_authenticator::test_utils as auth_utils;
     use safe_core::crypto::{shared_box, shared_secretbox};
@@ -618,7 +617,7 @@ mod tests {
         let access_container_info = AccessContInfo {
             id: rand::random(),
             tag: rand::random(),
-            nonce: secretbox::gen_nonce(),
+            nonce: utils::generate_nonce(),
         };
 
         let auth_granted = AuthGranted {

--- a/safe_authenticator/build.rs
+++ b/safe_authenticator/build.rs
@@ -16,7 +16,7 @@ fn main() {
 #[cfg(feature = "bindings")]
 mod bindings {
     use jni::signature::{JavaType, Primitive};
-    use rust_sodium::crypto::{box_, secretbox, sign};
+    use rust_sodium::crypto::{box_, sign};
     use safe_bindgen::{Bindgen, FilterMode, LangC, LangCSharp, LangJava};
     use safe_nd::XOR_NAME_LEN;
     use std::collections::HashMap;
@@ -200,8 +200,6 @@ mod bindings {
         lang.add_const("ulong", "ASYM_PUBLIC_KEY_LEN", box_::PUBLICKEYBYTES);
         lang.add_const("ulong", "ASYM_SECRET_KEY_LEN", box_::SECRETKEYBYTES);
         lang.add_const("ulong", "ASYM_NONCE_LEN", box_::NONCEBYTES);
-        lang.add_const("ulong", "SYM_KEY_LEN", secretbox::KEYBYTES);
-        lang.add_const("ulong", "SYM_NONCE_LEN", secretbox::NONCEBYTES);
         lang.add_const("ulong", "SIGN_PUBLIC_KEY_LEN", sign::PUBLICKEYBYTES);
         lang.add_const("ulong", "SIGN_SECRET_KEY_LEN", sign::SECRETKEYBYTES);
         lang.add_const("ulong", "XOR_NAME_LEN", XOR_NAME_LEN);

--- a/safe_authenticator/src/tests/utils.rs
+++ b/safe_authenticator/src/tests/utils.rs
@@ -10,10 +10,9 @@ use crate::access_container::{fetch_authenticator_entry, put_authenticator_entry
 use crate::client::AuthClient;
 use crate::AuthFuture;
 use futures::Future;
-use rust_sodium::crypto::secretbox;
 use safe_core::crypto::shared_secretbox;
 use safe_core::ipc::req::{ContainerPermissions, Permission};
-use safe_core::FutureExt;
+use safe_core::{utils, FutureExt};
 use std::collections::HashMap;
 
 // Creates a containers request asking for "documents with permission to
@@ -45,7 +44,7 @@ pub fn corrupt_container(client: &AuthClient, container_id: &str) -> Box<AuthFut
         .and_then(move |(version, mut ac_entry)| {
             {
                 let entry = unwrap!(ac_entry.get_mut(&container_id));
-                entry.enc_info = Some((shared_secretbox::gen_key(), secretbox::gen_nonce()));
+                entry.enc_info = Some((shared_secretbox::gen_key(), utils::generate_nonce()));
             }
             // Update the old entry.
             put_authenticator_entry(&c2, &ac_entry, version + 1)

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -25,13 +25,14 @@ lazy_static = "~1.2.0"
 log = "~0.4.8"
 log4rs = { version = "~0.8.3", features = ["toml_format"] }
 lru-cache = "~0.1.1"
+miscreant = { version = "0.4.2", features = ["soft-aes"] }
 quic-p2p = "~0.3.0"
 rand = "0.6"
 rust_sodium = "~0.10.2"
 regex = "~1.3.1"
 safe-nd = "~0.6.0"
 self_encryption = "~0.15.0"
-serde = { version = "~1.0.97", features = ["derive"] }
+serde = { version = "~1.0.97", features = ["derive", "rc"] }
 serde_json = "~1.0.40"
 serde-value = "~0.5.3"
 tiny-keccak = "~1.5.0"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -26,6 +26,7 @@ log = "~0.4.8"
 log4rs = { version = "~0.8.3", features = ["toml_format"] }
 lru-cache = "~0.1.1"
 miscreant = { version = "0.4.2", features = ["soft-aes"] }
+pbkdf2 = { version = "0.3.0", default-features = false }
 quic-p2p = "~0.3.0"
 rand = "0.6"
 rust_sodium = "~0.10.2"
@@ -35,6 +36,8 @@ self_encryption = "~0.15.0"
 serde = { version = "~1.0.97", features = ["derive", "rc"] }
 serde_json = "~1.0.40"
 serde-value = "~0.5.3"
+hmac = "0.7.1"
+sha3 = "0.8.2"
 tiny-keccak = "~1.5.0"
 threshold_crypto = "~0.3.2"
 tokio = "~0.1.22"

--- a/safe_core/src/crypto.rs
+++ b/safe_core/src/crypto.rs
@@ -51,7 +51,7 @@ pub mod shared_secretbox {
 
     /// Generate new random shared symmetric encryption key.
     pub fn gen_key() -> Key {
-        Key::new(&utils::generate_symm_enc_key())
+        Key::new(&utils::generate_sym_enc_key())
     }
 
     impl Deref for Key {

--- a/safe_core/src/ffi/arrays.rs
+++ b/safe_core/src/ffi/arrays.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::utils::{SYM_ENC_KEY_LEN, SYM_ENC_NONCE_LEN};
 use rust_sodium::crypto::box_::{
     NONCEBYTES as ASYM_NONCE_LEN, PUBLICKEYBYTES as ASYM_PUBLIC_KEY_LEN,
     SECRETKEYBYTES as ASYM_SECRET_KEY_LEN,
 };
-use rust_sodium::crypto::secretbox::{KEYBYTES as SYM_KEY_LEN, NONCEBYTES as SYM_NONCE_LEN};
 use safe_nd::XOR_NAME_LEN;
 use threshold_crypto::{PK_SIZE as BLS_PUBLIC_KEY_LEN, SIG_SIZE};
 
@@ -22,9 +22,9 @@ pub type AsymSecretKey = [u8; ASYM_SECRET_KEY_LEN];
 pub type AsymNonce = [u8; ASYM_NONCE_LEN];
 
 /// Array containing private key bytes.
-pub type SymSecretKey = [u8; SYM_KEY_LEN];
+pub type SymSecretKey = [u8; SYM_ENC_KEY_LEN];
 /// Array containing nonce bytes.
-pub type SymNonce = [u8; SYM_NONCE_LEN];
+pub type SymNonce = [u8; SYM_ENC_NONCE_LEN];
 
 /// Array containing BLS public key.
 pub type BlsPublicKey = [u8; BLS_PUBLIC_KEY_LEN];

--- a/safe_core/src/nfs/tests.rs
+++ b/safe_core/src/nfs/tests.rs
@@ -15,11 +15,10 @@ use crate::nfs::reader::Reader;
 use crate::nfs::writer::Writer;
 use crate::nfs::{create_dir, File, Mode, NfsError, NfsFuture};
 use crate::utils::test_utils::random_client;
-use crate::utils::{generate_random_vector, FutureExt};
+use crate::utils::{self, generate_random_vector, FutureExt};
 use crate::DIR_TAG;
 use futures::future::{self, Loop};
 use futures::Future;
-use rust_sodium::crypto::secretbox;
 use safe_nd::{Error as SndError, MDataKind};
 use self_encryption::MIN_CHUNK_SIZE;
 use std;
@@ -86,8 +85,8 @@ fn file_fetch_public_md() {
         let c7 = client.clone();
 
         let mut root = unwrap!(MDataInfo::random_public(MDataKind::Unseq, DIR_TAG));
-        root.enc_info = Some((shared_secretbox::gen_key(), secretbox::gen_nonce()));
-        root.new_enc_info = Some((shared_secretbox::gen_key(), secretbox::gen_nonce()));
+        root.enc_info = Some((shared_secretbox::gen_key(), utils::generate_nonce()));
+        root.new_enc_info = Some((shared_secretbox::gen_key(), utils::generate_nonce()));
         let root2 = root.clone();
 
         create_dir(client, &root, btree_map![], btree_map![])

--- a/safe_core/src/utils/mod.rs
+++ b/safe_core/src/utils/mod.rs
@@ -82,7 +82,7 @@ struct SymmetricEnc {
 }
 
 /// Generates a symmetric encryption key
-pub fn generate_symm_enc_key() -> SymEncKey {
+pub fn generate_sym_enc_key() -> SymEncKey {
     rand::random()
 }
 


### PR DESCRIPTION
- Replace the use of symmetric encryption methods from rust-sodium with
miscreant.
- Use pbkdf2 for key generation
- This PR also updates the deploy github action to make the deployed artifacts publicly readable.