### PR TITLE
Pedantic auth&app

### DIFF
--- a/safe_app/src/cipher_opt.rs
+++ b/safe_app/src/cipher_opt.rs
@@ -47,8 +47,8 @@ impl CipherOpt {
     /// Encrypt plain text
     pub fn encrypt(&self, plain_text: &[u8], app_ctx: &AppContext) -> Result<Vec<u8>, AppError> {
         match *self {
-            CipherOpt::PlainText => Ok(serialize(&WireFormat::Plain(plain_text.to_owned()))?),
-            CipherOpt::Symmetric => {
+            Self::PlainText => Ok(serialize(&WireFormat::Plain(plain_text.to_owned()))?),
+            Self::Symmetric => {
                 let nonce = utils::generate_nonce().to_vec();
                 let sym_enc_key = app_ctx.sym_enc_key()?;
                 let mut cipher = Aes128SivAead::new(&**sym_enc_key);
@@ -57,7 +57,7 @@ impl CipherOpt {
 
                 Ok(serialize(&wire_format)?)
             }
-            CipherOpt::Asymmetric {
+            Self::Asymmetric {
                 ref peer_encrypt_key,
             } => {
                 let cipher_text = peer_encrypt_key.encrypt(plain_text);

--- a/safe_app/src/client.rs
+++ b/safe_app/src/client.rs
@@ -24,7 +24,7 @@ use std::rc::Rc;
 use std::time::Duration;
 use tokio::runtime::current_thread::{block_on_all, Handle};
 
-/// Client object used by safe_app.
+/// Client object used by `safe_app`.
 pub struct AppClient {
     inner: Rc<RefCell<Inner<AppClient, AppContext>>>,
     app_inner: Rc<RefCell<AppInner>>,
@@ -178,12 +178,12 @@ impl Client for AppClient {
 
     fn public_encryption_key(&self) -> threshold_crypto::PublicKey {
         let app_inner = self.app_inner.borrow();
-        app_inner.keys.clone().enc_pk
+        app_inner.keys.clone().enc_public_key
     }
 
     fn secret_encryption_key(&self) -> shared_box::SecretKey {
         let app_inner = self.app_inner.borrow();
-        app_inner.keys.clone().enc_sk
+        app_inner.keys.clone().enc_secret_key
     }
 
     fn secret_symmetric_key(&self) -> shared_secretbox::Key {

--- a/safe_app/src/errors.rs
+++ b/safe_app/src/errors.rs
@@ -200,7 +200,7 @@ impl Display for AppError {
                 formatter,
                 "Invalid file mode (e.g. trying to write when file is opened for reading only)"
             ),
-            AppError::UnregisteredClientAccess => write!(
+            Self::UnregisteredClientAccess => write!(
                 formatter,
                 "Tried to access a client key from an unregistered client",
             ),
@@ -435,7 +435,7 @@ fn core_error_code(err: &CoreError) -> i32 {
             SndError::InsufficientBalance => ERR_INSUFFICIENT_BALANCE,
             SndError::ExceededSize => ERR_EXCEEDED_SIZE,
         },
-        CoreError::QuicP2p(ref _err) => ERR_QUIC_P2P, // FIXME: use proper error codes
+        CoreError::QuicP2p(ref _error) => ERR_QUIC_P2P, // FIXME: use proper error codes
         CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
         CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
         CoreError::OperationAborted => ERR_OPERATION_ABORTED,

--- a/safe_app/src/ffi/crypto.rs
+++ b/safe_app/src/ffi/crypto.rs
@@ -66,10 +66,15 @@ pub unsafe extern "C" fn sign_generate_key_pair(
         let user_data = OpaqueCtx(user_data);
 
         (*app).send(move |_, context| {
-            let pk_h = context.object_cache().insert_pub_sign_key(public_key);
-            let sk_h = context.object_cache().insert_sec_sign_key(full_id);
+            let public_key_handle = context.object_cache().insert_pub_sign_key(public_key);
+            let secret_key_handle = context.object_cache().insert_sec_sign_key(full_id);
 
-            o_cb(user_data.0, FFI_RESULT_OK, pk_h, sk_h);
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                public_key_handle,
+                secret_key_handle,
+            );
 
             None
         })
@@ -247,14 +252,19 @@ pub unsafe extern "C" fn enc_generate_key_pair(
     ),
 ) {
     catch_unwind_cb(user_data, o_cb, || {
-        let (ourpk, oursk) = shared_box::gen_keypair();
+        let (our_public_key, our_secret_key) = shared_box::gen_keypair();
         let user_data = OpaqueCtx(user_data);
 
         (*app).send(move |_, context| {
-            let pk_h = context.object_cache().insert_encrypt_key(ourpk);
-            let sk_h = context.object_cache().insert_secret_key(oursk);
+            let public_key_handle = context.object_cache().insert_encrypt_key(our_public_key);
+            let secret_key_handle = context.object_cache().insert_secret_key(our_secret_key);
 
-            o_cb(user_data.0, FFI_RESULT_OK, pk_h, sk_h);
+            o_cb(
+                user_data.0,
+                FFI_RESULT_OK,
+                public_key_handle,
+                secret_key_handle,
+            );
 
             None
         })

--- a/safe_app/src/ffi/logging.rs
+++ b/safe_app/src/ffi/logging.rs
@@ -8,7 +8,7 @@
 // Software.
 
 //! Logging utilities
-//! This module is exactly the same as safe_authenticator::ffi::logging, therefore changes to
+//! This module is exactly the same as `safe_authenticator::ffi::logging`, therefore changes to
 //! either one of them should also be reflected to the other to stay in sync.
 
 use super::AppError;

--- a/safe_app/src/ffi/mutable_data/entries.rs
+++ b/safe_app/src/ffi/mutable_data/entries.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn seq_mdata_entries_new(
         send_sync(app, user_data, o_cb, |_, context| {
             Ok(context
                 .object_cache()
-                .insert_seq_mdata_entries(Default::default()))
+                .insert_seq_mdata_entries(BTreeMap::<Vec<u8>, MDataSeqValue>::default()))
         })
     })
 }

--- a/safe_app/src/ffi/mutable_data/entry_actions.rs
+++ b/safe_app/src/ffi/mutable_data/entry_actions.rs
@@ -13,7 +13,7 @@ use crate::ffi::helper::send_sync;
 use crate::ffi::object_cache::MDataEntryActionsHandle;
 use crate::App;
 use ffi_utils::{catch_unwind_cb, vec_clone_from_raw_parts, FfiResult};
-use safe_nd::{MDataSeqEntryAction, MDataSeqValue};
+use safe_nd::{MDataSeqEntryAction, MDataSeqEntryActions, MDataSeqValue};
 use std::os::raw::c_void;
 
 /// Create new entry actions.
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn mdata_entry_actions_new(
 ) {
     catch_unwind_cb(user_data, o_cb, || {
         send_sync(app, user_data, o_cb, |_, context| {
-            let actions = Default::default();
+            let actions = MDataSeqEntryActions::default();
             Ok(context
                 .object_cache()
                 .insert_seq_mdata_entry_actions(actions))

--- a/safe_app/src/ffi/mutable_data/permissions.rs
+++ b/safe_app/src/ffi/mutable_data/permissions.rs
@@ -18,6 +18,8 @@ use crate::App;
 use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, SafePtr, FFI_RESULT_OK};
 use safe_core::ffi::ipc::req::PermissionSet;
 use safe_core::ipc::req::{permission_set_clone_from_repr_c, permission_set_into_repr_c};
+use safe_nd::{MDataPermissionSet, PublicKey};
+use std::collections::BTreeMap;
 use std::os::raw::c_void;
 
 /// Special value that represents `User::Anyone` in permission sets.
@@ -48,7 +50,7 @@ pub unsafe extern "C" fn mdata_permissions_new(
         send_sync(app, user_data, o_cb, |_, context| {
             Ok(context
                 .object_cache()
-                .insert_mdata_permissions(Default::default()))
+                .insert_mdata_permissions(BTreeMap::<PublicKey, MDataPermissionSet>::default()))
         })
     })
 }

--- a/safe_app/src/lib.rs
+++ b/safe_app/src/lib.rs
@@ -267,7 +267,7 @@ impl App {
 
         let core_tx = rx.recv()??;
 
-        Ok(App {
+        Ok(Self {
             core_tx: Mutex::new(core_tx),
             _core_joiner: joiner,
         })
@@ -316,7 +316,7 @@ pub struct Registered {
 
 impl AppContext {
     fn unregistered() -> Self {
-        AppContext::Unregistered(Rc::new(Unregistered {
+        Self::Unregistered(Rc::new(Unregistered {
             object_cache: ObjectCache::new(),
         }))
     }
@@ -326,7 +326,7 @@ impl AppContext {
         sym_enc_key: shared_secretbox::Key,
         access_container_info: AccessContInfo,
     ) -> Self {
-        AppContext::Registered(Rc::new(Registered {
+        Self::Registered(Rc::new(Registered {
             object_cache: ObjectCache::new(),
             app_id,
             sym_enc_key,
@@ -338,8 +338,8 @@ impl AppContext {
     /// Object cache
     pub fn object_cache(&self) -> &ObjectCache {
         match *self {
-            AppContext::Unregistered(ref context) => &context.object_cache,
-            AppContext::Registered(ref context) => &context.object_cache,
+            Self::Unregistered(ref context) => &context.object_cache,
+            Self::Registered(ref context) => &context.object_cache,
         }
     }
 
@@ -368,8 +368,8 @@ impl AppContext {
 
     fn as_registered(&self) -> Result<&Rc<Registered>, AppError> {
         match *self {
-            AppContext::Registered(ref a) => Ok(a),
-            AppContext::Unregistered(_) => Err(AppError::OperationForbidden),
+            Self::Registered(ref a) => Ok(a),
+            Self::Unregistered(_) => Err(AppError::OperationForbidden),
         }
     }
 }

--- a/safe_app/src/object_cache.rs
+++ b/safe_app/src/object_cache.rs
@@ -46,7 +46,7 @@ pub struct ObjectCache {
 impl ObjectCache {
     /// Construct object cache.
     pub fn new() -> Self {
-        ObjectCache {
+        Self {
             handle_gen: HandleGenerator::new(),
             cipher_opt: Store::new(),
             encrypt_key: Store::new(),
@@ -233,7 +233,7 @@ struct HandleGenerator(Cell<ObjectHandle>);
 
 impl HandleGenerator {
     fn new() -> Self {
-        HandleGenerator(Cell::new(NULL_OBJECT_HANDLE))
+        Self(Cell::new(NULL_OBJECT_HANDLE))
     }
 
     fn gen(&self) -> ObjectHandle {
@@ -253,7 +253,7 @@ struct Store<V> {
 
 impl<V> Store<V> {
     fn new() -> Self {
-        Store {
+        Self {
             inner: RefCell::new(HashMap::new()),
         }
     }

--- a/safe_authenticator/src/apps.rs
+++ b/safe_authenticator/src/apps.rs
@@ -39,7 +39,7 @@ pub struct RegisteredApp {
 impl RegisteredApp {
     /// Construct FFI wrapper for the native Rust object, consuming self.
     pub fn into_repr_c(self) -> Result<FfiRegisteredApp, IpcError> {
-        let RegisteredApp {
+        let Self {
             app_info,
             containers,
         } = self;
@@ -120,8 +120,7 @@ pub fn list_revoked(client: &AuthClient) -> Box<AuthFuture<Vec<AppExchangeInfo>>
                 // been deleted (is empty), then it's revoked.
                 let revoked = entries
                     .get(&key)
-                    .map(|entry| entry.data.is_empty())
-                    .unwrap_or(true);
+                    .map_or(true, |entry| entry.data.is_empty());
 
                 if revoked {
                     apps.push(app.info.clone());

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use tiny_keccak::sha3_256;
 use tokio::runtime::current_thread::{block_on_all, Handle};
 
-/// Client object used by safe_authenticator.
+/// Client object used by `safe_authenticator`.
 pub struct AuthClient {
     inner: Rc<RefCell<Inner<AuthClient, ()>>>,
     auth_inner: Rc<RefCell<AuthInner>>,
@@ -186,7 +186,7 @@ impl AuthClient {
 
         block_on_all(connection_manager.bootstrap(client_safe_key))?;
 
-        Ok(AuthClient {
+        Ok(Self {
             inner: Rc::new(RefCell::new(Inner::new(
                 el_handle,
                 connection_manager,
@@ -319,7 +319,7 @@ impl AuthClient {
 
         block_on_all(connection_manager.bootstrap(id_packet))?;
 
-        Ok(AuthClient {
+        Ok(Self {
             inner: Rc::new(RefCell::new(Inner::new(
                 el_handle,
                 connection_manager,
@@ -354,11 +354,11 @@ impl AuthClient {
         let mut auth_inner = self.auth_inner.borrow_mut();
         let acc = &mut auth_inner.acc;
 
-        if acc.config_root != dir {
+        if acc.config_root == dir {
+            false
+        } else {
             acc.config_root = dir;
             true
-        } else {
-            false
         }
     }
 
@@ -380,11 +380,11 @@ impl AuthClient {
         let mut auth_inner = self.auth_inner.borrow_mut();
         let account = &mut auth_inner.acc;
 
-        if account.access_container != dir {
+        if account.access_container == dir {
+            false
+        } else {
             account.access_container = dir;
             true
-        } else {
-            false
         }
     }
 
@@ -500,12 +500,12 @@ impl Client for AuthClient {
 
     fn public_encryption_key(&self) -> threshold_crypto::PublicKey {
         let auth_inner = self.auth_inner.borrow();
-        auth_inner.acc.maid_keys.enc_pk
+        auth_inner.acc.maid_keys.enc_public_key
     }
 
     fn secret_encryption_key(&self) -> shared_box::SecretKey {
         let auth_inner = self.auth_inner.borrow();
-        auth_inner.acc.maid_keys.enc_sk.clone()
+        auth_inner.acc.maid_keys.enc_secret_key.clone()
     }
 
     fn secret_symmetric_key(&self) -> shared_secretbox::Key {
@@ -522,7 +522,7 @@ impl fmt::Debug for AuthClient {
 
 impl Clone for AuthClient {
     fn clone(&self) -> Self {
-        AuthClient {
+        Self {
             inner: Rc::clone(&self.inner),
             auth_inner: Rc::clone(&self.auth_inner),
         }
@@ -546,8 +546,8 @@ struct UserCred {
 }
 
 impl UserCred {
-    fn new(password: Vec<u8>, pin: Vec<u8>) -> UserCred {
-        UserCred { pin, password }
+    fn new(password: Vec<u8>, pin: Vec<u8>) -> Self {
+        Self { pin, password }
     }
 }
 

--- a/safe_authenticator/src/config.rs
+++ b/safe_authenticator/src/config.rs
@@ -52,7 +52,7 @@ pub type RevocationQueue = VecDeque<String>;
 
 /// Bump the current version to obtain new version.
 pub fn next_version(version: Option<u64>) -> u64 {
-    version.map(|v| v + 1).unwrap_or(0)
+    version.map_or(0, |v| v + 1)
 }
 
 /// Retrieves apps registered with the authenticator.
@@ -127,11 +127,11 @@ pub fn push_to_app_revocation_queue(
         queue,
         new_version,
         move |queue| {
-            if !queue.contains(&app_id) {
+            if queue.contains(&app_id) {
+                false
+            } else {
                 queue.push_back(app_id.clone());
                 true
-            } else {
-                false
             }
         },
     )
@@ -205,10 +205,10 @@ where
         .get_seq_mdata_value(parent.name(), parent.type_tag(), key)
         .and_then(move |value| {
             let decoded = parent.decrypt(&value.data)?;
-            let decoded = if !decoded.is_empty() {
-                deserialize(&decoded)?
-            } else {
+            let decoded = if decoded.is_empty() {
                 Default::default()
+            } else {
+                deserialize(&decoded)?
             };
 
             Ok((Some(value.version), decoded))

--- a/safe_authenticator/src/errors.rs
+++ b/safe_authenticator/src/errors.rs
@@ -340,7 +340,7 @@ fn core_error_code(err: &CoreError) -> i32 {
         CoreError::RandomDataGenerationFailure => ERR_RANDOM_DATA_GENERATION_FAILURE,
         CoreError::OperationForbidden => ERR_OPERATION_FORBIDDEN,
         CoreError::DataError(ref err) => safe_nd_error_core(err),
-        CoreError::QuicP2p(ref _err) => ERR_QUIC_P2P, // FIXME: use proper error codes
+        CoreError::QuicP2p(ref _error) => ERR_QUIC_P2P, // FIXME: use proper error codes
         CoreError::UnsupportedSaltSizeForPwHash => ERR_UNSUPPORTED_SALT_SIZE_FOR_PW_HASH,
         CoreError::UnsuccessfulPwHash => ERR_UNSUCCESSFUL_PW_HASH,
         CoreError::OperationAborted => ERR_OPERATION_ABORTED,

--- a/safe_authenticator/src/ffi/logging.rs
+++ b/safe_authenticator/src/ffi/logging.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 //! Logging utilities
-//! This module is exactly the same as safe_app::ffi::logging, therefore changes to either one of
+//! This module is exactly the same as `safe_app::ffi::logging`, therefore changes to either one of
 //! them should also be reflected to the other to stay in sync.
 
 use super::AuthError;

--- a/safe_authenticator/src/ipc.rs
+++ b/safe_authenticator/src/ipc.rs
@@ -37,32 +37,32 @@ pub fn decode_ipc_msg(
 ) -> Box<AuthFuture<Result<IpcMsg, (i32, String, CString)>>> {
     match msg {
         IpcMsg::Req {
-            req: IpcReq::Auth(auth_req),
+            request: IpcReq::Auth(auth_req),
             req_id,
         } => {
             // Ok status should be returned for all app states (including
             // Revoked and Authenticated).
             ok!(Ok(IpcMsg::Req {
                 req_id,
-                req: IpcReq::Auth(auth_req),
+                request: IpcReq::Auth(auth_req),
             }))
         }
         IpcMsg::Req {
-            req: IpcReq::Unregistered(extra_data),
+            request: IpcReq::Unregistered(extra_data),
             req_id,
         } => ok!(Ok(IpcMsg::Req {
             req_id,
-            req: IpcReq::Unregistered(extra_data),
+            request: IpcReq::Unregistered(extra_data),
         })),
         IpcMsg::Req {
-            req: IpcReq::ShareMData(share_mdata_req),
+            request: IpcReq::ShareMData(share_mdata_req),
             req_id,
         } => ok!(Ok(IpcMsg::Req {
             req_id,
-            req: IpcReq::ShareMData(share_mdata_req),
+            request: IpcReq::ShareMData(share_mdata_req),
         })),
         IpcMsg::Req {
-            req: IpcReq::Containers(cont_req),
+            request: IpcReq::Containers(cont_req),
             req_id,
         } => {
             trace!("Handling IpcReq::Containers({:?})", cont_req);
@@ -76,20 +76,20 @@ pub fn decode_ipc_msg(
                     match app_state {
                         AppState::Authenticated => Ok(Ok(IpcMsg::Req {
                             req_id,
-                            req: IpcReq::Containers(cont_req),
+                            request: IpcReq::Containers(cont_req),
                         })),
                         AppState::Revoked | AppState::NotAuthenticated => {
                             // App is not authenticated
                             let (error_code, description) =
                                 ffi_error!(AuthError::from(IpcError::UnknownApp));
 
-                            let resp = IpcMsg::Resp {
-                                resp: IpcResp::Auth(Err(IpcError::UnknownApp)),
+                            let response = IpcMsg::Resp {
+                                response: IpcResp::Auth(Err(IpcError::UnknownApp)),
                                 req_id,
                             };
-                            let resp = encode_response(&resp)?;
+                            let encoded_response = encode_response(&response)?;
 
-                            Ok(Err((error_code, description, resp)))
+                            Ok(Err((error_code, description, encoded_response)))
                         }
                     }
                 })
@@ -153,8 +153,8 @@ pub fn update_container_perms(
 
 /// Encode `IpcMsg` into a `CString`, using base32 encoding.
 pub fn encode_response(msg: &IpcMsg) -> Result<CString, IpcError> {
-    let resp = ipc::encode_msg(msg)?;
-    Ok(CString::new(resp).map_err(StringError::from)?)
+    let response = ipc::encode_msg(msg)?;
+    Ok(CString::new(response).map_err(StringError::from)?)
 }
 
 enum ShareMDataError {

--- a/safe_authenticator/src/revocation.rs
+++ b/safe_authenticator/src/revocation.rs
@@ -139,18 +139,17 @@ fn revoke_single_app(client: &AuthClient, app_id: &str) -> Box<AuthFuture<()>> {
         .and_then(move |app| {
             access_container::fetch_entry(&c3, &app.info.id, app.keys.clone()).and_then(
                 move |(version, ac_entry)| {
-                    match ac_entry {
-                        Some(ac_entry) => {
-                            let containers: Containers = ac_entry
-                                .into_iter()
-                                .map(|(name, (mdata_info, _))| (name, mdata_info))
-                                .collect();
+                    if let Some(ac_entry) = ac_entry {
+                        let containers: Containers = ac_entry
+                            .into_iter()
+                            .map(|(name, (mdata_info, _))| (name, mdata_info))
+                            .collect();
 
-                            clear_from_access_container_entry(&c4, app, version, containers)
-                        }
+                        clear_from_access_container_entry(&c4, app, version, containers)
+                    } else {
                         // If the access container entry was not found, the entry must have been
                         // deleted with the app having stayed on the revocation queue.
-                        None => ok!(()),
+                        ok!(())
                     }
                 },
             )

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -196,7 +196,7 @@ pub fn register_app(
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Auth(auth_req.clone()),
+        request: IpcReq::Auth(auth_req.clone()),
     };
 
     // Invoke `decode_ipc_msg` and expect to get AuthReq back.
@@ -205,7 +205,7 @@ pub fn register_app(
     )));
     match ipc_req {
         Ok(IpcMsg::Req {
-            req: IpcReq::Auth(_),
+            request: IpcReq::Auth(_),
             ..
         }) => (),
         x => return Err(AuthError::Unexpected(format!("Unexpected {:?}", x))),
@@ -492,7 +492,7 @@ pub fn auth_decode_ipc_msg_helper(authenticator: &Authenticator, msg: &str) -> C
 
             let msg = IpcMsg::Req {
                 req_id,
-                req: IpcReq::Auth(req),
+                request: IpcReq::Auth(req),
             };
 
             send_via_user_data::<ChannelType>(user_data, Ok((msg, None)))
@@ -508,7 +508,7 @@ pub fn auth_decode_ipc_msg_helper(authenticator: &Authenticator, msg: &str) -> C
 
             let msg = IpcMsg::Req {
                 req_id,
-                req: IpcReq::Containers(req),
+                request: IpcReq::Containers(req),
             };
 
             send_via_user_data::<ChannelType>(user_data, Ok((msg, None)))
@@ -545,7 +545,7 @@ pub fn auth_decode_ipc_msg_helper(authenticator: &Authenticator, msg: &str) -> C
 
             let msg = IpcMsg::Req {
                 req_id,
-                req: IpcReq::ShareMData(req),
+                request: IpcReq::ShareMData(req),
             };
 
             send_via_user_data::<ChannelType>(
@@ -592,7 +592,7 @@ pub extern "C" fn unregistered_cb(
     unsafe {
         let msg = IpcMsg::Req {
             req_id,
-            req: IpcReq::Unregistered(vec_clone_from_raw_parts(extra_data, extra_data_len)),
+            request: IpcReq::Unregistered(vec_clone_from_raw_parts(extra_data, extra_data_len)),
         };
 
         send_via_user_data::<ChannelType>(user_data, Ok((msg, None)))

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -462,7 +462,7 @@ fn app_authentication() {
 
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Auth(auth_req.clone()),
+        request: IpcReq::Auth(auth_req.clone()),
     };
 
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
@@ -473,7 +473,7 @@ fn app_authentication() {
         (
             IpcMsg::Req {
                 req_id,
-                req: IpcReq::Auth(req),
+                request: IpcReq::Auth(req),
             },
             _,
         ) => (req_id, req),
@@ -500,7 +500,7 @@ fn app_authentication() {
     let auth_granted = match unwrap!(ipc::decode_msg(&encoded_auth_resp)) {
         IpcMsg::Resp {
             req_id: received_req_id,
-            resp: IpcResp::Auth(Ok(auth_granted)),
+            response: IpcResp::Auth(Ok(auth_granted)),
         } => {
             assert_eq!(received_req_id, req_id);
             auth_granted
@@ -630,7 +630,7 @@ fn unregistered_authentication() {
     // Try to send IpcReq::Auth - it should fail
     let msg = IpcMsg::Req {
         req_id: ipc::gen_req_id(),
-        req: IpcReq::Auth(AuthReq {
+        request: IpcReq::Auth(AuthReq {
             app: test_utils::rand_app(),
             app_container: true,
             app_permissions: Default::default(),
@@ -649,7 +649,7 @@ fn unregistered_authentication() {
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Unregistered(test_data.clone()),
+        request: IpcReq::Unregistered(test_data.clone()),
     };
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -658,7 +658,7 @@ fn unregistered_authentication() {
         (
             IpcMsg::Req {
                 req_id,
-                req: IpcReq::Unregistered(extra_data),
+                request: IpcReq::Unregistered(extra_data),
             },
             _,
         ) => (req_id, extra_data),
@@ -680,7 +680,7 @@ fn unregistered_authentication() {
     let bootstrap_cfg = match unwrap!(ipc::decode_msg(&encoded_resp)) {
         IpcMsg::Resp {
             req_id: received_req_id,
-            resp: IpcResp::Unregistered(Ok(bootstrap_cfg)),
+            response: IpcResp::Unregistered(Ok(bootstrap_cfg)),
         } => {
             assert_eq!(received_req_id, req_id);
             bootstrap_cfg
@@ -700,7 +700,7 @@ fn unregistered_authentication() {
         (
             IpcMsg::Req {
                 req_id,
-                req: IpcReq::Unregistered(extra_data),
+                request: IpcReq::Unregistered(extra_data),
             },
             _,
         ) => (req_id, extra_data),
@@ -728,7 +728,7 @@ fn authenticated_app_can_be_authenticated_again() {
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Auth(auth_req.clone()),
+        request: IpcReq::Auth(auth_req.clone()),
     };
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -738,7 +738,7 @@ fn authenticated_app_can_be_authenticated_again() {
     )) {
         (
             IpcMsg::Req {
-                req: IpcReq::Auth(_),
+                request: IpcReq::Auth(_),
                 ..
             },
             _,
@@ -764,7 +764,7 @@ fn authenticated_app_can_be_authenticated_again() {
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Auth(auth_req),
+        request: IpcReq::Auth(auth_req),
     };
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -774,7 +774,7 @@ fn authenticated_app_can_be_authenticated_again() {
     )) {
         (
             IpcMsg::Req {
-                req: IpcReq::Auth(_),
+                request: IpcReq::Auth(_),
                 ..
             },
             _,
@@ -792,7 +792,7 @@ fn containers_unknown_app() {
     let req_id = ipc::gen_req_id();
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::Containers(ContainersReq {
+        request: IpcReq::Containers(ContainersReq {
             app: test_utils::rand_app(),
             containers: utils::create_containers_req(),
         }),
@@ -809,7 +809,7 @@ fn containers_unknown_app() {
         Err((
             code,
             Some(IpcMsg::Resp {
-                resp: IpcResp::Auth(Err(IpcError::UnknownApp)),
+                response: IpcResp::Auth(Err(IpcError::UnknownApp)),
                 ..
             }),
         )) if code == ERR_UNKNOWN_APP => (),
@@ -865,7 +865,7 @@ fn containers_access_request() {
 
     match ipc::decode_msg(&encoded_containers_resp) {
         Ok(IpcMsg::Resp {
-            resp: IpcResp::Containers(Ok(())),
+            response: IpcResp::Containers(Ok(())),
             ..
         }) => (),
         x => panic!("Unexpected {:?}", x),

--- a/safe_authenticator/src/tests/share_mdata.rs
+++ b/safe_authenticator/src/tests/share_mdata.rs
@@ -28,7 +28,7 @@ fn share_zero_mdatas() {
 
     let msg = IpcMsg::Req {
         req_id: ipc::gen_req_id(),
-        req: IpcReq::ShareMData(ShareMDataReq {
+        request: IpcReq::ShareMData(ShareMDataReq {
             app: test_utils::rand_app(),
             mdata: vec![],
         }),
@@ -42,7 +42,7 @@ fn share_zero_mdatas() {
     match decoded {
         (
             IpcMsg::Req {
-                req: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
+                request: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
                 ..
             },
             Some(Payload::Metadata(metadatas)),
@@ -91,7 +91,7 @@ fn share_some_mdatas() {
 
     let msg = IpcMsg::Req {
         req_id: ipc::gen_req_id(),
-        req: IpcReq::ShareMData(ShareMDataReq {
+        request: IpcReq::ShareMData(ShareMDataReq {
             app: test_utils::rand_app(),
             mdata: mdatas.clone(),
         }),
@@ -105,7 +105,7 @@ fn share_some_mdatas() {
     match decoded {
         (
             IpcMsg::Req {
-                req: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
+                request: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
                 ..
             },
             Some(Payload::Metadata(received_metadatas)),
@@ -140,7 +140,7 @@ fn share_invalid_mdatas() {
 
     let msg = IpcMsg::Req {
         req_id: ipc::gen_req_id(),
-        req: IpcReq::ShareMData(ShareMDataReq {
+        request: IpcReq::ShareMData(ShareMDataReq {
             app: test_utils::rand_app(),
             mdata: share_mdatas,
         }),
@@ -216,7 +216,7 @@ fn share_some_mdatas_with_valid_metadata() {
     };
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::ShareMData(req.clone()),
+        request: IpcReq::ShareMData(req.clone()),
     };
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -227,7 +227,7 @@ fn share_some_mdatas_with_valid_metadata() {
     match decoded {
         (
             IpcMsg::Req {
-                req: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
+                request: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
                 ..
             },
             Some(Payload::Metadata(received_metadatas)),
@@ -296,7 +296,7 @@ fn share_some_mdatas_with_ownership_error() {
     };
     let msg = IpcMsg::Req {
         req_id,
-        req: IpcReq::ShareMData(req.clone()),
+        request: IpcReq::ShareMData(req.clone()),
     };
     let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -322,7 +322,7 @@ fn share_some_mdatas_with_ownership_error() {
 
     match ipc::decode_msg(&share_mdata_resp) {
         Ok(IpcMsg::Resp {
-            resp: IpcResp::ShareMData(Err(IpcError::ShareMDataDenied)),
+            response: IpcResp::ShareMData(Err(IpcError::ShareMDataDenied)),
             ..
         }) => (),
         x => panic!("Unexpected {:?}", x),
@@ -437,7 +437,7 @@ fn auth_apps_accessing_mdatas() {
         };
         let msg = IpcMsg::Req {
             req_id,
-            req: IpcReq::ShareMData(req.clone()),
+            request: IpcReq::ShareMData(req.clone()),
         };
         let encoded_msg = unwrap!(ipc::encode_msg(&msg));
 
@@ -449,7 +449,7 @@ fn auth_apps_accessing_mdatas() {
         match decoded {
             (
                 IpcMsg::Req {
-                    req: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
+                    request: IpcReq::ShareMData(ShareMDataReq { mdata, .. }),
                     ..
                 },
                 Some(Payload::Metadata(received_metadatas)),

--- a/safe_core/src/client/account.rs
+++ b/safe_core/src/client/account.rs
@@ -115,9 +115,9 @@ pub struct ClientKeys {
     /// Symmetric encryption key.
     pub enc_key: shared_secretbox::Key,
     /// Encryption public key.
-    pub enc_pk: threshold_crypto::PublicKey,
+    pub enc_public_key: threshold_crypto::PublicKey,
     /// Encryption private key.
-    pub enc_sk: shared_box::SecretKey,
+    pub enc_secret_key: shared_box::SecretKey,
 }
 
 impl ClientKeys {
@@ -130,8 +130,8 @@ impl ClientKeys {
         let client_id = ClientFullId::new_bls(rng);
 
         Self {
-            enc_pk: enc_public_key,
-            enc_sk: enc_secret_key,
+            enc_public_key,
+            enc_secret_key,
             enc_key,
             client_id,
         }

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -173,11 +173,11 @@ impl Client for CoreClient {
     }
 
     fn public_encryption_key(&self) -> threshold_crypto::PublicKey {
-        self.keys.enc_pk
+        self.keys.enc_public_key
     }
 
     fn secret_encryption_key(&self) -> shared_box::SecretKey {
-        self.keys.enc_sk.clone()
+        self.keys.enc_secret_key.clone()
     }
 
     fn secret_symmetric_key(&self) -> shared_secretbox::Key {

--- a/safe_core/src/ffi/ipc/resp.rs
+++ b/safe_core/src/ffi/ipc/resp.rs
@@ -27,11 +27,11 @@ pub struct AppKeys {
     /// Data symmetric encryption key.
     pub enc_key: SymSecretKey,
     /// Asymmetric enc public key.
-    pub enc_pk: AsymPublicKey,
+    pub enc_public_key: AsymPublicKey,
     /// Pointer to serialized asymmetric encryption private key.
-    pub enc_sk: *const u8,
+    pub enc_secret_key: *const u8,
     /// Asymmetric enc private key's length.
-    pub enc_sk_len: usize,
+    pub enc_secret_key_len: usize,
 }
 
 impl Drop for AppKeys {

--- a/safe_core/src/ipc/mod.rs
+++ b/safe_core/src/ipc/mod.rs
@@ -43,14 +43,14 @@ pub enum IpcMsg {
         /// Request ID.
         req_id: u32,
         /// Request.
-        req: IpcReq,
+        request: IpcReq,
     },
     /// Response.
     Resp {
         /// Request ID.
         req_id: u32,
         /// Response.
-        resp: IpcResp,
+        response: IpcResp,
     },
     /// Revoked.
     Revoked {


### PR DESCRIPTION
Fixes `clippy::pedantic` warnings and errors for `safe_authenticator` & `safe_app` module. Leaves out some renaming suggestions as to leave the crux structs unchanged.

Rebased on: #1120 