### PR TITLE
chore/ci: add missing macOS build job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,12 +16,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-gnu
+          - os: macOS-latest
+            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
