### PR TITLE
chore/ci: add caching to GHA

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,6 +31,24 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # Build prod libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -48,6 +66,8 @@ jobs:
         with:
           name: safe_client_libs-${{ matrix.target }}-prod
           path: artifacts
+
+      # Build dev libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -84,6 +104,24 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.target }}
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # Build prod libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -101,10 +139,13 @@ jobs:
           [[ -d "artifacts" ]] && rm -rf artifacts
           mkdir artifacts
           find "target/${{ matrix.target }}/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      # Upload for build-ios-universal
       - uses: actions/upload-artifact@master
         with:
           name: safe_client_libs-${{ matrix.target }}-prod
           path: artifacts
+
+      # Build dev libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -122,6 +163,7 @@ jobs:
           [[ -d "artifacts" ]] && rm -rf artifacts
           mkdir artifacts
           find "target/${{ matrix.target }}/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      # Upload for build-ios-universal
       - uses: actions/upload-artifact@master
         with:
           name: safe_client_libs-${{ matrix.target }}-dev
@@ -428,6 +470,7 @@ jobs:
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 
+  # Automatic publish, triggered by a commit starting with "Version change".
   publish:
     name: Publish
     needs: deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,10 +21,28 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      # Check if the code is formatted correctly.
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      # Run Clippy.
       - shell: bash
         run: ./scripts/clippy-all
 
@@ -39,6 +57,23 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      # Test build scripts.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -57,6 +92,24 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.target }}
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # Build prod libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -79,6 +132,8 @@ jobs:
         with:
           name: safe_client_libs-${{ matrix.target }}-prod
           path: artifacts
+
+      # Build dev libraries.
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -138,6 +193,7 @@ jobs:
       - shell: bash
         run: make build-android
 
+  # Run test suite.
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -151,6 +207,23 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      # Run tests.
       - shell: bash
         run: ./scripts/test-mock
 


### PR DESCRIPTION
This PR enables caching in GitHub Actions.

I'm happy to report that, while builds are slightly slower if there is no matching cache, they are significantly faster when the cache is available.

[Control build without cache:](https://github.com/m-cat/safe_client_libs/runs/347511290)

|Ubuntu|Windows|macOS|iOS aarch64|iOS x86_64|
|---|---|---|---|---|
|780s|1219s|529s|569s|568s|

[First build with caching (no cache available):](https://github.com/m-cat/safe_client_libs/runs/347594633)

|Ubuntu|Windows|macOS|iOS aarch64|iOS x86_64|
|---|---|---|---|---|
|913s|1265s|576s|605s|619s|
|117%|104%|109%|106%|109%|

[Second build with caching (cache available):](https://github.com/m-cat/safe_client_libs/runs/347647058)

|Ubuntu|Windows|macOS|iOS aarch64|iOS x86_64|
|---|---|---|---|---|
|403s|655s|294s|463s|458s|
|52%|54%|56%|81%|81%|