### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+
+[[package]]
 name = "arc-swap"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,12 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
-
-[[package]]
 name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +336,12 @@ dependencies = [
  "iovec",
  "serde",
 ]
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "c2-chacha"
@@ -434,6 +446,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "ct-logs"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
+checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 dependencies = [
  "sct",
 ]
@@ -566,6 +594,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -665,14 +704,14 @@ dependencies = [
 
 [[package]]
 name = "err-derive"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41487fadaa500d02a819eefcde5f713599a01dd51626ef25d2d72d87115667b"
+checksum = "14ce82f12540e448ece75759f36d341dcca4148bb76fb393b087c24e00b15d07"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "rustc_version",
+ "rustversion",
  "syn 1.0.13",
  "synstructure",
 ]
@@ -828,6 +867,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
+name = "futures"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+
+[[package]]
+name = "futures-task"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+
+[[package]]
+name = "futures-util"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1086,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "js-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -1225,6 +1364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1407,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "ordered-float"
@@ -1349,6 +1504,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+
+[[package]]
 name = "pmac"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,14 +1534,46 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.2.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+checksum = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "rustversion",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5717d9fa2664351a01ed73ba5ef6df09c01a521cb42cb65a061432a826f3c7a"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "rustversion",
+ "syn 1.0.13",
+ "syn-mid",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "syn 1.0.13",
 ]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"
@@ -1397,25 +1596,26 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c385be2b310e1707e7d6b2be496388799e7b9ef32d5764e404a44c2c72628"
+source = "git+https://github.com/maidsafe/quic-p2p?rev=f1991746a8#f1991746a82ef21ac69b26e17ba8c6a6b4c15653"
 dependencies = [
  "base64 0.10.1",
  "bincode",
- "bytes",
+ "bytes 0.4.12",
  "crossbeam-channel",
+ "derive_more",
  "directories 1.0.2",
+ "err-derive",
+ "futures 0.3.4",
  "log 0.4.8",
- "quick-error",
  "quinn",
  "rcgen",
  "rustls",
  "serde",
- "serde_derive",
  "serde_json",
  "structopt",
- "tokio",
+ "tokio 0.2.11",
  "unwrap",
+ "webpki",
 ]
 
 [[package]]
@@ -1426,45 +1626,38 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.3.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f79b799f97a3f97a69ab888bc92124fcdac3c6654ee5d46952f94fadd6a06d9"
+checksum = "a550f3a1c4c2f8e7156d62b423d029a5a82d0973adc603be02693c106c70b754"
 dependencies = [
- "bytes",
+ "bytes 0.5.4",
  "ct-logs",
  "err-derive",
- "fnv",
- "futures",
+ "futures 0.3.4",
  "libc",
  "mio",
  "quinn-proto",
- "rand 0.6.5",
  "rustls",
- "slog",
- "tokio-io",
- "tokio-reactor",
- "tokio-timer",
- "untrusted",
+ "rustls-native-certs",
+ "tokio 0.2.11",
+ "tracing",
  "webpki",
- "webpki-roots",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.3.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aeb6dc5d670066a6c90a666139f92d95f73b4ca8883d80e33b0693ef103f65"
+checksum = "36f238b2b3252726f41171302f3976bc22ef4d4845bad6bc2f4fce000a833ee7"
 dependencies = [
- "byteorder",
- "bytes",
+ "bytes 0.5.4",
  "err-derive",
- "fnv",
  "lazy_static",
- "rand 0.6.5",
+ "rand 0.7.3",
  "ring",
  "rustls",
  "slab",
- "slog",
+ "tracing",
  "webpki",
 ]
 
@@ -1667,15 +1860,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.2.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a1bddb9004dcf72359777bd1f51ce1ffecaf6cf5bed14b69da0774865576ed"
+checksum = "e6d6cbbf5f43710b9242a4897f4671a469198e2d826d9df043fc16e046f45d8a"
 dependencies = [
- "bit-vec",
  "chrono",
  "pem",
  "ring",
- "untrusted",
  "yasna",
 ]
 
@@ -1757,15 +1948,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.14.6"
+version = "0.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
+checksum = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 dependencies = [
  "cc",
  "lazy_static",
  "libc",
  "spin",
  "untrusted",
+ "web-sys",
  "winapi 0.3.8",
 ]
 
@@ -1822,16 +2014,38 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f271e3552cd835fa28c541c34a7e8fdd8cdff09d77fe4eb8f6c42e87a11b096e"
+checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 dependencies = [
  "base64 0.10.1",
  "log 0.4.8",
  "ring",
  "sct",
- "untrusted",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -1842,9 +2056,9 @@ checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "safe-nd"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3d264c8abe486c1eb91c96621fc98b980907edd282eecdd39ad961834b7b77"
+checksum = "d22dcd7515d740dd0133c19c738830da96813e33dcc949849025d871de59564d"
 dependencies = [
  "bincode",
  "ed25519-dalek",
@@ -1866,7 +2080,7 @@ dependencies = [
  "clap",
  "env_logger 0.6.2",
  "ffi_utils",
- "futures",
+ "futures 0.1.29",
  "jni",
  "log 0.4.8",
  "lru-cache",
@@ -1881,7 +2095,7 @@ dependencies = [
  "serde_derive",
  "threshold_crypto",
  "tiny-keccak",
- "tokio",
+ "tokio 0.1.22",
  "unwrap",
 ]
 
@@ -1905,11 +2119,10 @@ dependencies = [
  "bincode",
  "env_logger 0.6.2",
  "ffi_utils",
- "futures",
+ "futures 0.1.29",
  "jni",
  "log 0.4.8",
  "lru-cache",
- "quic-p2p",
  "rand 0.6.5",
  "safe-nd",
  "safe_bindgen",
@@ -1917,7 +2130,7 @@ dependencies = [
  "serde",
  "threshold_crypto",
  "tiny-keccak",
- "tokio",
+ "tokio 0.1.22",
  "unwrap",
 ]
 
@@ -1957,7 +2170,7 @@ name = "safe_core"
 version = "0.37.3"
 dependencies = [
  "bincode",
- "bytes",
+ "bytes 0.4.12",
  "chrono",
  "crossbeam-channel",
  "data-encoding",
@@ -1965,7 +2178,7 @@ dependencies = [
  "env_logger 0.6.2",
  "ffi_utils",
  "fs2",
- "futures",
+ "futures 0.1.29",
  "hmac",
  "lazy_static",
  "log 0.4.8",
@@ -1985,7 +2198,7 @@ dependencies = [
  "tempfile",
  "threshold_crypto",
  "tiny-keccak",
- "tokio",
+ "tokio 0.1.22",
  "unwrap",
  "url",
  "ws",
@@ -2007,6 +2220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,12 +2237,33 @@ checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 
 [[package]]
 name = "sct"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5adf8fbd58e1b1b52699dc8bed2630faecb6d8c7bee77d009d6bbe4af569b9"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+dependencies = [
+ "core-foundation-sys",
 ]
 
 [[package]]
@@ -2032,7 +2276,7 @@ dependencies = [
  "bincode",
  "block-modes",
  "brotli",
- "futures",
+ "futures 0.1.29",
  "memmap",
  "rand 0.6.5",
  "rand_chacha 0.1.1",
@@ -2141,12 +2385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
-name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
-
-[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2398,12 @@ name = "smallvec"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
+
+[[package]]
+name = "sourcefile"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "spin"
@@ -2245,6 +2489,17 @@ dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]
@@ -2338,7 +2593,7 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "ffi_utils",
- "futures",
+ "futures 0.1.29",
  "safe-nd",
  "safe_app",
  "safe_authenticator",
@@ -2433,8 +2688,8 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "mio",
  "num_cpus",
  "tokio-codec",
@@ -2452,13 +2707,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv",
+ "lazy_static",
+ "mio",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "tokio-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "tokio-io",
 ]
 
@@ -2468,7 +2737,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "tokio-executor",
 ]
 
@@ -2479,7 +2748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 dependencies = [
  "crossbeam-utils 0.6.6",
- "futures",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -2488,7 +2757,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -2499,8 +2768,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "log 0.4.8",
 ]
 
@@ -2511,7 +2780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 dependencies = [
  "crossbeam-utils 0.6.6",
- "futures",
+ "futures 0.1.29",
  "lazy_static",
  "log 0.4.8",
  "mio",
@@ -2530,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -2539,8 +2808,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "iovec",
  "mio",
  "tokio-io",
@@ -2556,7 +2825,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils 0.6.6",
- "futures",
+ "futures 0.1.29",
  "lazy_static",
  "log 0.4.8",
  "num_cpus",
@@ -2571,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 dependencies = [
  "crossbeam-utils 0.6.6",
- "futures",
+ "futures 0.1.29",
  "slab",
  "tokio-executor",
 ]
@@ -2582,8 +2851,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "log 0.4.8",
  "mio",
  "tokio-codec",
@@ -2597,8 +2866,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 0.4.12",
+ "futures 0.1.29",
  "iovec",
  "libc",
  "log 0.4.8",
@@ -2625,6 +2894,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e213bd24252abeb86a0b7060e02df677d367ce6cb772cef17e9214b8390a8d3"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
+dependencies = [
+ "quote 1.0.2",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2716,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
+checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 
 [[package]]
 name = "unwrap"
@@ -2777,23 +3076,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "webpki"
-version = "0.19.1"
+name = "wasm-bindgen"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7e1cd7900a3a6b65a3e8780c51a3e6b59c0e2c55c6dc69578c288d69f7d082"
+checksum = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log 0.4.8",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+dependencies = [
+ "quote 1.0.2",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
+
+[[package]]
+name = "wasm-bindgen-webidl"
+version = "0.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
+dependencies = [
+ "anyhow",
+ "heck",
+ "log 0.4.8",
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.13",
+ "wasm-bindgen-backend",
+ "weedle",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+dependencies = [
+ "anyhow",
+ "js-sys",
+ "sourcefile",
+ "wasm-bindgen",
+ "wasm-bindgen-webidl",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
 dependencies = [
  "ring",
  "untrusted",
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.16.0"
+name = "weedle"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10fa4212003ba19a564f25cd8ab572c6791f99a03cc219c13ed35ccab00de0e"
+checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
- "untrusted",
- "webpki",
+ "nom",
 ]
 
 [[package]]
@@ -2846,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.4.12",
  "httparse",
  "log 0.4.8",
  "mio",
@@ -2878,11 +3259,10 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
+checksum = "a563d10ead87e2d798e357d44f40f495ad70bcee4d5c0d3f77a5b1b7376645d9"
 dependencies = [
- "bit-vec",
  "chrono",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.3.0"
-source = "git+https://github.com/maidsafe/quic-p2p?rev=f1991746a8#f1991746a82ef21ac69b26e17ba8c6a6b4c15653"
+source = "git+https://github.com/maidsafe/quic-p2p?rev=52f8ae2a#52f8ae2a44f41a4a2c36063b7c70276a7fdd1aa1"
 dependencies = [
  "base64 0.10.1",
  "bincode",

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -23,7 +23,7 @@ miscreant = { version = "0.4.2", features = ["soft-aes"] }
 rand = "0.6"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.12.0", optional = true }
 safe_core = { path = "../safe_core", version = "~0.37.3" }
-safe-nd = "~0.7.2"
+safe-nd = "~0.8.0"
 self_encryption = "~0.16.0"
 serde = "~1.0.27"
 serde_derive = "~1.0.27"
@@ -42,7 +42,7 @@ safe_core = { path = "../safe_core", version = "~0.37.3", features = ["testing"]
 ffi_utils = "~0.15.0"
 jni = "~0.12.0"
 safe_bindgen = { version = "~0.13.2", optional = true }
-safe-nd = "~0.7.0"
+safe-nd = "~0.8.0"
 threshold_crypto = "~0.3.2"
 unwrap = "~1.2.0"
 

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -28,7 +28,7 @@ use safe_core::utils;
 use safe_core::utils::test_utils::random_client;
 #[cfg(feature = "mock-network")]
 use safe_core::ConnectionManager;
-use safe_core::{Client, CoreError};
+use safe_core::{client::COST_OF_PUT, Client, CoreError};
 use safe_nd::{
     ADataAddress, ADataOwner, AppPermissions, AppendOnlyData, Coins, Error as SndError,
     PubImmutableData, PubSeqAppendOnlyData, PubUnseqAppendOnlyData, UnpubUnseqAppendOnlyData,
@@ -465,8 +465,5 @@ fn account_info() {
         client.get_balance(None).map_err(AppError::from)
     }));
 
-    assert_eq!(
-        new_balance,
-        unwrap!(orig_balance.checked_sub(unwrap!(Coins::from_nano(1))))
-    );
+    assert_eq!(new_balance, unwrap!(orig_balance.checked_sub(COST_OF_PUT)));
 }

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -18,10 +18,9 @@ futures = "~0.1.17"
 jni = { version = "~0.12.0", optional = true }
 log = "~0.4.1"
 lru-cache = "~0.1.1"
-quic-p2p = "~0.3.0"
 rand = "0.6"
 safe_core = { path = "../safe_core", version = "~0.37.3" }
-safe-nd = "~0.7.2"
+safe-nd = "~0.8.0"
 serde = { version = "~1.0.97", features = ["derive"] }
 threshold_crypto = "~0.3.2"
 tiny-keccak = "~1.5.0"
@@ -37,7 +36,7 @@ safe_core = { path = "../safe_core", version = "~0.37.3", features = ["testing"]
 ffi_utils = "~0.15.0"
 jni = "~0.12.0"
 safe_bindgen = { version = "~0.13.2", optional = true }
-safe-nd = "~0.7.0"
+safe-nd = "~0.8.0"
 threshold_crypto = "~0.3.2"
 unwrap = "~1.2.0"
 

--- a/safe_authenticator/src/ffi/mod.rs
+++ b/safe_authenticator/src/ffi/mod.rs
@@ -174,7 +174,7 @@ mod tests {
     use crate::AuthError;
     use ffi_utils::test_utils::call_1;
     use futures::Future;
-    use safe_core::{utils, FutureExt};
+    use safe_core::{client::COST_OF_PUT, utils, FutureExt};
     use safe_nd::PubImmutableData;
     use std::ffi::CString;
     use std::os::raw::c_void;
@@ -342,10 +342,7 @@ mod tests {
         let new_balance: Coins = unwrap!(run(unsafe { &*auth }, |client| {
             client.get_balance(None).map_err(AuthError::from)
         }));
-        assert_eq!(
-            new_balance,
-            unwrap!(orig_balance.checked_sub(unwrap!(Coins::from_nano(1))))
-        );
+        assert_eq!(new_balance, unwrap!(orig_balance.checked_sub(COST_OF_PUT)));
 
         unsafe { auth_free(auth) };
     }

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -27,10 +27,10 @@ log4rs = { version = "~0.8.3", features = ["toml_format"] }
 lru-cache = "~0.1.1"
 miscreant = { version = "0.4.2", features = ["soft-aes"] }
 pbkdf2 = { version = "0.3.0", default-features = false }
-quic-p2p = "~0.3.0"
+quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "f1991746a8" }
 rand = "0.6"
 regex = "~1.3.1"
-safe-nd = "~0.7.2"
+safe-nd = "~0.8.0"
 self_encryption = "~0.16.0"
 serde = { version = "~1.0.97", features = ["derive", "rc"] }
 serde_json = "~1.0.40"

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -27,7 +27,7 @@ log4rs = { version = "~0.8.3", features = ["toml_format"] }
 lru-cache = "~0.1.1"
 miscreant = { version = "0.4.2", features = ["soft-aes"] }
 pbkdf2 = { version = "0.3.0", default-features = false }
-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "f1991746a8" }
+quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "52f8ae2a" }
 rand = "0.6"
 regex = "~1.3.1"
 safe-nd = "~0.8.0"

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -114,7 +114,7 @@ fn immutable_data_basics() {
 
     // Initial balance is 10 coins
     let balance = unwrap!(Coins::from_str("10"));
-    let balance = unwrap!(balance.checked_sub(*COST_OF_PUT));
+    let balance = unwrap!(balance.checked_sub(COST_OF_PUT));
     send_req_expect_ok!(
         &mut connection_manager,
         &client_safe_key,
@@ -134,7 +134,7 @@ fn immutable_data_basics() {
     );
 
     // The balance should be deducted twice
-    let balance = unwrap!(balance.checked_sub(*COST_OF_PUT));
+    let balance = unwrap!(balance.checked_sub(COST_OF_PUT));
     send_req_expect_ok!(
         &mut connection_manager,
         &client_safe_key,
@@ -1325,7 +1325,7 @@ fn low_balance_check() {
             &client_safe_key,
             Request::CreateBalance {
                 new_balance_owner,
-                amount: unwrap!(balance.checked_sub(*COST_OF_PUT)),
+                amount: unwrap!(balance.checked_sub(COST_OF_PUT)),
                 transaction_id: rand::random(),
             },
         );

--- a/safe_core/src/client/mock/vault.rs
+++ b/safe_core/src/client/mock/vault.rs
@@ -266,7 +266,7 @@ impl Vault {
             for operation in operations {
                 // Mutation operations must be checked for min COST_OF_PUT balance
                 if let Operation::Mutation = operation {
-                    if !self.has_sufficient_balance(balance, *COST_OF_PUT) {
+                    if !self.has_sufficient_balance(balance, COST_OF_PUT) {
                         return Err(SndError::InsufficientBalance);
                     }
                 }
@@ -304,7 +304,7 @@ impl Vault {
                         debug!("Performing mutations not authorised");
                         return Err(SndError::AccessDenied);
                     }
-                    if !self.has_sufficient_balance(balance, *COST_OF_PUT) {
+                    if !self.has_sufficient_balance(balance, COST_OF_PUT) {
                         return Err(SndError::InsufficientBalance);
                     }
                 }
@@ -318,7 +318,7 @@ impl Vault {
         if !unlimited_coins(&self.config) {
             let balance = unwrap!(self.get_coin_balance_mut(account));
             // Cannot fail - Balance is checked before
-            unwrap!(balance.debit_balance(*COST_OF_PUT));
+            unwrap!(balance.debit_balance(COST_OF_PUT));
         }
     }
 
@@ -349,7 +349,7 @@ impl Vault {
         let _ = self
             .cache
             .coin_balances
-            .insert(destination, CoinBalance::new(Coins::from_nano(0)?, owner));
+            .insert(destination, CoinBalance::new(Coins::from_nano(0), owner));
         Ok(())
     }
 
@@ -556,7 +556,7 @@ impl Vault {
                         .and_then(|_| self.get_balance(&source))
                         .and_then(|source_balance| {
                             let total_amount = amount
-                                .checked_add(*COST_OF_PUT)
+                                .checked_add(COST_OF_PUT)
                                 .ok_or(SndError::ExcessiveValue)?;
                             if !self.has_sufficient_balance(source_balance, total_amount) {
                                 return Err(SndError::InsufficientBalance);
@@ -602,7 +602,7 @@ impl Vault {
                     self.get_balance(&source)
                         .and_then(|source_balance| {
                             let debit_amt = amount
-                                .checked_add(*COST_OF_PUT)
+                                .checked_add(COST_OF_PUT)
                                 .ok_or(SndError::ExcessiveValue)?;
                             if !self.has_sufficient_balance(source_balance, debit_amt) {
                                 return Err(SndError::InsufficientBalance);
@@ -651,7 +651,7 @@ impl Vault {
                     let result = self
                         .get_balance(&source)
                         .and_then(|source_balance| {
-                            if !self.has_sufficient_balance(source_balance, *COST_OF_PUT) {
+                            if !self.has_sufficient_balance(source_balance, COST_OF_PUT) {
                                 return Err(SndError::InsufficientBalance);
                             }
                             self.commit_mutation(&source);

--- a/safe_core/src/client/mod.rs
+++ b/safe_core/src/client/mod.rs
@@ -40,7 +40,6 @@ use crate::ipc::BootstrapConfig;
 use crate::network_event::{NetworkEvent, NetworkTx};
 use crate::utils::FutureExt;
 use futures::{future, sync::mpsc, Future};
-use lazy_static::lazy_static;
 use log::trace;
 use lru_cache::LruCache;
 use safe_nd::{
@@ -66,10 +65,8 @@ pub const IMMUT_DATA_CACHE_SIZE: usize = 300;
 // FIXME: move to conn manager
 // const CONNECTION_TIMEOUT_SECS: u64 = 40;
 
-lazy_static! {
-    /// Expected cost of mutation operations.
-    pub static ref COST_OF_PUT: Coins = unwrap!(Coins::from_nano(1));
-}
+/// Expected cost of mutation operations.
+pub const COST_OF_PUT: Coins = Coins::from_nano(1);
 
 /// Return the `crust::Config` associated with the `crust::Service` (if any).
 pub fn bootstrap_config() -> Result<BootstrapConfig, CoreError> {
@@ -1433,6 +1430,7 @@ mod tests {
     // Test putting, getting, and deleting unpub idata.
     #[test]
     fn unpub_idata_test() {
+        crate::utils::test_utils::init_log();
         // The `random_client()` initializes the client with 10 coins.
         let start_bal = unwrap!(Coins::from_str("10"));
 
@@ -1774,7 +1772,7 @@ mod tests {
                     // Subtract to cover the cost of inserting the login packet
                     let expected_amt = unwrap!(Coins::from_str("10")
                         .ok()
-                        .and_then(|x| x.checked_sub(*COST_OF_PUT)));
+                        .and_then(|x| x.checked_sub(COST_OF_PUT)));
                     match res {
                         Ok(fetched_amt) => assert_eq!(expected_amt, fetched_amt),
                         res => panic!("Unexpected result: {:?}", res),
@@ -2800,7 +2798,7 @@ mod tests {
 
         let client_balance = unwrap!(wallet_get_balance(&client_id));
         let expected = unwrap!(Coins::from_str("30"));
-        let expected = unwrap!(expected.checked_sub(*COST_OF_PUT));
+        let expected = unwrap!(expected.checked_sub(COST_OF_PUT));
         assert_eq!(client_balance, expected);
 
         let new_client_balance = unwrap!(wallet_get_balance(&new_client_id));

--- a/safe_core/src/errors.rs
+++ b/safe_core/src/errors.rs
@@ -9,6 +9,7 @@
 use crate::self_encryption_storage::SEStorageError;
 use bincode::Error as SerialisationError;
 use futures::sync::mpsc::SendError;
+use quic_p2p::QuicP2pError;
 use safe_nd::Error as SndError;
 use self_encryption::SelfEncryptionError;
 use std::error::Error as StdError;
@@ -59,7 +60,7 @@ pub enum CoreError {
     /// Io error.
     IoError(io::Error),
     /// QuicP2p error.
-    QuicP2p(quic_p2p::Error),
+    QuicP2p(QuicP2pError),
 }
 
 impl<'a> From<&'a str> for CoreError {
@@ -110,8 +111,8 @@ impl From<io::Error> for CoreError {
     }
 }
 
-impl From<quic_p2p::Error> for CoreError {
-    fn from(error: quic_p2p::Error) -> Self {
+impl From<QuicP2pError> for CoreError {
+    fn from(error: QuicP2pError) -> Self {
         Self::QuicP2p(error)
     }
 }

--- a/safe_core/src/immutable_data.rs
+++ b/safe_core/src/immutable_data.rs
@@ -214,11 +214,11 @@ mod tests {
     }
 
     // Test creating and retrieving a 10mb idata.
-    #[cfg(not(debug_assertions))]
-    #[test]
-    fn create_and_retrieve_10mb() {
-        create_and_retrieve(10 * 1024 * 1024)
-    }
+    // #[cfg(not(debug_assertions))]
+    // #[test]
+    // fn create_and_retrieve_10mb() {
+    //     create_and_retrieve(10 * 1024 * 1024)
+    // }
 
     fn create_and_retrieve(size: usize) {
         // Published and unencrypted

--- a/safe_core/src/immutable_data.rs
+++ b/safe_core/src/immutable_data.rs
@@ -214,11 +214,11 @@ mod tests {
     }
 
     // Test creating and retrieving a 10mb idata.
-    // #[cfg(not(debug_assertions))]
-    // #[test]
-    // fn create_and_retrieve_10mb() {
-    //     create_and_retrieve(10 * 1024 * 1024)
-    // }
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn create_and_retrieve_10mb() {
+        create_and_retrieve(10 * 1024 * 1024)
+    }
 
     fn create_and_retrieve(size: usize) {
         // Published and unencrypted

--- a/safe_core/src/ipc/mod.rs
+++ b/safe_core/src/ipc/mod.rs
@@ -23,14 +23,14 @@ use bincode::{deserialize, serialize};
 use data_encoding::BASE32_NOPAD;
 #[cfg(any(test, feature = "testing"))]
 use ffi_utils;
-use quic_p2p::NodeInfo;
 use rand::{self, Rng};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::u32;
 
 /// `QuicP2P` bootstrap info, shared from Authenticator to apps.
-pub type BootstrapConfig = HashSet<NodeInfo>;
+pub type BootstrapConfig = HashSet<SocketAddr>;
 
 /// IPC message.
 #[allow(clippy::large_enum_variant)]

--- a/safe_core/src/utils/test_utils/mod.rs
+++ b/safe_core/src/utils/test_utils/mod.rs
@@ -159,11 +159,31 @@ pub fn calculate_new_balance(
     transferred_coins: Option<Coins>,
 ) -> Coins {
     if let Some(x) = mutation_count {
-        balance =
-            unwrap!(balance.checked_sub(unwrap!(Coins::from_nano(x * COST_OF_PUT.as_nano()))));
+        balance = unwrap!(balance.checked_sub(Coins::from_nano(x * COST_OF_PUT.as_nano())));
     }
     if let Some(coins) = transferred_coins {
         balance = unwrap!(balance.checked_sub(coins));
     }
     balance
+}
+
+/// Initialises `env_logger` with custom settings.
+pub fn init_log() {
+    use std::io::Write;
+    let do_format = move |formatter: &mut env_logger::fmt::Formatter, record: &log::Record<'_>| {
+        let now = formatter.timestamp();
+        writeln!(
+            formatter,
+            "{} {} [{}:{}] {}",
+            formatter.default_styled_level(record.level()),
+            now,
+            record.file().unwrap_or_default(),
+            record.line().unwrap_or_default(),
+            record.args()
+        )
+    };
+    let _ = env_logger::Builder::from_default_env()
+        .format(do_format)
+        .is_test(true)
+        .try_init();
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,7 @@ futures = "~0.1.17"
 safe_app = { path = "../safe_app", version = "~0.12.0", features = ["testing"] }
 safe_authenticator = { path = "../safe_authenticator", version = "~0.12.0", features = ["testing"] }
 safe_core = { path = "../safe_core", version = "~0.37.3", features = ["testing"] }
-safe-nd = "~0.7.2"
+safe-nd = "~0.8.0"
 serde = "~1.0.24"
 serde_derive = "~1.0.24"
 serde_json = "~1.0.2"


### PR DESCRIPTION
Update safe-nd and quic-p2p dependencies. This PR makes SCL compatible with the latest version of safe_vault and routing for Fleming.