### PR TITLE
chore/ci: remove --verbose flag from scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@
 
 env:
   global:
+    # Run all cargo commands with --verbose.
+    - CARGO_TERM_VERBOSE=true
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
 language: rust

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -4,7 +4,7 @@ set -e -x
 
 echo "--- Building the binary compatibility test ---"
 
-cargo test --verbose --release --no-run --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+cargo test --release --no-run --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
 
 # Find the file to run.
 TEST_FILE=$(find target/release -maxdepth 1 -type f -executable -name "safe_authenticator-*" -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ")

--- a/scripts/build-mock
+++ b/scripts/build-mock
@@ -2,8 +2,8 @@
 
 set -e -x
 
-cargo build --verbose --features=mock-network --release --manifest-path=safe_core/Cargo.toml
-cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml
-cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
-cargo build --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml
-cargo build --verbose --features=mock-network --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo build --features=mock-network --release --manifest-path=safe_core/Cargo.toml
+cargo build --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml
+cargo build --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+cargo build --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo build --features=mock-network --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/build-real
+++ b/scripts/build-real
@@ -3,6 +3,6 @@
 set -e -x
 
 scripts/build-real-core
-cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
-cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml
-cargo build --verbose --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo build --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+cargo build --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo build --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/build-real-core
+++ b/scripts/build-real-core
@@ -2,5 +2,5 @@
 
 set -e -x
 
-cargo build --verbose --release --manifest-path=safe_core/Cargo.toml
-cargo build --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml
+cargo build --release --manifest-path=safe_core/Cargo.toml
+cargo build --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml

--- a/scripts/check-mock
+++ b/scripts/check-mock
@@ -2,8 +2,8 @@
 
 set -e -x;
 
-cargo check --verbose --features=mock-network --release --manifest-path=safe_core/Cargo.toml
-cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml
-cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
-cargo check --verbose --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml
-cargo check --verbose --features="mock-network" --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo check --features=mock-network --release --manifest-path=safe_core/Cargo.toml
+cargo check --features="testing mock-network" --release --lib --tests --manifest-path=safe_core/Cargo.toml
+cargo check --features="testing mock-network" --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+cargo check --features="testing mock-network" --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo check --features="mock-network" --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/check-real
+++ b/scripts/check-real
@@ -2,8 +2,8 @@
 
 set -e -x;
 
-cargo check --verbose --release --manifest-path=safe_core/Cargo.toml
-cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml
-cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
-cargo check --verbose --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml
-cargo check --verbose --release --lib --tests --manifest-path=tests/Cargo.toml
+cargo check --release --manifest-path=safe_core/Cargo.toml
+cargo check --features=testing --release --lib --tests --manifest-path=safe_core/Cargo.toml
+cargo check --features=testing --release --lib --tests --manifest-path=safe_authenticator/Cargo.toml
+cargo check --features=testing --release --lib --tests --manifest-path=safe_app/Cargo.toml
+cargo check --release --lib --tests --manifest-path=tests/Cargo.toml

--- a/scripts/clippy-mock
+++ b/scripts/clippy-mock
@@ -2,6 +2,6 @@
 
 set -e -x;
 
-cargo clippy --verbose --features="mock-network" --all-targets --manifest-path=safe_core/Cargo.toml
-cargo clippy --verbose --features="mock-network" --all-targets --manifest-path=safe_authenticator/Cargo.toml
-cargo clippy --verbose --features="mock-network" --all-targets --manifest-path=safe_app/Cargo.toml
+cargo clippy --features="mock-network" --all-targets --manifest-path=safe_core/Cargo.toml
+cargo clippy --features="mock-network" --all-targets --manifest-path=safe_authenticator/Cargo.toml
+cargo clippy --features="mock-network" --all-targets --manifest-path=safe_app/Cargo.toml

--- a/scripts/clippy-real
+++ b/scripts/clippy-real
@@ -2,7 +2,7 @@
 
 set -e -x;
 
-cargo clippy --verbose --features=testing --all-targets --manifest-path=safe_core/Cargo.toml
-cargo clippy --verbose --features=testing --all-targets --manifest-path=safe_authenticator/Cargo.toml
-cargo clippy --verbose --features=testing --all-targets --manifest-path=safe_app/Cargo.toml
-cargo clippy --verbose --all-targets --manifest-path=tests/Cargo.toml
+cargo clippy --features=testing --all-targets --manifest-path=safe_core/Cargo.toml
+cargo clippy --features=testing --all-targets --manifest-path=safe_authenticator/Cargo.toml
+cargo clippy --features=testing --all-targets --manifest-path=safe_app/Cargo.toml
+cargo clippy --all-targets --manifest-path=tests/Cargo.toml

--- a/scripts/rustfmt
+++ b/scripts/rustfmt
@@ -2,4 +2,4 @@
 
 set -e -x;
 
-cargo fmt --verbose --all -- --check
+cargo fmt --all -- --check

--- a/scripts/test-binary
+++ b/scripts/test-binary
@@ -14,11 +14,11 @@ if [[ -f "$COMPAT_TESTS" ]]; then
     export SAFE_MOCK_VAULT_PATH=$HOME/tmp
     mkdir -p "$SAFE_MOCK_VAULT_PATH"
 
-    cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_write_data -- --ignored
+    cargo test --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_write_data -- --ignored
 
     chmod +x "$COMPAT_TESTS"
     "$COMPAT_TESTS" serialisation_read_data --ignored
     "$COMPAT_TESTS" serialisation_write_data --ignored
 
-    cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_read_data -- --ignored
+    cargo test --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml serialisation_read_data -- --ignored
 fi

--- a/scripts/test-integration
+++ b/scripts/test-integration
@@ -2,4 +2,4 @@
 
 set -e -x
 
-cargo test --verbose --features="mock-network" --release --manifest-path=tests/Cargo.toml
+cargo test --features="mock-network" --release --manifest-path=tests/Cargo.toml

--- a/scripts/test-mock
+++ b/scripts/test-mock
@@ -3,8 +3,8 @@
 set -e -x
 
 # SAFE_MOCK_IN_MEMORY_STORAGE should not be set for this first test.
-cargo test config_mock_vault_path --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+cargo test config_mock_vault_path --release --features=mock-network --manifest-path=safe_core/Cargo.toml
 export SAFE_MOCK_IN_MEMORY_STORAGE=1 &&
-cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
-cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
-cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_app/Cargo.toml

--- a/scripts/test-with-mock-vault-file
+++ b/scripts/test-with-mock-vault-file
@@ -3,7 +3,7 @@
 set -e -x
 
 export RUST_BACKTRACE=full
-cargo test --verbose --release --features=mock-network --manifest-path=safe_core/Cargo.toml
-cargo test --verbose --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
-cargo test --verbose --release --features=mock-network --manifest-path=safe_app/Cargo.toml
-cargo test --verbose --release --features=mock-network --manifest-path=tests/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_core/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_authenticator/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=safe_app/Cargo.toml
+cargo test --release --features=mock-network --manifest-path=tests/Cargo.toml


### PR DESCRIPTION
The --verbose flag is not needed in CI since we set `CARGO_TERM_VERBOSE`.

This makes the output less cluttered when running the scripts locally.

<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->
