### PR TITLE
Enable tests in safe_core::client::mock - Part 2

### DIFF
--- a/safe_core/src/client/mock/connection_manager.rs
+++ b/safe_core/src/client/mock/connection_manager.rs
@@ -53,6 +53,17 @@ impl ConnectionManager {
         })
     }
 
+    /// Create a new connection manager with the vault instance created from the provided config.
+    pub fn new_with_vault(vault_config: Config, net_tx: &NetworkTx) -> Result<Self, CoreError> {
+        Ok(Self {
+            vault: Arc::new(Mutex::new(Vault::new(vault_config))),
+            request_hook: None,
+            response_hook: None,
+            groups: Arc::new(Mutex::new(HashSet::default())),
+            net_tx: net_tx.clone(),
+        })
+    }
+
     /// Returns `true` if this connection manager is already connected to a Client Handlers
     /// group serving the provided public ID.
     pub fn has_connection_to(&self, pub_id: &PublicId) -> bool {

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -1467,8 +1467,16 @@ impl FileStore {
 
     #[cfg(test)]
     fn open_file(&self) -> File {
-        assert!(self.path.is_none());
-        unwrap!(tempfile())
+        if let Some(path) = &self.path {
+            // Using File::create here as it creates a new file in write mode if it doesn't exist
+            // or truncates if it already exists.
+            unwrap!(
+                std::fs::File::create(path),
+                "Error creating mock vault file"
+            )
+        } else {
+            unwrap!(tempfile())
+        }
     }
 }
 


### PR DESCRIPTION
Re-enables 2nd half of the mock vault tests in safe_core.
Rebased on: https://github.com/maidsafe/safe_client_libs/pull/1106