### PR TITLE
Enable tests in safe_core::client::mock

### DIFF
--- a/safe_core/src/client/mock/mod.rs
+++ b/safe_core/src/client/mock/mod.rs
@@ -10,9 +10,8 @@ pub mod vault;
 
 mod account;
 mod connection_manager;
-// TODO: Update these tests
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 pub use self::account::{Account, CoinBalance};
 pub use self::connection_manager::{ConnectionManager, RequestHookFn};


### PR DESCRIPTION
@m-cat this PR is a work in progress to re-enable the tests in the `safe_core::client::mock`.

I have refactored the helper functions used for the tests and re-enabled a single test. Let me know what you think about this approach. If it's okay, then I can proceed with refactoring the other tests as well using the same pattern. Thanks!

EDIT: PR is now ready for review