### PR TITLE
Always use a random port for client QUIC connections

### DIFF
--- a/safe_core/src/config_handler.rs
+++ b/safe_core/src/config_handler.rs
@@ -193,7 +193,6 @@ pub fn write_config_file(config: &Config) -> Result<PathBuf, CoreError> {
     fs::create_dir_all(dir.clone())?;
 
     let path = dir.join(CONFIG_FILE);
-    dbg!(&path);
     let mut file = File::create(&path)?;
     serde_json::to_writer_pretty(&mut file, config)?;
     file.sync_all()?;

--- a/safe_core/src/connection_manager.rs
+++ b/safe_core/src/connection_manager.rs
@@ -37,7 +37,7 @@ pub struct ConnectionManager {
 impl ConnectionManager {
     /// Create a new connection manager.
     pub fn new(mut config: QuicP2pConfig, net_tx: &NetworkTx) -> Result<Self, CoreError> {
-        config.port = None; // Make sure we always use a random port for client connections.
+        config.port = Some(0); // Make sure we always use a random port for client connections.
 
         let inner = Rc::new(RefCell::new(Inner {
             config,

--- a/safe_core/src/connection_manager/connection_group.rs
+++ b/safe_core/src/connection_manager/connection_group.rs
@@ -343,7 +343,6 @@ impl Connected {
             .remove(&msg_id)
             .map(|(sender, count)| {
                 let count = count - 1;
-                dbg!("Response no: {}", count);
                 if count == 0 {
                     sender.send(response)
                 } else {


### PR DESCRIPTION
If in the quic-p2p config we supply port as unspecified (`None`), quic-p2p will use the default port which is set to 443, or 0 if 443 is unavailable. While this behaviour almost always results in having random ports for clients on *nix operating systems (since low-number ports are restricted to superusers only), it can result in a situation when both local vault and a client bind to the same port number (443). We observed this behaviour on Windows and the solution is to always use a random port for clients.