### PR TITLE
chore/ci: update deprecated AWS action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -372,12 +372,10 @@ jobs:
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 
       # Upload all the release archives to S3.
-      - uses: actions/aws/cli@master
-        with:
-          args: s3 sync deploy/dev s3://safe-client-libs --acl public-read
-      - uses: actions/aws/cli@master
-        with:
-          args: s3 sync deploy/prod s3://safe-client-libs --acl public-read
+      - name: Upload dev to S3
+        run: aws s3 sync deploy/dev s3://safe-client-libs --acl public-read
+      - name: Upload prod to S3
+        run: aws s3 sync deploy/prod s3://safe-client-libs --acl public-read
 
       # Create the release and attach safe_client_libs archives as assets.
       - uses: csexton/create-release@add-body


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->

The `aws` command is now available in the GHA virtual environments:

https://stackoverflow.com/questions/59166099/github-action-aws-cli

Fixes #1108 