### PR TITLE
fix/action: fix error in master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           [[ -d "artifacts" ]] && rm -rf artifacts
           mkdir artifacts
-          find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+          /usr/bin/find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
       - uses: actions/upload-artifact@master
         with:
           name: safe_client_libs-${{ matrix.target }}-prod
@@ -84,7 +84,7 @@ jobs:
         run: |
           [[ -d "artifacts" ]] && rm -rf artifacts
           mkdir artifacts
-          find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+          /usr/bin/find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
       - uses: actions/upload-artifact@master
         with:
           name: safe_client_libs-${{ matrix.target }}-dev


### PR DESCRIPTION
when the find command was executed on windows it used the "C:/Windows/System32/find" executable instead of the expected *NIX binary. This patch uses the full path to the find binary provided by git bash

Tested [here](https://github.com/lionel1704/gh-actions-demo/commit/5370d9bac18b35ecb1c2c831e6ad59a3bd50be5b/checks?check_suite_id=411931272)