### PR TITLE
Update version number and changelog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "safe_app"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "clap",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "safe_authenticator"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "env_logger 0.6.2",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "safe_core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "bincode",
  "bytes",

--- a/safe_app/CHANGELOG.md
+++ b/safe_app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SAFE App
 
+## [0.11.0]
+- Update to quic-p2p 0.3.0
+- Add `set_config_dir_path` API to set a custom path for configuration files.
+- Deprecate the `maidsafe_utilities` and `config_file_handler` dependencies.
+- Migrate to GitHub actions for CI / CD for all platforms except Mac OS builds.
+
 ## [0.10.0]
 - Use safe_core 0.33.0.
 - Use the new network data types.

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR BSD-3-Clause"
 name = "safe_app"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_client_libs"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 bincode = "~1.1.4"
@@ -22,8 +22,8 @@ lru-cache = "~0.1.1"
 miscreant = { version = "0.4.2", features = ["soft-aes"] }
 rand = "0.6"
 rust_sodium = "~0.10.2"
-safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", optional = true }
-safe_core = { path = "../safe_core", version = "~0.35.0" }
+safe_authenticator = { path = "../safe_authenticator", version = "~0.11.0", optional = true }
+safe_core = { path = "../safe_core", version = "~0.36.0" }
 safe-nd = "~0.6.0"
 self_encryption = "~0.15.0"
 serde = "~1.0.27"
@@ -36,8 +36,8 @@ unwrap = "~1.2.0"
 [dev-dependencies]
 clap = "~2.33.0"
 env_logger = "~0.6.2"
-safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", features = ["testing"] }
-safe_core = { path = "../safe_core", version = "~0.35.0", features = ["testing"] }
+safe_authenticator = { path = "../safe_authenticator", version = "~0.11.0", features = ["testing"] }
+safe_core = { path = "../safe_core", version = "~0.36.0", features = ["testing"] }
 
 [build-dependencies]
 ffi_utils = "~0.14.0"

--- a/safe_app_jni/Cargo.toml
+++ b/safe_app_jni/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.1.0"
 ffi_utils = { version = "0.14.0", features = ["java"] }
 jni = "~0.12.0"
 log = "~0.4.5"
-safe_app = { path = "../safe_app", version = "~0.10.0", features = ["bindings"] }
-safe_core = { path = "../safe_core", version = "~0.35.0" }
+safe_app = { path = "../safe_app", version = "~0.11.0", features = ["bindings"] }
+safe_core = { path = "../safe_core", version = "~0.36.0" }
 unwrap = "~1.2.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/safe_authenticator/CHANGELOG.md
+++ b/safe_authenticator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SAFE Authenticator - Change Log
 
+## [0.11.0]
+- Update to quic-p2p 0.3.0
+- Add `set_config_dir_path` API to set a custom path for configuration files.
+- Deprecate the `maidsafe_utilities` and `config_file_handler` dependencies.
+- Migrate to GitHub actions for CI / CD for all platforms except Mac OS builds.
+- Fix inconsistency with real vault.
+
 ## [0.10.0]
 - Use safe_core 0.33.0.
 - Use the new network data types internally.

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 name = "safe_authenticator"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_client_libs"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 bincode = "~1.1.4"
@@ -21,7 +21,7 @@ lru-cache = "~0.1.1"
 quic-p2p = "~0.3.0"
 rand = "0.6"
 rust_sodium = "~0.10.2"
-safe_core = { path = "../safe_core", version = "~0.35.0" }
+safe_core = { path = "../safe_core", version = "~0.36.0" }
 safe-nd = "~0.6.0"
 serde = { version = "~1.0.97", features = ["derive"] }
 threshold_crypto = "~0.3.2"
@@ -32,7 +32,7 @@ env_logger = { version = "~0.6.2", optional = true }
 
 [dev-dependencies]
 env_logger = "~0.6.2"
-safe_core = { path = "../safe_core", version = "~0.35.0", features = ["testing"] }
+safe_core = { path = "../safe_core", version = "~0.36.0", features = ["testing"] }
 
 [build-dependencies]
 ffi_utils = "~0.14.0"

--- a/safe_authenticator_jni/Cargo.toml
+++ b/safe_authenticator_jni/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.1.0"
 ffi_utils = { version = "~0.14.0", features = ["java"] }
 jni = "~0.12.0"
 log = "~0.4.5"
-safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", features = ["bindings"] }
-safe_core = { path = "../safe_core", version = "~0.35.0" }
+safe_authenticator = { path = "../safe_authenticator", version = "~0.11.0", features = ["bindings"] }
+safe_core = { path = "../safe_core", version = "~0.36.0" }
 unwrap = "~1.2.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/safe_core/CHANGELOG.md
+++ b/safe_core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Safe Core - Change Log
 
+## [0.36.0]
+- Update to quic-p2p 0.3.0
+- Add `set_config_dir_path` API to set a custom path for configuration files.
+- Deprecate the `maidsafe_utilities` and `config_file_handler` dependencies.
+- Migrate to GitHub actions for CI / CD for all platforms except Mac OS builds.
+- Fix inconsistency with real vault.
+
 ## [0.35.0]
 - Remove unused `routing` module and fix errors
 - Rework MDataKey and MDataValue to use FFI conventions

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 name = "safe_core"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_client_libs"
-version = "0.35.0"
+version = "0.36.0"
 
 [dependencies]
 bincode = "~1.1.4"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.1.0"
 [dependencies]
 ffi_utils = "~0.14.0"
 futures = "~0.1.17"
-safe_app = { path = "../safe_app", version = "~0.10.0", features = ["testing"] }
-safe_authenticator = { path = "../safe_authenticator", version = "~0.10.0", features = ["testing"] }
-safe_core = { path = "../safe_core", version = "~0.35.0", features = ["testing"] }
+safe_app = { path = "../safe_app", version = "~0.11.0", features = ["testing"] }
+safe_authenticator = { path = "../safe_authenticator", version = "~0.11.0", features = ["testing"] }
+safe_core = { path = "../safe_core", version = "~0.36.0", features = ["testing"] }
 safe-nd = "~0.6.0"
 serde = "~1.0.24"
 serde_derive = "~1.0.24"


### PR DESCRIPTION
- New versions of safe_core, safe_authenticator and safe_app were
manually released by checking out to commit 26add71
- Update version number and changelog for the above mentioned crates.
- Note that the commit does not follow the standard for version change commits since we don't want the publish github action to be triggered.
