### PR TITLE
chore/ci: add missing iOS builds to GHA deploy + fix tags

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -229,6 +229,32 @@ jobs:
         with:
           name: safe_client_libs-x86_64-apple-darwin-dev
           path: artifacts/dev/x86_64-apple-darwin/release
+      # iOS
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-aarch64-apple-ios-prod
+          path: artifacts/prod/aarch64-apple-ios/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-aarch64-apple-ios-dev
+          path: artifacts/dev/aarch64-apple-ios/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-apple-ios-prod
+          path: artifacts/prod/x86_64-apple-ios/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-x86_64-apple-ios-dev
+          path: artifacts/dev/x86_64-apple-ios/release
+      # Universal iOS
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-apple-ios-prod
+          path: artifacts/prod/apple-ios/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe_client_libs-apple-ios-dev
+          path: artifacts/dev/apple-ios/release
 
       # Get information for the release.
       - shell: bash
@@ -276,12 +302,14 @@ jobs:
       - uses: csexton/create-release@add-body
         id: create_release
         with:
-          tag_name: ${{ steps.versioning.outputs.app_version }}
+          tag_name: safe_core-${{ steps.versioning.outputs.core_version }}-safe_app-${{ steps.versioning.outputs.app_version }}
           release_name: safe_client_libs
           draft: false
           prerelease: false
           body: ${{ steps.release_description.outputs.description }}
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
+      # Upload safe_app assets
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -320,36 +348,80 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
-          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-aarch64-apple-ios.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-aarch64-apple-ios.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
-          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-apple-ios.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-x86_64-apple-ios.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
-          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-apple-darwin.tar.gz
+          asset_path: deploy/prod/safe_app-${{ steps.versioning.outputs.app_version }}-apple-ios.tar.gz
+          asset_name: safe_app-${{ steps.versioning.outputs.app_version }}-apple-ios.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
+      # Upload safe_auth assets
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-unknown-linux-gnu.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
-          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-x86_64-linux-android.tar.gz
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-pc-windows-gnu.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
-          asset_name: safe_authenticator-${{ steps.versioning.outputs.app_version }}-armv7-linux-androideabi.tar.gz
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-apple-darwin.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-apple-darwin.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-linux-android.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-linux-android.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-armv7-linux-androideabi.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-armv7-linux-androideabi.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-aarch64-apple-ios.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-aarch64-apple-ios.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-apple-ios.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-x86_64-apple-ios.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe_authenticator-${{ steps.versioning.outputs.auth_version }}-apple-ios.tar.gz
+          asset_name: safe_authenticator-${{ steps.versioning.outputs.auth_version }}-apple-ios.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ stages:
   - warmup
   - tests
   - tests-binary-compat
-  - deploy
 jobs:
   include:
     # Warm up the cache dependencies
@@ -49,18 +48,6 @@ jobs:
       script: set -x; scripts/build-binary
       # if: type = push
       os: linux
-
-    # Deploy
-    - stage: deploy
-      script: set -x; true
-      if: type = push
-      os: linux
-      env: RUN_DEPLOY=1
-    - stage: deploy
-      script: set -x; true
-      if: type = push
-      os: osx
-      env: RUN_DEPLOY=1
 sudo: false
 cache:
   # Double the default timeout.
@@ -100,35 +87,3 @@ after_script:
     fi
 before_cache:
   - cargo prune
-before_deploy:
-  - bash cargo_install.sh cargo-script 0.2.8
-  - mkdir -p target/deploy
-  - if [[ "$TRAVIS_COMMIT_MESSAGE" =~ [Vv]ersion[[:space:]]change.*safe_authenticator[[:space:]]to[[:space:]]([^;]+) ]]; then
-      ./scripts/package.rs --rebuild --lib --name safe_app -d target/deploy --mock --strip;
-      ./scripts/package.rs --rebuild --lib --name safe_app -d target/deploy --strip;
-    else
-      ./scripts/package.rs --rebuild --lib --name safe_app -d target/deploy --mock --commit --strip;
-      ./scripts/package.rs --rebuild --lib --name safe_app -d target/deploy --commit --strip;
-    fi
-  - if [[ "$TRAVIS_COMMIT_MESSAGE" =~ [Vv]ersion[[:space:]]change.*safe_app[[:space:]]to[[:space:]]([^;]+) ]]; then
-      ./scripts/package.rs --rebuild --lib --name safe_authenticator -d target/deploy --mock --strip;
-      ./scripts/package.rs --rebuild --lib --name safe_authenticator -d target/deploy --strip;
-    else
-      ./scripts/package.rs --rebuild --lib --name safe_authenticator -d target/deploy --mock --commit --strip;
-      ./scripts/package.rs --rebuild --lib --name safe_authenticator -d target/deploy --commit --strip;
-    fi
-deploy:
-  provider: s3
-  access_key_id: AKIAIA2TXTG7EV5VIG2Q
-  secret_access_key:
-    secure: qEDay6TCAy3tBLqLYFOx9OjAdoRl010paK2//teFETfwUfJA/RtNSfkp1yrgx+kZ3FO8cthdDnwR3zjM3pkCL+5mGkQMAgvRY7rcEB5H1VyO4jkZRoB4n/yUu5jB4dHdeeRWTOJxNOOPA0G1Q65LLkJql2JGoJatqE3pBmJm0X8=
-  bucket: safe-client-libs
-  local-dir: target/deploy
-  acl: public_read
-  region: eu-west-2
-  skip_cleanup: true
-  on:
-    branch: master
-    tags: false
-    condition: $RUN_DEPLOY = 1
-after_deploy: rm -rf target/deploy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,20 +69,3 @@ test_script:
     cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
     cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
     cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
-
-before_deploy:
-  - PowerShell .\scripts\package.ps1
-  - ps: $root = Resolve-Path .\target\deploy; [IO.Directory]::GetFiles($root.Path, '*.zip') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) }
-  - ps: $root = Resolve-Path .\target\deploy; [IO.Directory]::GetFiles($root.Path, '*.tar.gz') | % { Push-AppveyorArtifact $_ -FileName $_.Substring($root.Path.Length + 1) }
-
-deploy:
-  provider: S3
-  access_key_id: AKIAIA2TXTG7EV5VIG2Q
-  secret_access_key:
-    secure: WtcjRuYVPF9Fhv1qBVBG+rP6VR7HEa+IayW1L8GqhgUJmp1M8gV4J9u/TdY5Fsb2
-  bucket: safe-client-libs
-  region: eu-west-2
-  set_public: true
-  artifact: /.*\.zip/,/.*\.tar.gz/
-  on:
-    branch: master

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -8,8 +8,8 @@
 
 /// User Account information.
 pub mod account;
-/// Not exclusively for testing purposes but also for its wait_for_response macro.
-#[macro_use]
+/// Core client used for testing purposes.
+#[cfg(any(test, feature = "testing"))]
 pub mod core_client;
 /// `MDataInfo` utilities.
 pub mod mdata_info;

--- a/scripts/package-runner
+++ b/scripts/package-runner
@@ -19,20 +19,17 @@ fi
 
 if [[ ! -d "artifacts" ]]; then
     echo "This script is intended to be used with a docker container and a set of pre-built artifacts."
-    echo "Place these artifacts in an 'artifacts' folder at the root of the reptargetitory and perform the 'docker run' command again."
+    echo "Place these artifacts in an 'artifacts' folder at the root of the repository and perform the 'docker run' command again."
     exit 1
 fi
 
 export RUST_BACKTRACE=1
 [[ ! -d "deploy" ]] && mkdir -p deploy/prod deploy/dev
 
-#declare -a targets=(\
-    #"x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
-    #"armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
-    #"aarch64-apple-ios" "apple-ios")
 declare -a targets=(\
-    "x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" \
-    "armv7-linux-androideabi" "x86_64-linux-android")
+    "x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
+    "armv7-linux-androideabi" "x86_64-linux-android" \
+    "aarch64-apple-ios" "x86_64-apple-ios" "apple-ios")
 
 function run_packaging() {
     local name=$1


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->

The last version-commit workflow in master has failed. This PR should fix those issues.

These changes have been tested on my fork [here](https://github.com/m-cat/safe_client_libs/commit/ae2e949b5dd57e00e5e9f2879a296f95c2752e65/checks?check_suite_id=351959029).

It produced [this release](https://github.com/m-cat/safe_client_libs/releases/tag/safe_core-0.37.1-safe_app-0.12.0).