### PR TITLE
feat(ci): auto generate dependency graph via CI

### DIFF
--- a/.github/workflows/generate_dependency_graphs.yml
+++ b/.github/workflows/generate_dependency_graphs.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Every day at 1 AM
+    - cron:  '0 1 * * *'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install dot
+        run: sudo apt-get install graphviz
+
+      - shell: bash
+        run: ./scripts/generate_dependency_graphs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: master # The branch the action should deploy to.
+          FOLDER: images # The folder the action should deploy.

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -x
+
+rm -rf images
+mkdir images
+
+cargo install cargo-deps
+
+cargo deps --all-deps --include-orphans --subgraph safe_app safe_authenticator safe_authenticator_ffi safe_core --subgraph-name "SAFE Client Libs" --filter safe-nd quic-p2p ffi_utils safe_app safe_authenticator safe_authenticator_ffi safe_bindgen safe_core self_encryption --manifest-path safe_app/Cargo.toml | dot -Tpng -Nfontname=Iosevka -Gfontname=Iosevka > images/safe-client-libs.png


### PR DESCRIPTION
The Crate graph displayed in the readme & the wiki is out of date. This PR will add auto update of the graph .png file every night, which the readme & wiki point to.
There will still be a (smaller) manual maintenance aspect after this PR - the command which produces the graph every night explicitly states which crates it should display, so if this updates we will need to update the command in the `generate_dependency_graphs` script. Current command:
`cargo deps --all-deps --include-orphans --subgraph safe_app safe_authenticator safe_authenticator_ffi safe_core --subgraph-name "SAFE Client Libs" --filter safe-nd quic-p2p ffi_utils safe_app safe_authenticator safe_authenticator_ffi safe_bindgen safe_core self_encryption --manifest-path safe_app/Cargo.toml | dot -Tpng -Nfontname=Iosevka -Gfontname=Iosevka > images/safe-client-libs.png`

If this PR is merged, what will the new graph look like?:
![image](https://user-images.githubusercontent.com/37112040/81934905-a5363a80-95e7-11ea-9ae6-9c2a8db21164.png)

Note that the command listed under the `More info` section on the wiki page needs to be updated, but that would need to be done after this PR is merged.